### PR TITLE
Add semantic tool discovery with plan action and dual search strategy

### DIFF
--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -98,6 +98,14 @@ class Config:
     # Minimum cosine similarity for RAG results (0.0-1.0)
     RAG_MIN_SCORE = float(os.getenv("RAG_MIN_SCORE", "0.3"))
 
+    # --- Semantic Tool Discovery ---
+    # Master switch for vector-based tool search via dispatch/dmcp
+    ALLOW_EMBEDDING_SEARCH = os.getenv("ALLOW_EMBEDDING_SEARCH", "true").lower() == "true"
+    # Bypass threshold — use vector search regardless of server count
+    ENFORCE_EMBEDDING_SEARCH = os.getenv("ENFORCE_EMBEDDING_SEARCH", "false").lower() == "true"
+    # Minimum visible servers before vector search auto-enables
+    EMBEDDING_SEARCH_THRESHOLD = int(os.getenv("EMBEDDING_SEARCH_THRESHOLD", "100"))
+
     # Data directory — when set (e.g. systemd JARVIS_DATA_DIR=/var/lib/jarvis),
     # memory, goal archive, and default socket use this base path
     _DEFAULT_DATA_DIR = os.path.join(os.path.expanduser("~"), ".jarvis")
@@ -237,20 +245,32 @@ Output exactly one JSON object. First char {{, last char }}.
 
     LLM_DISPATCH_PROMPT = """\
 You are operating in DISPATCH mode. Your job is to find and execute MCP server tools.
-You do NOT have a pre-loaded list of tools. Discover them on demand by searching.
 
 CRITICAL: Your ENTIRE response must be a single valid JSON object.
 
 --- Workflow ---
-1. search: Find MCP servers by keywords
-2. list_tools: See what tools a server offers and their parameter schemas
-3. install: Install a server that isn't installed yet (runs setup automatically)
-4. dispatch: Execute tasks on installed servers
-5. done: Return a summary to the root system when finished
+1. plan: ALWAYS start here. Break down your intent into sub-tasks with keywords for each.
+   The system will search for matching tools (semantic + keyword) and return AVAILABLE TOOLS.
+2. If AVAILABLE TOOLS are provided: skip search/list_tools and dispatch directly.
+3. If no tools were found: fall back to search → list_tools → install → dispatch.
+4. done: Return a summary to the root system when finished.
 
 --- Actions ---
 
-Search for servers:
+Plan sub-tasks (ALWAYS start with this):
+{{
+    "action": "plan",
+    "tasks": [
+        {{"intent": "get weather forecast for Berlin", "keywords": ["weather", "forecast"], "top_k": 3, "min_score": 0.7}},
+        {{"intent": "convert 50 EUR to USD", "keywords": ["currency", "exchange", "convert"], "top_k": 3, "min_score": 0.7}}
+    ]
+}}
+- intent: Natural language description of what this sub-task needs
+- keywords: Fallback keywords if semantic search finds nothing
+- top_k: Max results per sub-task (default 5)
+- min_score: Min relevance threshold 0.0-1.0 (default 0.3, use higher for precise queries)
+
+Search for servers (fallback — use only if plan returned no tools):
 {{"action": "search", "keywords": ["calculator", "math"]}}
 
 List tools on a server:
@@ -282,7 +302,8 @@ Return to root with results:
 --- Context you receive ---
 - INTENT: What the root system asked you to do
 - GOALS: Active goals
-- SEARCH_RESULTS: Server search results
+- AVAILABLE_TOOLS: Tools matched by semantic/keyword search (after plan action)
+- SEARCH_RESULTS: Server search results (legacy keyword search)
 - TOOLS: Tool listings from a server
 - INSTALL_RESULT: Installation outcome
 - DISPATCH_RESULT: Task execution results (signal window with PIDs, INIT/EXIT events)
@@ -297,7 +318,10 @@ Return to root with results:
 - KILL: Task was terminated
 
 --- Rules ---
-- Do NOT guess server IDs or tool names — always search first
+- ALWAYS start with "plan" to break down the intent — even for single tasks
+- If AVAILABLE TOOLS appear after planning, dispatch directly (skip search/list_tools)
+- Fall back to "search" only when plan returned no matching tools
+- Do NOT guess server IDs or tool names — let the system find them
 - You can dispatch multiple tasks for parallelism
 - When tasks complete, use "done" to return the summary to root
 - Output exactly one JSON object — no preamble, no trailing text

--- a/jarvis/core/command_parser.py
+++ b/jarvis/core/command_parser.py
@@ -18,8 +18,8 @@ VALID_ACTIONS = {
     # Root
     "respond", "dispatch", "contextor",
     # Dispatch subsystem
-    "search", "list_tools", "install", "wait", "kill", "defer", "done",
-    # Contextor subsystem (placeholders)
+    "plan", "search", "list_tools", "install", "wait", "kill", "defer", "done",
+    # Contextor subsystem
     "store", "recall", "search_memory", "list_memory",
 }
 
@@ -86,6 +86,10 @@ class TaskParser:
             return f", pids={result.get('pids', [])}"
         if action == "defer":
             return f", goal_id={result.get('goal_id')}, duration={result.get('duration')}s"
+        if action == "plan":
+            tasks = result.get("tasks", [])
+            intents = [t.get("intent", "")[:40] for t in tasks]
+            return f", tasks={intents}"
         if action == "search":
             return f", keywords={result.get('keywords', [])}"
         if action == "list_tools":
@@ -175,6 +179,41 @@ def _parse_contextor(response: Dict[str, Any]) -> Dict[str, Any]:
 # ------------------------------------------------------------------
 # DISPATCH subsystem actions
 # ------------------------------------------------------------------
+
+@_parser("plan")
+def _parse_plan(response: Dict[str, Any]) -> Dict[str, Any]:
+    """Parse plan action — LLM breaks intent into sub-tasks for tool discovery."""
+    tasks = response.get("tasks", [])
+    if not isinstance(tasks, list) or not tasks:
+        return {"error": "Plan action requires a non-empty 'tasks' list", "raw": response}
+
+    validated_tasks = []
+    for i, task in enumerate(tasks):
+        if not isinstance(task, dict):
+            logger.warning(f"TaskParser: Plan task {i} is not a dict, skipping")
+            continue
+
+        intent = task.get("intent", "")
+        if not intent:
+            logger.warning(f"TaskParser: Plan task {i} missing 'intent', skipping")
+            continue
+
+        validated_tasks.append({
+            "intent": str(intent),
+            "keywords": [str(k) for k in task.get("keywords", [])],
+            "top_k": int(task.get("top_k", 5)),
+            "min_score": float(task.get("min_score", 0.3)),
+        })
+
+    if not validated_tasks:
+        return {"error": "No valid sub-tasks in plan action", "raw": response}
+
+    return {
+        "action": "plan",
+        "tasks": validated_tasks,
+        "goal_updates": response.get("goal_updates", []),
+    }
+
 
 @_parser("search")
 def _parse_search(response: Dict[str, Any]) -> Dict[str, Any]:

--- a/jarvis/core/component_factory.py
+++ b/jarvis/core/component_factory.py
@@ -326,6 +326,25 @@ class ComponentFactory:
         # Kernel integration client (started first — LLM providers may use keyring)
         components['kernel_client'] = ComponentFactory.create_kernel_client()
 
+        # Shared embeddings instance — used by both contextor (memory RAG)
+        # and dispatch (semantic tool discovery). Created once, shared.
+        embeddings = None
+        if Config.RAG_ENABLED or Config.ALLOW_EMBEDDING_SEARCH:
+            try:
+                from ..contextor.embeddings import OllamaEmbeddings
+                embeddings = OllamaEmbeddings(model=Config.EMBED_MODEL)
+                if not embeddings.ensure_model():
+                    logger.warning(
+                        f"Embedding model '{Config.EMBED_MODEL}' not available. "
+                        f"Semantic search disabled."
+                    )
+                    embeddings = None
+            except ImportError as e:
+                logger.warning(f"Embeddings unavailable: {e}")
+            except Exception as e:
+                logger.warning(f"Embeddings init failed (non-fatal): {e}")
+        components['embeddings'] = embeddings
+
         # Core components (always needed)
         # Contextor is created first so it can be passed to LLM for RAG
         components['contextor'] = (

--- a/jarvis/dispatch/adapter.py
+++ b/jarvis/dispatch/adapter.py
@@ -6,8 +6,15 @@ as an MCP server via `dispatch serve`. This adapter connects to it over
 stdio and provides methods to send task batches, kill tasks, and receive
 signals.
 
-The adapter is intentionally thin — it translates Python calls into MCP
-tool invocations and surfaces results. All decision-making lives in Jarvis.
+The adapter also handles semantic tool discovery:
+- Embeds sub-task intents via Ollama (when embedding search is enabled)
+- Passes vectors to dispatch → dmcp for cosine similarity search
+- Falls back to keyword search when vector search is unavailable or
+  returns no results
+- Auto-indexes non-approved servers after installation
+
+All decision-making lives in JARVIS — dispatch and dmcp are tools that
+do what they're told.
 """
 
 import asyncio
