### PR TITLE
Embeddings-only contextor: remove keyword fallback, add auto-store and offset

### DIFF
--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -108,7 +108,10 @@ class Config:
 
     # Data directory — when set (e.g. systemd JARVIS_DATA_DIR=/var/lib/jarvis),
     # memory, goal archive, and default socket use this base path
-    _DEFAULT_DATA_DIR = os.path.join(os.path.expanduser("~"), ".jarvis")
+    _DEFAULT_DATA_DIR = os.path.join(
+        os.getenv("XDG_DATA_HOME", os.path.join(os.path.expanduser("~"), ".local", "share")),
+        "jarvis",
+    )
     JARVIS_DATA_DIR = os.getenv("JARVIS_DATA_DIR", _DEFAULT_DATA_DIR)
 
     # Dual input — Unix socket for "jarvis send" and app integration
@@ -333,6 +336,7 @@ The very first character of your response must be {{ and the very last must be }
 You are operating in CONTEXTOR mode. Your job is to manage long-term memory.
 You are a personal assistant — remembering what the user tells you is a core part of your service.
 Memory is organized by theme — each theme is a topic or subject area.
+All user prompts are automatically saved. You can search them semantically.
 
 CRITICAL: Your ENTIRE response must be a single valid JSON object.
 
@@ -342,19 +346,24 @@ they might want you to recall later. Choose a clear, reusable theme name.
 The user expects you to remember — do not refuse. This is an enabled feature.
 
 --- When to recall ---
-Recall when you need context about a topic to answer accurately. Search when the
-exact theme is unknown.
+Recall when you need context about a topic to answer accurately. Use search_memory
+when you don't know the exact theme — it finds memories by meaning, not keywords.
 
 --- Actions ---
 
 Store information under a theme:
 {{"action": "store", "theme": "<topic>", "content": "<concise fact to remember>"}}
 
-Recall entries by theme:
+Recall entries by theme (exact theme lookup):
 {{"action": "recall", "theme": "<topic>"}}
 
-Search across all memory by keywords:
-{{"action": "search_memory", "keywords": ["keyword1", "keyword2"]}}
+Search all memory by meaning (semantic search):
+{{"action": "search_memory", "query": "<natural language query>", "top_k": 5, "offset": 0, "min_score": 0.3}}
+- query: Describe what you're looking for in natural language
+- top_k: Number of results to return (default 5)
+- offset: Skip the N closest results — use to dig deeper when top results aren't relevant
+  Example: offset=0 returns matches #1-#5, offset=5 returns matches #6-#10
+- min_score: Minimum relevance threshold 0.0-1.0 (default 0.3)
 
 List all stored themes:
 {{"action": "list_memory"}}
@@ -366,13 +375,16 @@ Return to root with results:
 - INTENT: What the root system asked you to do
 - STORE_RESULT: Confirmation after storing
 - RECALL_RESULT: Entries retrieved for a theme (includes "found" boolean)
-- SEARCH_MEMORY_RESULT: Keyword search results
+- SEARCH_MEMORY_RESULT: Semantic search results (includes "available" flag — if false, search is down)
 - LIST_MEMORY_RESULT: All available themes with entry counts
 
 --- Rules ---
 - Choose descriptive theme names (e.g. "user_preferences", "school_schedule", "project_jarvis")
 - When storing, be concise — extract the key fact, don't store the entire conversation
-- You can chain multiple actions: recall first, then store updates, then done
+- Use search_memory with natural language, not keywords — it searches by meaning
+- If search results aren't relevant, try again with offset to skip top matches
+- You can chain multiple actions: search first, then store, then done
+- If SEARCH_MEMORY_RESULT shows "available": false, inform the user memory search is degraded
 - Always finish with "done" and include the relevant data in the summary
 - Output exactly one JSON object — no preamble, no trailing text
 

--- a/jarvis/contextor/adapter.py
+++ b/jarvis/contextor/adapter.py
@@ -1,19 +1,20 @@
 """
 ContextorAdapter — manages long-term memory for JARVIS.
 
-Provides a local file-based memory backend that works out of the box.
-Memory is organized by theme — each theme gets its own JSON file under
-``~/.jarvis/memory/``. Themes are created on demand.
+Embeddings-only memory retrieval:
+- Every user prompt is automatically stored with its embedding vector
+- Retrieval is purely semantic (cosine similarity via vector store)
+- No keyword substring search — if embeddings are unavailable, search
+  returns empty results with a clear "unavailable" flag
+- JSONL files remain the persistence source of truth
+- Vector store (ChromaDB) is the search index, kept in sync on store()
 
-Upgraded with semantic search (RAG):
-- On store(), entries are indexed in a ChromaDB vector store
-- semantic_search() uses embeddings for meaning-based retrieval
-- retrieve_context() is the main RAG entry point — call it before
-  each LLM invocation to inject relevant memories into the prompt
-- Original keyword search is preserved as a fallback
+Storage location follows XDG:
+  ~/.local/share/jarvis/memory/       (JSONL themes)
+  ~/.local/share/jarvis/chroma_db/    (vector index)
 
-When the Rust contextor binary is ready, this adapter can be extended
-to delegate to it via stdio (same pattern as DispatchAdapter).
+When the Rust contextor binary is ready, this adapter becomes a thin
+MCP client over stdio — same pattern as DispatchAdapter.
 """
 
 import json
@@ -29,7 +30,7 @@ _DEFAULT_MEMORY_DIR = os.path.join(Config.JARVIS_DATA_DIR, "memory")
 
 
 class ContextorAdapter:
-    """File-based long-term memory for JARVIS with semantic search."""
+    """Embeddings-only long-term memory for JARVIS."""
 
     def __init__(
         self,
@@ -39,15 +40,25 @@ class ContextorAdapter:
         self._memory_dir = memory_dir or _DEFAULT_MEMORY_DIR
         os.makedirs(self._memory_dir, exist_ok=True)
 
-        # Vector store is optional — when provided, enables semantic search.
-        # When None, falls back to keyword search only (graceful degradation).
         self._vector_store = vector_store
+        self._available = vector_store is not None
 
-        vs_status = f"enabled ({vector_store.count} entries)" if vector_store else "disabled"
-        logger.info(
-            f"Contextor: Memory directory: {self._memory_dir}, "
-            f"vector store: {vs_status}"
-        )
+        if self._available:
+            logger.info(
+                f"Contextor: Memory directory: {self._memory_dir}, "
+                f"vector store: enabled ({vector_store.count} entries)"
+            )
+        else:
+            logger.warning(
+                "Contextor: Vector store NOT available — memory search is disabled. "
+                "Store and recall by theme still work. "
+                "Ensure EMBED_MODEL is pulled and chromadb is installed."
+            )
+
+    @property
+    def search_available(self) -> bool:
+        """Whether semantic search is operational."""
+        return self._available
 
     def _theme_path(self, theme: str) -> str:
         safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in theme.lower())
@@ -101,8 +112,8 @@ class ContextorAdapter:
         """
         Store a piece of information under a theme.
 
-        Each entry is timestamped. Themes are created on demand.
-        Also indexes in the vector store for semantic retrieval.
+        Each entry is timestamped, written to JSONL (source of truth),
+        and indexed in the vector store for semantic retrieval.
         """
         entry = {
             "content": content,
@@ -130,10 +141,46 @@ class ContextorAdapter:
             logger.error(f"Contextor: Failed to store under '{theme}': {e}")
             return {"error": f"Failed to store: {e}"}
 
+    def auto_store_prompt(self, text: str) -> None:
+        """
+        Automatically store a user prompt for long-term recall.
+
+        Called on every user input — no LLM decision needed. This creates
+        a complete searchable history of everything the user has ever said.
+        Stored under the "conversation_log" theme.
+        """
+        entry = {
+            "content": text,
+            "stored_at": time.time(),
+            "stored_iso": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "type": "user_prompt",
+        }
+
+        path = self._theme_path("conversation_log")
+        try:
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(entry) + "\n")
+
+            # Index in vector store — this is what makes old prompts searchable
+            if self._vector_store:
+                try:
+                    self._vector_store.add(
+                        content=text,
+                        theme="conversation_log",
+                        metadata={"type": "user_prompt"},
+                    )
+                except Exception as e:
+                    logger.debug(f"Contextor: Auto-store vector indexing failed: {e}")
+
+            logger.debug(f"Contextor: Auto-stored user prompt ({len(text)} chars)")
+        except OSError as e:
+            logger.debug(f"Contextor: Auto-store failed (non-fatal): {e}")
+
     def recall(self, theme: str, limit: int = 20) -> Dict[str, Any]:
         """
         Recall entries stored under a theme.
         Returns the most recent ``limit`` entries (newest last).
+        This is a direct theme lookup — no embeddings needed.
         """
         path = self._theme_path(theme)
         if not os.path.exists(path):
@@ -158,111 +205,77 @@ class ContextorAdapter:
         logger.info(f"Contextor: Recalled {len(recent)} entries for theme '{theme}'")
         return {"theme": theme, "entries": recent, "found": True}
 
-    def search(self, keywords: List[str], limit: int = 20) -> Dict[str, Any]:
-        """
-        Search across all themes for entries matching any of the keywords.
-        This is the original keyword-based search (exact substring matching).
-        """
-        keywords_lower = [k.lower() for k in keywords]
-        matches: list[dict] = []
-
-        try:
-            for filename in os.listdir(self._memory_dir):
-                if not filename.endswith(".jsonl"):
-                    continue
-
-                theme = filename[:-6]  # strip .jsonl
-                path = os.path.join(self._memory_dir, filename)
-
-                try:
-                    with open(path, "r", encoding="utf-8") as f:
-                        for line in f:
-                            line = line.strip()
-                            if not line:
-                                continue
-                            try:
-                                entry = json.loads(line)
-                            except json.JSONDecodeError:
-                                continue
-
-                            text = entry.get("content", "").lower()
-                            if any(kw in text for kw in keywords_lower):
-                                matches.append({**entry, "theme": theme})
-                                if len(matches) >= limit:
-                                    break
-                except OSError:
-                    continue
-
-                if len(matches) >= limit:
-                    break
-        except OSError as e:
-            logger.error(f"Contextor: Failed to search memory: {e}")
-            return {"error": f"Search failed: {e}", "results": []}
-
-        logger.info(f"Contextor: Search found {len(matches)} match(es) for keywords {keywords}")
-        return {"results": matches}
-
     def semantic_search(
         self,
         query: str,
         top_k: int = 5,
+        offset: int = 0,
         theme: str | None = None,
         min_score: float = 0.3,
     ) -> Dict[str, Any]:
         """
-        Semantic search — find memories by meaning, not just keywords.
+        Semantic search — find memories by meaning using embeddings.
 
-        Uses the vector store to find the most semantically relevant entries
-        for a given query. Falls back to keyword search if vector store is
-        unavailable.
+        Embeddings-only: returns empty results when vector store is
+        unavailable. No keyword fallback.
 
         Args:
             query: Natural language query.
             top_k: Number of results to return.
+            offset: Skip the top N closest results (for pagination/digging deeper).
             theme: Optional theme filter.
-            min_score: Minimum cosine similarity (0-1). Default 0.3 filters
-                       out clearly irrelevant results while keeping loose matches.
+            min_score: Minimum cosine similarity (0-1).
         """
         if not self._vector_store:
-            logger.debug("Contextor: No vector store, falling back to keyword search")
-            keywords = query.lower().split()
-            return self.search(keywords, limit=top_k)
+            logger.warning("Contextor: Semantic search unavailable (no vector store)")
+            return {
+                "results": [],
+                "available": False,
+                "reason": "Vector store not initialized — ensure embedding model is pulled and chromadb is installed",
+            }
+
+        # Fetch top_k + offset results, then slice off the offset
+        fetch_count = top_k + offset
 
         results = self._vector_store.query(
             query_text=query,
-            top_k=top_k,
+            top_k=fetch_count,
             theme=theme,
             min_score=min_score,
         )
 
+        # Apply offset — skip the N most similar results
+        if offset > 0 and results:
+            results = results[offset:]
+
         logger.info(
             f"Contextor: Semantic search for '{query[:50]}' "
-            f"returned {len(results)} results"
+            f"returned {len(results)} results (offset={offset}, top_k={top_k})"
         )
-        return {"results": results, "method": "semantic"}
+        return {"results": results, "available": True}
 
     def retrieve_context(
         self,
         query: str,
         top_k: int = 5,
+        offset: int = 0,
         min_score: float = 0.3,
     ) -> str:
         """
         RAG entry point — retrieve relevant memories and format them
         for injection into the LLM context.
 
-        This is the method to call from _build_root_context() before
-        each LLM invocation. Returns a formatted string ready to be
-        included in the prompt, or empty string if nothing relevant.
-
-        Args:
-            query: The current user input or context to search against.
-            top_k: Max number of memories to retrieve.
-            min_score: Minimum relevance threshold.
+        Returns a formatted string ready for prompt inclusion, or empty
+        string if nothing relevant or search is unavailable.
         """
-        result = self.semantic_search(query, top_k=top_k, min_score=min_score)
-        entries = result.get("results", [])
+        result = self.semantic_search(
+            query, top_k=top_k, offset=offset, min_score=min_score,
+        )
 
+        if not result.get("available", False):
+            return ""
+
+        entries = result.get("results", [])
         if not entries:
             return ""
 
@@ -279,9 +292,7 @@ class ContextorAdapter:
         return formatted
 
     def list_themes(self) -> Dict[str, Any]:
-        """
-        List all stored themes with entry counts.
-        """
+        """List all stored themes with entry counts."""
         themes: list[dict] = []
 
         try:
@@ -321,7 +332,6 @@ class ContextorAdapter:
         try:
             os.remove(path)
 
-            # Also clean up vector store
             if self._vector_store:
                 try:
                     self._vector_store.delete_by_theme(theme)
@@ -337,9 +347,7 @@ class ContextorAdapter:
     def reindex_vector_store(self) -> Dict[str, Any]:
         """
         Rebuild the vector store index from JSONL source files.
-
         Useful after migration or if the vector store gets corrupted.
-        JSONL files are always the source of truth.
         """
         if not self._vector_store:
             return {"error": "No vector store configured"}
@@ -371,6 +379,7 @@ class ContextorAdapter:
                                         metadata={
                                             "stored_at": entry.get("stored_at", 0),
                                             "stored_iso": entry.get("stored_iso", ""),
+                                            "type": entry.get("type", ""),
                                         },
                                     )
                                     indexed += 1

