### PR TITLE
Pass CONFIRMATION_MODE config to socket security warning

### DIFF
--- a/jarvis/runtime/lifecycle.py
+++ b/jarvis/runtime/lifecycle.py
@@ -94,7 +94,7 @@ async def start_runtime_services(
         from ..core.socket_security import harden_socket_path, warn_if_allow_all
 
         harden_socket_path(Config.JARVIS_INPUT_SOCKET)
-        warn_if_allow_all()
+        warn_if_allow_all(Config.CONFIRMATION_MODE)
         input_socket_task = asyncio.create_task(app._run_socket_listener())
         logger.info(f"JARVIS: Socket listener at {Config.JARVIS_INPUT_SOCKET}")
 


### PR DESCRIPTION
## What changed

- Modified `warn_if_allow_all()` call in `start_runtime_services()` to pass `Config.CONFIRMATION_MODE` as an argument
- This allows the socket security warning function to access the confirmation mode configuration

## Why this change

The `warn_if_allow_all()` function needs access to the `CONFIRMATION_MODE` configuration to properly handle or customize its warning behavior based on whether confirmation mode is enabled.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Tests only

## Test plan

N/A - This is a straightforward parameter passing change. Existing tests that cover the `start_runtime_services()` function will validate this change.

## Checklist

- [ ] I followed `docs/engineering-standards.md`
- [ ] I added or updated tests for behavior changes
- [ ] I updated documentation where needed
- [ ] I did not include secrets or sensitive data
- [ ] I verified there are no unrelated changes in this PR

## Risk and rollout notes

Low risk - This change only adds a configuration parameter to an existing function call. The behavior depends on how `warn_if_allow_all()` uses the `CONFIRMATION_MODE` parameter.

https://claude.ai/code/session_01LtSUNQhUVnpY2dmPsydsP3