@@ -336,6 +343,455 @@ class DispatchAdapter:
 
         logger.info(f"Dispatch: Server '{server_id}' has {len(tools)} tool(s)")
         return {"server": server_id, "tools": tools}
+
+    # ------------------------------------------------------------------
+    # Semantic tool discovery (vector-based via dispatch → dmcp)
+    # ------------------------------------------------------------------
+
+    async def server_count(self) -> Dict[str, Any]:
+        """
+        Get the number of visible MCP servers from dmcp.
+
+        Returns dict with total, local, registry counts.
+        JARVIS uses this to decide whether to enable embedding search.
+        """
+        if not self._connected:
+            # Fall back to direct dmcp call if dispatch isn't connected
+            raw = await self._run_dmcp("count", "--json")
+            if raw is None:
+                return {"total": 0, "local": 0, "registry": 0}
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                # Plain number output
+                try:
+                    return {"total": int(raw.strip()), "local": 0, "registry": 0}
+                except ValueError:
+                    return {"total": 0, "local": 0, "registry": 0}
+
+        try:
+            result = await asyncio.wait_for(
+                self.session.call_tool("server_count", {}),
+                timeout=self.timeout,
+            )
+            content = self._extract_content(result)
+            logger.info(f"Dispatch: Server count: {content}")
+            return content
+        except Exception as e:
+            logger.warning(f"Dispatch: server_count failed: {e}")
+            return {"total": 0, "local": 0, "registry": 0}
+
+    async def embedding_spec(self) -> Optional[Dict[str, Any]]:
+        """
+        Get the registry's embedding model spec from dmcp.
+
+        Returns: {"model": "nomic-embed-text", "version": "v1.5", "dimensions": 768}
+        or None if not available.
+        """
+        if not self._connected:
+            raw = await self._run_dmcp("embedding-spec")
+            if raw is None:
+                return None
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                return None
+
+        try:
+            result = await asyncio.wait_for(
+                self.session.call_tool("embedding_spec", {}),
+                timeout=self.timeout,
+            )
+            content = self._extract_content(result)
+            if "error" in content:
+                logger.warning(f"Dispatch: embedding_spec: {content['error']}")
+                return None
+            logger.info(f"Dispatch: Embedding spec: {content}")
+            return content
+        except Exception as e:
+            logger.warning(f"Dispatch: embedding_spec failed: {e}")
+            return None
+
+    async def sync_index(self) -> Dict[str, Any]:
+        """Trigger dmcp sync-index to refresh the vector index from registries."""
+        if not self._connected:
+            raw = await self._run_dmcp("sync-index")
+            if raw is None:
+                return {"error": "dmcp sync-index failed"}
+            return {"output": raw.strip()}
+
+        try:
+            result = await asyncio.wait_for(
+                self.session.call_tool("sync_index", {}),
+                timeout=self.timeout,
+            )
+            content = self._extract_content(result)
+            logger.info(f"Dispatch: sync_index result: {content}")
+            return content
+        except Exception as e:
+            logger.warning(f"Dispatch: sync_index failed: {e}")
+            return {"error": f"sync_index failed: {e}"}
+
+    async def browse_vector(
+        self,
+        vector: List[float],
+        top_k: int = 5,
+        min_score: float = 0.3,
+    ) -> Dict[str, Any]:
+        """
+        Semantic search: find MCP servers/tools by vector similarity.
+
+        Passes the vector to dispatch → dmcp browse --vector for cosine
+        similarity search against the local vector index.
+        """
+        if not self._connected:
+            vector_json = json.dumps(vector)
+            raw = await self._run_dmcp(
+                "browse", "--vector", vector_json,
+                "--top-k", str(top_k),
+                "--min-score", str(min_score),
+                "--json",
+            )
+            if raw is None:
+                return {"results": []}
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                return {"results": []}
+
+        try:
+            result = await asyncio.wait_for(
+                self.session.call_tool("browse_vector", {
+                    "vector": vector,
+                    "top_k": top_k,
+                    "min_score": min_score,
+                }),
+                timeout=self.timeout,
+            )
+            content = self._extract_content(result)
+            return content
+        except Exception as e:
+            logger.warning(f"Dispatch: browse_vector failed: {e}")
+            return {"results": []}
+
+    async def browse_vectors_batch(
+        self,
+        vectors: List[List[float]],
+        top_k: int = 5,
+        min_score: float = 0.3,
+    ) -> Dict[str, Any]:
+        """
+        Batch semantic search: search multiple vectors in one call.
+
+        Returns grouped results — one result set per input vector.
+        """
+        if not self._connected:
+            vectors_json = json.dumps(vectors)
+            raw = await self._run_dmcp(
+                "browse", "--vectors", vectors_json,
+                "--top-k", str(top_k),
+                "--min-score", str(min_score),
+                "--json",
+            )
+            if raw is None:
+                return {"results": [[] for _ in vectors]}
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                return {"results": [[] for _ in vectors]}
+
+        try:
+            result = await asyncio.wait_for(
+                self.session.call_tool("browse_vectors", {
+                    "vectors": vectors,
+                    "top_k": top_k,
+                    "min_score": min_score,
+                }),
+                timeout=self.timeout,
+            )
+            content = self._extract_content(result)
+            return content
+        except Exception as e:
+            logger.warning(f"Dispatch: browse_vectors_batch failed: {e}")
+            return {"results": [[] for _ in vectors]}
+
+    async def index_server(
+        self,
+        server_id: str,
+        vectors: Dict[str, Any],
+        name: str = "",
+        description: str = "",
+    ) -> Dict[str, Any]:
+        """
+        Index a non-approved server's vectors for semantic search.
+
+        Called after installing a server that doesn't have pre-computed
+        vectors in the registry. JARVIS embeds the tool descriptions
+        locally via Ollama and passes the vectors here for storage.
+
+        Args:
+            server_id: The MCP server ID.
+            vectors: {"server": [...], "tools": {"tool_name": [...]}}
+            name: Optional server name.
+            description: Optional server description.
+        """
+        if not self._connected:
+            args = ["index-server", server_id, "--vectors", json.dumps(vectors)]
+            if name:
+                args.extend(["--name", name])
+            if description:
+                args.extend(["--description", description])
+            raw = await self._run_dmcp(*args)
+            if raw is None:
+                return {"error": f"Failed to index server '{server_id}'"}
+            return {"indexed": server_id, "output": raw.strip()}
+
+        try:
+            params: Dict[str, Any] = {
+                "server_id": server_id,
+                "vectors": json.dumps(vectors),
+            }
+            if name:
+                params["name"] = name
+            if description:
+                params["description"] = description
+
+            result = await asyncio.wait_for(
+                self.session.call_tool("index_server", params),
+                timeout=self.timeout,
+            )
+            content = self._extract_content(result)
+            logger.info(f"Dispatch: Indexed server '{server_id}': {content}")
+            return content
+        except Exception as e:
+            logger.warning(f"Dispatch: index_server failed: {e}")
+            return {"error": f"Failed to index server: {e}"}
+
+    async def discover_tools(
+        self,
+        tasks: List[Dict[str, Any]],
+        embeddings: Optional[Any] = None,
+    ) -> str:
+        """
+        Semantic tool discovery — the main entry point.
+
+        Takes a list of sub-tasks from the LLM's "plan" action, searches
+        for matching tools using vectors (preferred) with keyword fallback,
+        and returns a formatted AVAILABLE TOOLS string for prompt injection.
+
+        Args:
+            tasks: List of dicts with "intent", "keywords", "top_k", "min_score".
+            embeddings: OllamaEmbeddings instance for local embedding.
+
+        Returns:
+            Formatted string of matched tools, or empty string if nothing found.
+        """
+        count = await self.server_count()
+        total = count.get("total", 0)
+
+        use_vectors = (
+            Config.ALLOW_EMBEDDING_SEARCH
+            and embeddings is not None
+            and (
+                total >= Config.EMBEDDING_SEARCH_THRESHOLD
+                or Config.ENFORCE_EMBEDDING_SEARCH
+            )
+        )
+
+        logger.info(
+            f"Dispatch: discover_tools — {len(tasks)} sub-task(s), "
+            f"{total} visible servers, use_vectors={use_vectors}"
+        )
+
+        all_results: List[Dict[str, Any]] = []
+
+        if use_vectors:
+            # Embed all intents and do batch vector search
+            intents = [t.get("intent", "") for t in tasks]
+            try:
+                vectors = embeddings.embed_batch(intents)
+                # Use the most restrictive top_k/min_score from the tasks
+                top_k = max(t.get("top_k", 5) for t in tasks)
+                min_score = min(t.get("min_score", 0.3) for t in tasks)
+
+                batch_result = await self.browse_vectors_batch(
+                    vectors=vectors,
+                    top_k=top_k,
+                    min_score=min_score,
+                )
+
+                result_sets = batch_result.get("results", [])
+                if isinstance(result_sets, list):
+                    for i, result_set in enumerate(result_sets):
+                        if isinstance(result_set, list) and result_set:
+                            for r in result_set:
+                                r["_source_task"] = intents[i]
+                            all_results.extend(result_set)
+                        else:
+                            # No vector match for this task — keyword fallback
+                            kw_results = await self._keyword_fallback(tasks[i])
+                            all_results.extend(kw_results)
+
+            except Exception as e:
+                logger.warning(f"Dispatch: Vector search failed, falling back to keywords: {e}")
+                for task in tasks:
+                    all_results.extend(await self._keyword_fallback(task))
+        else:
+            # Vector search disabled — keyword only
+            for task in tasks:
+                all_results.extend(await self._keyword_fallback(task))
+
+        if not all_results:
+            logger.info("Dispatch: discover_tools found no matching tools")
+            return ""
+
+        return self._format_available_tools(all_results)
+
+    async def _keyword_fallback(self, task: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Keyword search fallback for a single sub-task."""
+        keywords = task.get("keywords", [])
+        if not keywords:
+            # Extract basic keywords from intent
+            intent = task.get("intent", "")
+            keywords = [w for w in intent.lower().split() if len(w) > 3]
+
+        if not keywords:
+            return []
+
+        result = await self.search_servers(keywords)
+        servers = result.get("servers", [])
+
+        # Convert to tool-level results for consistent formatting
+        tool_results = []
+        for server in servers:
+            server_id = server.get("id", server.get("server_id", ""))
+            tool_results.append({
+                "server_id": server_id,
+                "server_name": server.get("name", server_id),
+                "description": server.get("description", ""),
+                "installed": server.get("installed", False),
+                "score": 0,  # keyword matches don't have scores
+                "_source": "keyword",
+                "_source_task": task.get("intent", ""),
+            })
+
+        return tool_results
+
+    @staticmethod
+    def _format_available_tools(results: List[Dict[str, Any]]) -> str:
+        """Format search results as AVAILABLE TOOLS for the LLM prompt."""
+        # Deduplicate by server_id + tool_name
+        seen = set()
+        unique = []
+        for r in results:
+            key = (r.get("server_id", ""), r.get("tool_name", ""))
+            if key not in seen:
+                seen.add(key)
+                unique.append(r)
+
+        parts = []
+        for r in unique:
+            server_id = r.get("server_id", "unknown")
+            tool_name = r.get("tool_name", "")
+            description = r.get("description", "")
+            params = r.get("params", r.get("parameter_schema", ""))
+            score = r.get("score", 0)
+            installed = r.get("installed", True)
+
+            if tool_name:
+                line = f"  {server_id}/{tool_name}"
+            else:
+                line = f"  {server_id}"
+
+            if score:
+                line += f" (relevance: {score:.0%})"
+            if not installed:
+                line += " [NOT INSTALLED]"
+            if description:
+                line += f"\n    {description}"
+            if params:
+                params_str = json.dumps(params) if isinstance(params, dict) else str(params)
+                line += f"\n    params: {params_str}"
+
+            parts.append(line)
+
+        return "AVAILABLE_TOOLS:\n" + "\n".join(parts)
+
+    async def auto_index_server(
+        self,
+        server_id: str,
+        embeddings: Optional[Any] = None,
+    ) -> None:
+        """
+        Auto-index a non-approved server after installation.
+
+        Reads the server's tool descriptions, embeds them locally via
+        Ollama, and stores the vectors in dmcp's local index.
+        Does nothing if embeddings are unavailable.
+        """
+        if embeddings is None:
+            logger.debug(f"Dispatch: Skipping auto-index for '{server_id}' (no embeddings)")
+            return
+
+        # Get tool descriptions from the installed server
+        tools_result = await self.list_server_tools(server_id)
+        tools = tools_result.get("tools", [])
+        if not tools:
+            logger.debug(f"Dispatch: No tools found for '{server_id}', skipping index")
+            return
+
+        try:
+            # Build texts to embed
+            server_desc = f"{server_id}"
+            tool_texts = {}
+            for tool in tools:
+                name = tool.get("name", "")
+                desc = tool.get("description", "")
+                params = tool.get("params", tool.get("inputSchema", {}))
+                text = f"{server_id} | {name} | {desc} | params: {json.dumps(params)}"
+                tool_texts[name] = text
+
+            # Embed server description
+            server_vector = embeddings.embed_single(server_desc)
+
+            # Embed each tool
+            tool_vectors = {}
+            for name, text in tool_texts.items():
+                tool_vectors[name] = embeddings.embed_single(text)
+
+            # Store in dmcp's index
+            vectors = {
+                "server": server_vector,
+                "tools": tool_vectors,
+            }
+            result = await self.index_server(server_id, vectors)
+            logger.info(f"Dispatch: Auto-indexed '{server_id}' ({len(tool_vectors)} tools): {result}")
+
+        except Exception as e:
+            # Non-fatal — server is installed, just not vector-indexed
+            logger.warning(f"Dispatch: Auto-index failed for '{server_id}' (non-fatal): {e}")
+
+    async def ensure_embedding_model(self, embeddings: Optional[Any] = None) -> None:
+        """
+        On startup, check the registry's embedding spec and ensure
+        the correct model is available locally.
+        """
+        if embeddings is None:
+            return
+
+        spec = await self.embedding_spec()
+        if spec is None:
+            logger.info("Dispatch: No embedding spec from registry (index may not be synced)")
+            return
+
+        registry_model = spec.get("model", "")
+        if registry_model and registry_model != embeddings.model:
+            logger.warning(
+                f"Dispatch: Registry embedding model '{registry_model}' differs from "
+                f"local model '{embeddings.model}'. Updating local model."
+            )
+            embeddings.model = registry_model
+            embeddings.ensure_model()
 
     async def __aenter__(self):
         await self.connect()

--- a/jarvis/main.py
+++ b/jarvis/main.py
@@ -48,6 +48,7 @@ class Jarvis:
         self.contextor = self.components['contextor']
         self.goals = self.components['goal_manager']
         self.events = self.components['event_merger']
+        self._embeddings = self.components.get('embeddings')
         self.task_parser = self.components['task_parser']
         self.output_manager = self.components['output_manager']
         self.confirmation = self.components['confirmation_manager']
@@ -73,6 +74,15 @@ class Jarvis:
         except Exception as e:
             logger.warning(f"JARVIS: Could not connect to dispatch: {e}")
             logger.info("JARVIS: Running in conversation-only mode")
+
+        # Startup: sync tool vector index and ensure embedding model
+        if self.dispatch.is_connected and self._embeddings:
+            try:
+                await self.dispatch.ensure_embedding_model(self._embeddings)
+                await self.dispatch.sync_index()
+                logger.info("JARVIS: Tool vector index synced")
+            except Exception as e:
+                logger.warning(f"JARVIS: Tool index sync failed (non-fatal): {e}")
 
         user_source = self._await_user_input if self._has_stdin() else None
         self.events.start(
@@ -270,6 +280,12 @@ class Jarvis:
         """
         Enter dispatch mode, give it the intent, and loop until it
         returns "done" with a summary.
+
+        The LLM starts with a "plan" action to split the intent into
+        sub-tasks. JARVIS then searches for matching tools (semantic
+        vectors + keyword fallback) and injects AVAILABLE TOOLS into
+        the next prompt. The LLM can then dispatch directly without
+        manual search/list_tools steps.
         """
         self.llm.switch_mode("dispatch")
 
@@ -294,7 +310,26 @@ class Jarvis:
                 logger.info(f"JARVIS: Dispatch sub-chain completed: {parsed['summary']}")
                 return parsed["summary"]
 
-            if action == "search":
+            if action == "plan":
+                # LLM split the intent into sub-tasks — search for tools
+                sub_tasks = parsed.get("tasks", [])
+                logger.info(f"JARVIS: Plan has {len(sub_tasks)} sub-task(s)")
+
+                available_tools = await self.dispatch.discover_tools(
+                    tasks=sub_tasks,
+                    embeddings=self._get_embeddings(),
+                )
+
+                if available_tools:
+                    context = f"{available_tools}\n\nINTENT: {intent}"
+                else:
+                    context = (
+                        "NO_TOOLS_FOUND: Semantic and keyword search returned no matches. "
+                        "Use 'search' with different keywords, or try 'list_tools' on a known server.\n"
+                        f"INTENT: {intent}"
+                    )
+
+            elif action == "search":
                 result = await self.dispatch.search_servers(parsed["keywords"])
                 context = f"SEARCH_RESULTS: {json.dumps(result)}"
 
@@ -305,6 +340,14 @@ class Jarvis:
             elif action == "install":
                 result = await self.dispatch.install_server(parsed["server_id"])
                 context = f"INSTALL_RESULT: {json.dumps(result)}"
+
+                # Auto-index non-approved servers after successful install
+                server_id = parsed.get("server_id", "")
+                if "error" not in result and server_id:
+                    await self.dispatch.auto_index_server(
+                        server_id=server_id,
+                        embeddings=self._get_embeddings(),
+                    )
 
             elif action == "dispatch" and "tasks" in parsed:
                 result = await self._dispatch_send(parsed["tasks"])
@@ -517,6 +560,10 @@ class Jarvis:
     # ------------------------------------------------------------------
     # Shared helpers
     # ------------------------------------------------------------------
+
+    def _get_embeddings(self):
+        """Return the OllamaEmbeddings instance, or None if unavailable."""
+        return self._embeddings
 
     def _ask_llm(self, context: str, tag: str = "") -> Dict[str, Any]:
         """Single LLM call with timing logs."""


### PR DESCRIPTION
Implement vector-based MCP tool discovery alongside existing keyword search, reducing dispatch sub-chain from 5-8 LLM round-trips to 2-3.

New dispatch flow:
1. LLM plans: splits intent into sub-tasks with keywords + search params
2. JARVIS embeds intents → dispatch → dmcp vector search (+ keyword fallback)
3. Matched tools injected as AVAILABLE TOOLS → LLM dispatches directly

dispatch/adapter.py — new methods:
- discover_tools(): dual search entry point (vectors preferred, keywords fallback)
- browse_vector() / browse_vectors_batch(): vector search via dispatch → dmcp
- server_count(): visible server count for threshold check
- embedding_spec(): registry embedding model spec
- sync_index(): refresh vector index from registry
- index_server(): store vectors for non-approved servers
- auto_index_server(): embed + index non-approved servers after install
- ensure_embedding_model(): verify local model matches registry spec

Search strategy logic (JARVIS decides, not dmcp):
- use_vectors = ALLOW_EMBEDDING_SEARCH AND (count >= 100 OR ENFORCE)
- Vector results supplemented with keyword fallback per sub-task
- Graceful degradation when embeddings unavailable

main.py:
- Handle "plan" action in dispatch sub-chain
- Auto-index non-approved servers after install
- Startup: sync tool vector index + verify embedding model

config.py:
- ALLOW_EMBEDDING_SEARCH, ENFORCE_EMBEDDING_SEARCH, EMBEDDING_SEARCH_THRESHOLD
- Updated LLM_DISPATCH_PROMPT with plan action and AVAILABLE TOOLS workflow

command_parser.py:
- Registered "plan" action with validation (intent, keywords, top_k, min_score)

component_factory.py:
- Shared OllamaEmbeddings instance created once, used by contextor + dispatch

https://claude.ai/code/session_01AqdY5j8F4JV4ZWJePPQwmP