### PR TITLE
Fix LLM returning identical responses: chat_history reference desync

### DIFF
--- a/jarvis/.env.example
+++ b/jarvis/.env.example
@@ -70,6 +70,10 @@ LLM_MODEL=qwen3:4b
 # Set to "true" for non-interactive environments (scripts, CI/CD)
 LLM_AUTO_PULL=false
 
+# Sampling temperature (0.0 = deterministic, 1.0+ = creative)
+# Default 0.7 gives varied but consistent responses.
+# LLM_TEMPERATURE=0.7
+
 # ===========================================
 # Text-to-Speech (Piper) Configuration
 # ===========================================

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -37,6 +37,10 @@ class Config:
     # Ollama-specific
     LLM_AUTO_PULL = os.getenv("LLM_AUTO_PULL", "false").lower() == "true"
 
+    # Sampling temperature for LLM responses (0.0 = deterministic, 1.0+ = creative)
+    # Default 0.7 gives a balance of consistency and variety.
+    LLM_TEMPERATURE = float(os.getenv("LLM_TEMPERATURE", "0.7"))
+
     TTS_MODEL_ONNX = os.getenv("TTS_MODEL_ONNX")
     TTS_MODEL_JSON = os.getenv("TTS_MODEL_JSON")
 

--- a/jarvis/core/component_factory.py
+++ b/jarvis/core/component_factory.py
@@ -35,6 +35,7 @@ class ComponentFactory:
             provider_kwargs["base_url"] = Config.LLM_URL
             provider_kwargs["api_key"] = Config.LLM_API_KEY
             provider_kwargs["auto_pull"] = getattr(Config, "LLM_AUTO_PULL", False)
+            provider_kwargs["temperature"] = getattr(Config, "LLM_TEMPERATURE", 0.7)
         elif provider_type == "api":
             if not Config.LLM_URL:
                 raise ValueError("LLM_URL must be set when using API provider")

--- a/jarvis/llm/chat.py
+++ b/jarvis/llm/chat.py
@@ -63,7 +63,7 @@ class LLM:
                 {"role": "system", "content": prompt},
             ]
 
-        self.chat_history = list(self._histories["root"])
+        self.chat_history = self._histories["root"]
 
         # --- Tiered context manager (ROOT mode only) ---
         self._context_manager = ContextManager(
@@ -74,7 +74,9 @@ class LLM:
 
         logger.info("LLM: Initiating Preload...")
         try:
-            self.provider.chat(self.chat_history)
+            # Preload with a copy — warms Ollama's KV cache for the system
+            # prompt without affecting the live chat_history reference.
+            self.provider.chat(list(self.chat_history))
             logger.info("LLM: Initiation Complete!")
         except Exception as e:
             logger.warning(f"LLM preload failed (this may be expected): {e}")

--- a/jarvis/llm/providers/ollama.py
+++ b/jarvis/llm/providers/ollama.py
@@ -19,10 +19,12 @@ class OllamaProvider(BaseLLMProvider):
         base_url: Optional[str] = None,
         api_key: Optional[str] = None,
         auto_pull: bool = False,
+        temperature: Optional[float] = None,
     ):
         super().__init__(model)
         self.base_url = base_url or "http://localhost:11434"
         self.auto_pull = auto_pull
+        self.temperature = temperature
 
         import os
         if base_url and base_url != "http://localhost:11434":
@@ -43,11 +45,16 @@ class OllamaProvider(BaseLLMProvider):
     # -- BaseLLMProvider interface -------------------------------------------
 
     def chat(self, messages: List[Dict[str, str]]) -> str:
+        options = {}
+        if self.temperature is not None:
+            options["temperature"] = self.temperature
+
         try:
             response = self._client.chat(
                 model=self.model,
                 messages=messages,
                 format="json",
+                options=options or None,
             )
             return response["message"]["content"]
         except Exception as e:
@@ -60,6 +67,7 @@ class OllamaProvider(BaseLLMProvider):
                             model=self.model,
                             messages=messages,
                             format="json",
+                            options=options or None,
                         )
                         return response["message"]["content"]
                     except Exception as retry_error:


### PR DESCRIPTION
Root cause: LLM.__init__ used `list()` to copy _histories["root"] into chat_history. This created two separate list objects. When switch_mode("root") was called while already in root mode, it returned early without reassigning chat_history — so user messages appended to the copy were invisible to _get_hot_exchanges(), which reads from _histories["root"] (the original).

Result: build_messages() received empty hot_exchanges and sent ONLY the system prompt to the provider — the exact same input as the preload. Ollama's KV cache returned the same cached greeting every time.

Fix:
- chat_history now points directly to _histories["root"] (no copy)
- Preload uses list(self.chat_history) to protect the live reference

Also added LLM_TEMPERATURE config (default 0.7) to prevent deterministic outputs. Some models default to temperature=0 in JSON mode, producing identical tokens for similar prompts even when user input varies. Wired through Config → ComponentFactory → OllamaProvider → ollama Client.chat(options={"temperature": ...}).

https://claude.ai/code/session_01AqdY5j8F4JV4ZWJePPQwmP