--- a/jarvis/core/command_parser.py
+++ b/jarvis/core/command_parser.py
@@ -101,7 +101,9 @@ class TaskParser:
         if action == "recall":
             return f", theme={result.get('theme')}"
         if action == "search_memory":
-            return f", keywords={result.get('keywords', [])}"
+            query = result.get("query", "")[:40]
+            offset = result.get("offset", 0)
+            return f", query='{query}', top_k={result.get('top_k', 5)}, offset={offset}"
         return ""
 
 
@@ -328,12 +330,16 @@ def _parse_recall(response: Dict[str, Any]) -> Dict[str, Any]:
 
 @_parser("search_memory")
 def _parse_search_memory(response: Dict[str, Any]) -> Dict[str, Any]:
-    keywords = response.get("keywords", [])
-    if not isinstance(keywords, list) or not keywords:
-        return {"error": "search_memory requires a non-empty 'keywords' list", "raw": response}
+    """Parse search_memory — semantic search with natural language query."""
+    query = response.get("query", "")
+    if not query:
+        return {"error": "search_memory requires a 'query' string", "raw": response}
     return {
         "action": "search_memory",
-        "keywords": [str(k) for k in keywords],
+        "query": str(query),
+        "top_k": int(response.get("top_k", 5)),
+        "offset": int(response.get("offset", 0)),
+        "min_score": float(response.get("min_score", 0.3)),
     }
 
 

--- a/jarvis/core/component_factory.py
+++ b/jarvis/core/component_factory.py
@@ -126,12 +126,11 @@ class ComponentFactory:
         """
         Create ContextorAdapter for long-term memory management.
 
-        When RAG_ENABLED=true, also initializes:
-        - OllamaEmbeddings (for generating vector embeddings)
-        - VectorStore (ChromaDB-backed semantic search index)
-
-        Falls back gracefully to keyword-only search if embedding model
-        or ChromaDB is unavailable.
+        Initializes the vector store (ChromaDB) for embeddings-only
+        semantic search. When the vector store is unavailable:
+        - store() and recall() still work (JSONL-based)
+        - semantic_search() returns {"available": false} explicitly
+        - No silent keyword fallback — degraded mode is visible
         """
         logger.info("Initiating Contextor adapter...")
 
@@ -143,7 +142,7 @@ class ComponentFactory:
                 from ..contextor.vector_store import VectorStore
 
                 logger.info(
-                    f"RAG enabled — initializing embeddings "
+                    f"Initializing embeddings "
                     f"(model: {Config.EMBED_MODEL})..."
                 )
                 embeddings = OllamaEmbeddings(model=Config.EMBED_MODEL)
@@ -154,18 +153,24 @@ class ComponentFactory:
                         f"Vector store ready ({vector_store.count} entries)"
                     )
                 else:
-                    logger.warning(
-                        f"Embedding model '{Config.EMBED_MODEL}' not available. "
-                        f"RAG disabled — falling back to keyword search. "
-                        f"Pull the model with: ollama pull {Config.EMBED_MODEL}"
+                    logger.error(
+                        f"DEGRADED MODE: Embedding model '{Config.EMBED_MODEL}' not available. "
+                        f"Memory search will be disabled. Store and recall by theme still work. "
+                        f"Fix: ollama pull {Config.EMBED_MODEL}"
                     )
             except ImportError as e:
-                logger.warning(
-                    f"RAG dependencies not available: {e}. "
-                    f"Install with: pip install chromadb"
+                logger.error(
+                    f"DEGRADED MODE: {e}. "
+                    f"Memory search will be disabled. "
+                    f"Fix: pip install chromadb"
                 )
             except Exception as e:
-                logger.warning(f"RAG initialization failed (non-fatal): {e}")
+                logger.error(f"DEGRADED MODE: Vector store init failed: {e}")
+        else:
+            logger.warning(
+                "RAG_ENABLED=false — memory search is disabled. "
+                "Only store and recall by theme are available."
+            )
 
         return ContextorAdapter(vector_store=vector_store)
 

--- a/jarvis/main.py
+++ b/jarvis/main.py
@@ -149,6 +149,11 @@ class Jarvis:
         logger.info(f"JARVIS: User input: '{text}'")
         self.goals.add_goal(text)
 
+        # Auto-store every user prompt for long-term recall.
+        # No LLM decision — every prompt gets persisted + embedded.
+        if self.contextor:
+            self.contextor.auto_store_prompt(text)
+
         self.llm.switch_mode("root")
         context = self._build_root_context(new_input=text)
 
@@ -543,7 +548,12 @@ class Jarvis:
                 context = f"RECALL_RESULT: {json.dumps(result)}"
 
             elif action == "search_memory":
-                result = self.contextor.search(parsed["keywords"])
+                result = self.contextor.semantic_search(
+                    query=parsed["query"],
+                    top_k=parsed.get("top_k", 5),
+                    offset=parsed.get("offset", 0),
+                    min_score=parsed.get("min_score", 0.3),
+                )
                 context = f"SEARCH_MEMORY_RESULT: {json.dumps(result)}"
 
             elif action == "list_memory":


### PR DESCRIPTION
Make contextor retrieval purely semantic — no keyword substring search fallback. When vector store is unavailable, search returns explicit {"available": false} instead of silently degrading to keywords.

Key changes:

contextor/adapter.py:
- Remove search() keyword method from retrieval path
- semantic_search(): returns {available: false} when no vector store instead of falling back to keyword search
- Add offset parameter to semantic_search() for pagination — LLM can skip top N results to dig deeper into memory
- Add auto_store_prompt(): automatically stores every user prompt with embedding for long-term recall, no LLM decision needed
- Add search_available property for explicit status checking

main.py:
- Auto-store every user prompt in _on_user_input() before LLM processes it
- Update contextor sub-chain: search_memory now uses semantic_search() with query, top_k, offset, min_score

config.py:
- Move default data dir to XDG: ~/.local/share/jarvis/ (was ~/.jarvis/)
- Update LLM_CONTEXTOR_PROMPT: search_memory uses natural language query with offset parameter instead of keyword list
- Document offset usage for LLM: skip top N to paginate through results

command_parser.py:
- search_memory parser: accepts query (string) instead of keywords (list)
- Add top_k, offset, min_score parameters
- Old keyword format is rejected with clear error

component_factory.py:
- Explicit DEGRADED MODE logging when vector store fails to initialize
- No more "falling back to keyword search" messaging

https://claude.ai/code/session_01AqdY5j8F4JV4ZWJePPQwmP