### PR TITLE
Add web search, app launcher, and session management features

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+        language_version: python3
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.2.0
+    hooks:
+      - id: flake8
+        args: [--select=E9,F63,F7,F82]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,4 +14,4 @@ repos:
     rev: 7.2.0
     hooks:
       - id: flake8
-        args: [--select=E9,F63,F7,F82]
+        args: ["--select=E9,F63,F7,F82"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
@@ -7,17 +7,15 @@
 
                             Preamble
 
-  The GNU General Public License is a free, copyleft license for
-software and other kinds of works.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
   The licenses for most software and other practical works are designed
 to take away your freedom to share and change the works.  By contrast,
-the GNU General Public License is intended to guarantee your freedom to
+our General Public Licenses are intended to guarantee your freedom to
 share and change all versions of a program--to make sure it remains free
-software for all its users.  We, the Free Software Foundation, use the
-GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors.  You can apply it to
-your programs, too.
+software for all its users.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
@@ -26,44 +24,34 @@ them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
 free programs, and that you know you can do these things.
 
-  To protect your rights, we need to prevent others from denying you
-these rights or asking you to surrender the rights.  Therefore, you have
-certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-  For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must pass on to the recipients the same
-freedoms that you received.  You must make sure that they, too, receive
-or can get the source code.  And you must show them these terms so they
-know their rights.
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-  Developers that use the GNU GPL protect your rights with two steps:
-(1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-  For the developers' and authors' protection, the GPL clearly explains
-that there is no warranty for this free software.  For both users' and
-authors' sake, the GPL requires that modified versions be marked as
-changed, so that their problems will not be attributed erroneously to
-authors of previous versions.
-
-  Some devices are designed to deny users access to install or run
-modified versions of the software inside them, although the manufacturer
-can do so.  This is fundamentally incompatible with the aim of
-protecting users' freedom to change the software.  The systematic
-pattern of such abuse occurs in the area of products for individuals to
-use, which is precisely where it is most unacceptable.  Therefore, we
-have designed this version of the GPL to prohibit the practice for those
-products.  If such problems arise substantially in other domains, we
-stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.
-
-  Finally, every program is threatened constantly by software patents.
-States should not allow patents to restrict development and use of
-software on general-purpose computers, but in those that do, we wish to
-avoid the special danger that patents applied to a free program could
-make it effectively proprietary.  To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
@@ -72,7 +60,7 @@ modification follow.
 
   0. Definitions.
 
-  "This License" refers to version 3 of the GNU General Public License.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
   "Copyright" also means copyright-like laws that apply to other kinds of
 works, such as semiconductor masks.
@@ -549,35 +537,45 @@ to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
 
-  13. Use with the GNU Affero General Public License.
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
 
   Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a single
+under version 3 of the GNU General Public License into a single
 combined work, and to convey the resulting work.  The terms of this
 License will continue to apply to the part which is the covered work,
-but the special requirements of the GNU Affero General Public License,
-section 13, concerning interaction through a network will apply to the
-combination as such.
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
 
   14. Revised Versions of this License.
 
   The Free Software Foundation may publish revised and/or new versions of
-the GNU General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
   Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU General
+Program specifies that a certain numbered version of the GNU Affero General
 Public License "or any later version" applies to it, you have the
 option of following the terms and conditions either of that numbered
 version or of any later version published by the Free Software
 Foundation.  If the Program does not specify a version number of the
-GNU General Public License, you may choose any version ever published
+GNU Affero General Public License, you may choose any version ever published
 by the Free Software Foundation.
 
   If the Program specifies that a proxy can decide which future
-versions of the GNU General Public License can be used, that proxy's
+versions of the GNU Affero General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
 to choose that version for the Program.
 
@@ -635,40 +633,29 @@ the "copyright" line and a pointer to where the full notice is found.
     Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
+    You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-  If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:
-
-    <program>  Copyright (C) <year>  <name of author>
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an "about box".
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
 
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
+For more information on this, and how to apply and follow the GNU AGPL, see
 <https://www.gnu.org/licenses/>.
-
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/jarvis/cli.py
+++ b/jarvis/cli.py
@@ -35,7 +35,11 @@ JarvisLogger.setup(
 
 logger = get_logger(__name__)
 
-ENV_FILE = Path(__file__).parent / ".env"
+_jarvis_config_dir = os.environ.get("JARVIS_CONFIG_DIR")
+if _jarvis_config_dir:
+    ENV_FILE = Path(_jarvis_config_dir) / "jarvis.conf"
+else:
+    ENV_FILE = Path.home() / ".config" / "jarvis" / "jarvis.conf"
 
 
 def _cmd_send() -> None:
@@ -246,6 +250,7 @@ def _update_env_setting(key: str, value: str) -> None:
     if not found:
         lines.append(f"{key}={value}")
 
+    ENV_FILE.parent.mkdir(parents=True, exist_ok=True)
     ENV_FILE.write_text("\n".join(lines) + "\n")
 
     os.environ[key] = value

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -241,6 +241,7 @@ store — Remember a personal fact or preference under a topic theme.
 recall — Recall stored facts by exact theme name.
 search_memory — Search all memories by meaning (semantic search). Use when you need context.
 list_memory — List all stored memory themes.
+rename_session — Rename the current chat session. Use after the first substantive exchange when SESSION_TITLE is "New chat" — pick a short (2–5 word) title that captures the topic.
 {data_consent_note}
 dispatch — Run tools (calc, files, web, etc.). Use when user wants to DO something that needs external tools.
 
@@ -280,15 +281,27 @@ dispatch — Run tools (calc, files, web, etc.). Use when user wants to DO somet
 }}
 
 {{
+    "action": "rename_session",
+    "title": "<short descriptive title, 2-5 words>",
+    "goal_updates": []
+}}
+
+{{
     "action": "dispatch",
     "intent": "<what to accomplish>"
 }}
 
 --- Context ---
-You receive: GOALS (with IDs), NEW INPUT, and optionally DISPATCH_SUMMARY from dispatch.
+You receive: GOALS (with IDs), SESSION_TITLE (current chat name), NEW INPUT, and optionally DISPATCH_SUMMARY from dispatch.
 Memory operation results appear as STORE_RESULT, RECALL_RESULT, SEARCH_MEMORY_RESULT, LIST_MEMORY_RESULT.
+RENAME_RESULT confirms the rename succeeded — then respond to the user normally.
 RELEVANT MEMORIES may be included automatically based on user input (RAG retrieval).
 Include goal_updates in respond: "completed" or "failed" with result.
+
+--- Session naming guidelines ---
+- When SESSION_TITLE is "New chat" and the user has sent a substantive message, use rename_session before responding.
+- Title should reflect the main topic (e.g. "System Update Verbose", "Python Help", "Music Recommendations").
+- After RENAME_RESULT arrives, respond to the user as normal.
 
 --- Memory guidelines ---
 - Choose descriptive theme names (e.g. "user_preferences", "school_schedule")
@@ -307,6 +320,7 @@ OS: {system} {release} ({machine}), Shell: {shell}
 --- When to use each action ---
 
 respond — Direct reply. Use for chat, greetings, general knowledge, or after a subsystem returns a summary.
+rename_session — Rename the current chat session. Use after the first substantive exchange when SESSION_TITLE is "New chat".
 dispatch — Run tools (calc, files, web, etc.). Use when user wants to DO something that needs external tools.
 Memory is disabled. Do not use store, recall, search_memory, or list_memory.
 
@@ -319,13 +333,24 @@ Memory is disabled. Do not use store, recall, search_memory, or list_memory.
 }}
 
 {{
+    "action": "rename_session",
+    "title": "<short descriptive title, 2-5 words>",
+    "goal_updates": []
+}}
+
+{{
     "action": "dispatch",
     "intent": "<what to accomplish>"
 }}
 
 --- Context ---
-You receive: GOALS (with IDs), NEW INPUT, and optionally DISPATCH_SUMMARY from subsystems.
+You receive: GOALS (with IDs), SESSION_TITLE (current chat name), NEW INPUT, and optionally DISPATCH_SUMMARY from subsystems.
+RENAME_RESULT confirms rename succeeded — then respond to the user normally.
 Include goal_updates in respond: "completed" or "failed" with result.
+
+--- Session naming guidelines ---
+- When SESSION_TITLE is "New chat" and the user has sent a substantive message, use rename_session before responding.
+- Title should reflect the main topic (2-5 words).
 
 Output exactly one JSON object. First char {{, last char }}.
 """

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -138,13 +138,18 @@ class Config:
     RAG_MIN_SCORE = float(os.getenv("RAG_MIN_SCORE", "0.3"))
 
     # --- Semantic Tool Discovery ---
-    # Tool discovery always uses embedding search (via dispatch → dmcp).
-    # When the embedding model is unavailable, all visible servers are shown
-    # as CANDIDATE_SERVERS so the LLM can still install and dispatch.
-    # Master switch: set false to completely disable embedding-based discovery.
+    # Master switch for vector-based tool search via dispatch/dmcp
     ALLOW_EMBEDDING_SEARCH = (
         os.getenv("ALLOW_EMBEDDING_SEARCH", "true").lower() == "true"
     )
+    # Bypass threshold — use vector search regardless of server count
+    ENFORCE_EMBEDDING_SEARCH = (
+        os.getenv("ENFORCE_EMBEDDING_SEARCH", "false").lower() == "true"
+    )
+    # Minimum visible servers before vector search auto-enables.
+    # Default 0 means embedding is always preferred when available;
+    # keyword search is the fallback when the embed model is unavailable.
+    EMBEDDING_SEARCH_THRESHOLD = int(os.getenv("EMBEDDING_SEARCH_THRESHOLD", "0"))
 
     # Data directory — when set (e.g. systemd JARVIS_DATA_DIR=/var/lib/jarvis),
     # memory, goal archive, and default socket use this base path
@@ -361,12 +366,104 @@ Output exactly one JSON object. First char {{, last char }}.
 """
 
     # ------------------------------------------------------------------
-    # Dispatch mode system prompt.
-    # Tool discovery always uses embedding search — the LLM never needs
-    # to know which backend is active; it just follows this schema.
+    # Dispatch mode: two variants selected per-turn by the system.
+    #
+    # JARVIS picks which prompt is active based on the current tool-
+    # discovery backend (see DispatchAdapter.select_discovery_mode).
+    # The LLM never sees the words "embedding", "semantic", "vector",
+    # or "keyword" — it just follows whichever schema is in front of it.
     # ------------------------------------------------------------------
 
-    LLM_DISPATCH_PROMPT = """\
+    LLM_DISPATCH_PROMPT_KEYWORD = """\
+You are operating in DISPATCH mode. Your job is to find and execute MCP server tools.
+
+CRITICAL: Your ENTIRE response must be a single valid JSON object.
+
+--- Workflow ---
+1. plan: ALWAYS start here. Break the intent into sub-tasks. For each sub-task,
+   give a short intent and a few keywords the system can look up.
+2. The system returns MATCHED_TOOLS (ready to dispatch) and/or
+   CANDIDATE_SERVERS (need installation first).
+3. If MATCHED_TOOLS is present → dispatch those tools with correct params.
+4. If only CANDIDATE_SERVERS is present → install a promising one,
+   then list_tools, then dispatch.
+5. If nothing matched → search with different keywords, or done with a failure summary.
+6. done: Return a concise summary to root.
+
+--- Actions ---
+
+Plan sub-tasks (ALWAYS start with this):
+{{
+    "action": "plan",
+    "tasks": [
+        {{"intent": "get weather forecast for Berlin", "keywords": ["weather", "forecast"]}},
+        {{"intent": "convert 50 EUR to USD", "keywords": ["currency", "convert"]}}
+    ]
+}}
+
+Search servers by keyword (use only if plan returned nothing useful):
+{{"action": "search", "keywords": ["calculator", "math"]}}
+
+List tools on an installed server:
+{{"action": "list_tools", "server_id": "com.example.server"}}
+
+Install a server:
+{{"action": "install", "server_id": "com.example.server"}}
+
+Dispatch tasks (concurrent execution):
+{{
+    "action": "dispatch",
+    "tasks": [
+        {{"server": "<server_id>", "tool": "<tool_name>", "params": {{}}, "remind_after": 60}}
+    ]
+}}
+
+Wait for running tasks:
+{{"action": "wait"}}
+
+Kill running tasks:
+{{"action": "kill", "pids": [1, 3]}}
+
+Defer a goal:
+{{"action": "defer", "goal_id": "<id>", "duration": 1800, "reason": "optional"}}
+
+Return to root with results:
+{{"action": "done", "summary": "<concise result summary for the root system>"}}
+
+--- Context you receive ---
+- INTENT: What root asked you to do
+- GOALS: Active goals
+- MATCHED_TOOLS: Tools ready to dispatch — server_id/tool_name plus params schema
+- CANDIDATE_SERVERS: Servers that look relevant but are NOT installed —
+                     use install + list_tools to make them dispatchable
+- TOOLS: Tool listings from a server (after list_tools)
+- SEARCH_RESULTS: Server search results (after search)
+- INSTALL_RESULT: Installation outcome
+- DISPATCH_RESULT / DISPATCH_ERROR: Task execution results
+- SIGNAL: Dispatch event (INIT, EXIT, REMIND, WAIT, KILL)
+
+--- Signal types ---
+- INIT: Task started (includes PID)
+- EXIT: Task finished (includes output or error)
+- REMIND: Task exceeded its reminder threshold
+- WAIT: You previously chose to wait
+- KILL: Task was terminated
+
+--- Rules ---
+- ALWAYS start with "plan" — even for a single task.
+- If MATCHED_TOOLS is present, dispatch those. Never invent tool names.
+- If only CANDIDATE_SERVERS is present, install + list_tools first.
+- If nothing matched, try search with different keywords, or done with a failure summary.
+- When done due to failure, the summary must be specific: "UNAVAILABLE: <reason>" or
+  "FAILED: <error>". Never write vague summaries like "please try again" — root must
+  know exactly why the task could not be completed.
+- You can dispatch multiple tasks in one action for parallelism.
+- Output exactly one JSON object — no preamble, no trailing text.
+
+The very first character of your response must be {{ and the very last must be }}.
+"""
+
+    LLM_DISPATCH_PROMPT_EMBEDDING = """\
 You are operating in DISPATCH mode. Your job is to find and execute MCP server tools.
 
 CRITICAL: Your ENTIRE response must be a single valid JSON object.

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -198,6 +198,10 @@ class Config:
     LOG_COLORS = (
         os.getenv("LOG_COLORS", "true").lower() == "true"
     )  # Enable colored console output
+    # Optional: path to JSONL file capturing every LLM call (input + output).
+    # Each line: {ts, mode, attempt, messages, raw_output, parse_source[, action]}
+    # Empty (default) disables the log entirely.
+    LLM_IO_LOG = os.getenv("LLM_IO_LOG", "")
 
     # os.environ["OLLAMA_NO_GPU"] = "1"
     # os.environ["OLLAMA_NUM_THREADS"] = str(multiprocessing.cpu_count())

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -295,6 +295,7 @@ dispatch — Run external tools. Use for: web/internet search, shell commands, o
 
 --- Context ---
 You receive: GOALS (with IDs), SESSION_TITLE (current chat name), NEW INPUT, and optionally DISPATCH_SUMMARY from dispatch.
+If DISPATCH_SUMMARY reports that a tool was unavailable or the task could not be completed, tell the user that honestly — do NOT infer, guess, or fabricate any result. Never make up command output, file listings, version numbers, or any system data.
 Memory operation results appear as STORE_RESULT, RECALL_RESULT, SEARCH_MEMORY_RESULT, LIST_MEMORY_RESULT.
 RENAME_RESULT confirms the rename succeeded — then respond to the user normally.
 RELEVANT MEMORIES may be included automatically based on user input (RAG retrieval).
@@ -347,6 +348,7 @@ Memory is disabled. Do not use store, recall, search_memory, or list_memory.
 
 --- Context ---
 You receive: GOALS (with IDs), SESSION_TITLE (current chat name), NEW INPUT, and optionally DISPATCH_SUMMARY from subsystems.
+If DISPATCH_SUMMARY reports that a tool was unavailable or the task could not be completed, tell the user that honestly — do NOT infer, guess, or fabricate any result. Never make up command output, file listings, or system data.
 RENAME_RESULT confirms rename succeeded — then respond to the user normally.
 Include goal_updates in respond: "completed" or "failed" with result.
 
@@ -446,6 +448,9 @@ Return to root with results:
 - If MATCHED_TOOLS is present, dispatch those. Never invent tool names.
 - If only CANDIDATE_SERVERS is present, install + list_tools first.
 - If nothing matched, try search with different keywords, or done with a failure summary.
+- When done due to failure, the summary must be specific: "UNAVAILABLE: <reason>" or
+  "FAILED: <error>". Never write vague summaries like "please try again" — root must
+  know exactly why the task could not be completed.
 - You can dispatch multiple tasks in one action for parallelism.
 - Output exactly one JSON object — no preamble, no trailing text.
 
@@ -531,6 +536,9 @@ Return to root with results:
 - If only CANDIDATE_SERVERS is present, install + list_tools first.
 - If nothing matched, re-plan with more specific sub-task intents,
   or done with a failure summary.
+- When done due to failure, the summary must be specific: "UNAVAILABLE: <reason>" or
+  "FAILED: <error>". Never write vague summaries like "please try again" — root must
+  know exactly why the task could not be completed.
 - You can dispatch multiple tasks in one action for parallelism.
 - Output exactly one JSON object — no preamble, no trailing text.
 

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -3,7 +3,7 @@ import os
 
 from dotenv import load_dotenv
 
-# Load config: JARVIS_CONFIG_DIR (system install) or jarvis/.env (dev)
+# Load config: JARVIS_CONFIG_DIR > ~/.config/jarvis/jarvis.conf > package .env
 _config_dir = os.getenv("JARVIS_CONFIG_DIR")
 if _config_dir:
     _env_path = os.path.join(_config_dir, "jarvis.conf")
@@ -12,6 +12,9 @@ if _config_dir:
     else:
         load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 else:
+    _user_conf = os.path.join(os.path.expanduser("~"), ".config", "jarvis", "jarvis.conf")
+    if os.path.isfile(_user_conf):
+        load_dotenv(_user_conf)
     load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 
 

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -241,11 +241,11 @@ OS: {system} {release} ({machine}), Shell: {shell}
 respond — Direct reply. Use for chat, greetings, general knowledge, or after a subsystem returns a result.
 store — Remember a personal fact or preference under a topic theme.
 recall — Recall stored facts by exact theme name.
-search_memory — Search all memories by meaning (semantic search). Use when you need context.
+search_memory — Search JARVIS's own stored memories by meaning. Use ONLY when looking for something previously remembered/stored. NOT for internet or web searches.
 list_memory — List all stored memory themes.
 rename_session — Rename the current chat session. Use after the first substantive exchange when SESSION_TITLE is "New chat" — pick a short (2–5 word) title that captures the topic.
 {data_consent_note}
-dispatch — Run tools (calc, files, web, etc.). Use when user wants to DO something that needs external tools.
+dispatch — Run external tools. Use for: web/internet search, shell commands, opening apps, calculator, file operations, anything requiring live data or system actions. Web search goes here, NOT to search_memory.
 
 --- Actions (exact format) ---
 
@@ -308,7 +308,7 @@ Include goal_updates in respond: "completed" or "failed" with result.
 --- Memory guidelines ---
 - Choose descriptive theme names (e.g. "user_preferences", "school_schedule")
 - When storing, extract the key fact — be concise
-- Use search_memory with natural language — it searches by meaning, not keywords
+- Use search_memory only for stored JARVIS memories — for internet/web searches use dispatch
 - If search results aren't relevant, try again with a higher offset to dig deeper
 
 Output exactly one JSON object. First char {{, last char }}.

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -138,16 +138,13 @@ class Config:
     RAG_MIN_SCORE = float(os.getenv("RAG_MIN_SCORE", "0.3"))
 
     # --- Semantic Tool Discovery ---
-    # Master switch for vector-based tool search via dispatch/dmcp
+    # Tool discovery always uses embedding search (via dispatch → dmcp).
+    # When the embedding model is unavailable, all visible servers are shown
+    # as CANDIDATE_SERVERS so the LLM can still install and dispatch.
+    # Master switch: set false to completely disable embedding-based discovery.
     ALLOW_EMBEDDING_SEARCH = (
         os.getenv("ALLOW_EMBEDDING_SEARCH", "true").lower() == "true"
     )
-    # Bypass threshold — use vector search regardless of server count
-    ENFORCE_EMBEDDING_SEARCH = (
-        os.getenv("ENFORCE_EMBEDDING_SEARCH", "false").lower() == "true"
-    )
-    # Minimum visible servers before vector search auto-enables
-    EMBEDDING_SEARCH_THRESHOLD = int(os.getenv("EMBEDDING_SEARCH_THRESHOLD", "100"))
 
     # Data directory — when set (e.g. systemd JARVIS_DATA_DIR=/var/lib/jarvis),
     # memory, goal archive, and default socket use this base path
@@ -364,104 +361,12 @@ Output exactly one JSON object. First char {{, last char }}.
 """
 
     # ------------------------------------------------------------------
-    # Dispatch mode: two variants selected per-turn by the system.
-    #
-    # JARVIS picks which prompt is active based on the current tool-
-    # discovery backend (see DispatchAdapter.select_discovery_mode).
-    # The LLM never sees the words "embedding", "semantic", "vector",
-    # or "keyword" — it just follows whichever schema is in front of it.
+    # Dispatch mode system prompt.
+    # Tool discovery always uses embedding search — the LLM never needs
+    # to know which backend is active; it just follows this schema.
     # ------------------------------------------------------------------
 
-    LLM_DISPATCH_PROMPT_KEYWORD = """\
-You are operating in DISPATCH mode. Your job is to find and execute MCP server tools.
-
-CRITICAL: Your ENTIRE response must be a single valid JSON object.
-
---- Workflow ---
-1. plan: ALWAYS start here. Break the intent into sub-tasks. For each sub-task,
-   give a short intent and a few keywords the system can look up.
-2. The system returns MATCHED_TOOLS (ready to dispatch) and/or
-   CANDIDATE_SERVERS (need installation first).
-3. If MATCHED_TOOLS is present → dispatch those tools with correct params.
-4. If only CANDIDATE_SERVERS is present → install a promising one,
-   then list_tools, then dispatch.
-5. If nothing matched → search with different keywords, or done with a failure summary.
-6. done: Return a concise summary to root.
-
---- Actions ---
-
-Plan sub-tasks (ALWAYS start with this):
-{{
-    "action": "plan",
-    "tasks": [
-        {{"intent": "get weather forecast for Berlin", "keywords": ["weather", "forecast"]}},
-        {{"intent": "convert 50 EUR to USD", "keywords": ["currency", "convert"]}}
-    ]
-}}
-
-Search servers by keyword (use only if plan returned nothing useful):
-{{"action": "search", "keywords": ["calculator", "math"]}}
-
-List tools on an installed server:
-{{"action": "list_tools", "server_id": "com.example.server"}}
-
-Install a server:
-{{"action": "install", "server_id": "com.example.server"}}
-
-Dispatch tasks (concurrent execution):
-{{
-    "action": "dispatch",
-    "tasks": [
-        {{"server": "<server_id>", "tool": "<tool_name>", "params": {{}}, "remind_after": 60}}
-    ]
-}}
-
-Wait for running tasks:
-{{"action": "wait"}}
-
-Kill running tasks:
-{{"action": "kill", "pids": [1, 3]}}
-
-Defer a goal:
-{{"action": "defer", "goal_id": "<id>", "duration": 1800, "reason": "optional"}}
-
-Return to root with results:
-{{"action": "done", "summary": "<concise result summary for the root system>"}}
-
---- Context you receive ---
-- INTENT: What root asked you to do
-- GOALS: Active goals
-- MATCHED_TOOLS: Tools ready to dispatch — server_id/tool_name plus params schema
-- CANDIDATE_SERVERS: Servers that look relevant but are NOT installed —
-                     use install + list_tools to make them dispatchable
-- TOOLS: Tool listings from a server (after list_tools)
-- SEARCH_RESULTS: Server search results (after search)
-- INSTALL_RESULT: Installation outcome
-- DISPATCH_RESULT / DISPATCH_ERROR: Task execution results
-- SIGNAL: Dispatch event (INIT, EXIT, REMIND, WAIT, KILL)
-
---- Signal types ---
-- INIT: Task started (includes PID)
-- EXIT: Task finished (includes output or error)
-- REMIND: Task exceeded its reminder threshold
-- WAIT: You previously chose to wait
-- KILL: Task was terminated
-
---- Rules ---
-- ALWAYS start with "plan" — even for a single task.
-- If MATCHED_TOOLS is present, dispatch those. Never invent tool names.
-- If only CANDIDATE_SERVERS is present, install + list_tools first.
-- If nothing matched, try search with different keywords, or done with a failure summary.
-- When done due to failure, the summary must be specific: "UNAVAILABLE: <reason>" or
-  "FAILED: <error>". Never write vague summaries like "please try again" — root must
-  know exactly why the task could not be completed.
-- You can dispatch multiple tasks in one action for parallelism.
-- Output exactly one JSON object — no preamble, no trailing text.
-
-The very first character of your response must be {{ and the very last must be }}.
-"""
-
-    LLM_DISPATCH_PROMPT_EMBEDDING = """\
+    LLM_DISPATCH_PROMPT = """\
 You are operating in DISPATCH mode. Your job is to find and execute MCP server tools.
 
 CRITICAL: Your ENTIRE response must be a single valid JSON object.

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -12,7 +12,9 @@ if _config_dir:
     else:
         load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 else:
-    _user_conf = os.path.join(os.path.expanduser("~"), ".config", "jarvis", "jarvis.conf")
+    _user_conf = os.path.join(
+        os.path.expanduser("~"), ".config", "jarvis", "jarvis.conf"
+    )
     if os.path.isfile(_user_conf):
         load_dotenv(_user_conf)
     load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))

--- a/jarvis/core/command_parser.py
+++ b/jarvis/core/command_parser.py
@@ -24,6 +24,8 @@ VALID_ACTIONS = {
     "recall",
     "search_memory",
     "list_memory",
+    # Root — session management
+    "rename_session",
     # Dispatch subsystem
     "plan",
     "search",
@@ -377,5 +379,17 @@ def _parse_search_memory(response: Dict[str, Any]) -> Dict[str, Any]:
 def _parse_list_memory(response: Dict[str, Any]) -> Dict[str, Any]:
     return {
         "action": "list_memory",
+        "goal_updates": response.get("goal_updates", []),
+    }
+
+
+@_parser("rename_session")
+def _parse_rename_session(response: Dict[str, Any]) -> Dict[str, Any]:
+    title = response.get("title", "").strip()
+    if not title:
+        return {"error": "rename_session requires 'title'", "raw": response}
+    return {
+        "action": "rename_session",
+        "title": title,
         "goal_updates": response.get("goal_updates", []),
     }

--- a/jarvis/dispatch/adapter.py
+++ b/jarvis/dispatch/adapter.py
@@ -7,9 +7,10 @@ stdio and provides methods to send task batches, kill tasks, and receive
 signals.
 
 The adapter also handles semantic tool discovery:
-- Embeds sub-task intents via Ollama (when embedding model is available)
+- Embeds sub-task intents via Ollama (when embedding search is enabled)
 - Passes vectors to dispatch → dmcp for cosine similarity search
-- Falls back to listing all visible servers when embeddings are unavailable
+- Falls back to keyword search when vector search is unavailable or
+  returns no results
 - Auto-indexes non-approved servers after installation
 
 All decision-making lives in JARVIS — dispatch and dmcp are tools that
@@ -34,8 +35,10 @@ from .dmcp_registry import install_server as registry_install_server
 from .dmcp_registry import list_server_tools as registry_list_server_tools
 from .dmcp_registry import list_visible_servers as registry_list_visible_servers
 from .dmcp_registry import run_dmcp as registry_run_dmcp
+from .dmcp_registry import search_servers as registry_search_servers
 from .tool_discovery import discover_tools as run_tool_discovery
 from .tool_discovery import format_available_tools as render_available_tools
+from .tool_discovery import keyword_fallback as run_keyword_fallback
 from .transport import call_tool as transport_call_tool
 from .transport import connect as transport_connect
 from .transport import disconnect as transport_disconnect
@@ -206,12 +209,20 @@ class DispatchAdapter:
         return {"output": str(result)}
 
     # ------------------------------------------------------------------
-    # MCP server registry operations via dmcp
+    # MCP server discovery via dmcp (on-demand, keyword-based)
     # ------------------------------------------------------------------
 
     async def _run_dmcp(self, *args: str) -> Optional[str]:
         """Run a dmcp command and return stdout, or None on failure."""
         return await registry_run_dmcp(logger, *args)
+
+    async def search_servers(self, keywords: List[str]) -> Dict[str, Any]:
+        """
+        Search for MCP servers by keywords via `dmcp browse`.
+
+        Returns installed matches first, then not-installed ones from registries.
+        """
+        return await registry_search_servers(logger, keywords)
 
     async def list_visible_servers(self) -> Dict[str, Any]:
         """Return all visible MCP servers via `dmcp browse` with no keyword filter."""
@@ -317,6 +328,36 @@ class DispatchAdapter:
             description,
         )
 
+    async def select_discovery_mode(
+        self,
+        embeddings: Optional[Any] = None,
+    ) -> str:
+        """
+        Return the active tool-discovery backend: ``"embedding"`` or ``"keyword"``.
+
+        Chosen from config + runtime state:
+          - embedding:  ALLOW_EMBEDDING_SEARCH, embeddings available,
+                        and (visible_servers >= threshold OR enforce flag)
+          - keyword:    everything else (embed model unavailable, master
+                        switch off, or server count below threshold)
+
+        EMBEDDING_SEARCH_THRESHOLD defaults to 0, so embedding runs
+        whenever the model is available. Raise it to force keyword search
+        below a certain registry size.
+        """
+        if not Config.ALLOW_EMBEDDING_SEARCH or embeddings is None:
+            return "keyword"
+
+        count = await self.server_count()
+        total = count.get("total", 0)
+
+        if (
+            Config.ENFORCE_EMBEDDING_SEARCH
+            or total >= Config.EMBEDDING_SEARCH_THRESHOLD
+        ):
+            return "embedding"
+        return "keyword"
+
     async def discover_tools(
         self,
         tasks: List[Dict[str, Any]],
@@ -325,15 +366,27 @@ class DispatchAdapter:
         """
         Tool discovery — the main entry point after a ``plan`` action.
 
-        Always uses embedding search. Falls back to listing all visible
-        servers when embeddings are unavailable or fail.
+        Runs whichever backend ``select_discovery_mode`` picked (embedding or
+        keyword) and returns a formatted ``MATCHED_TOOLS`` / ``CANDIDATE_SERVERS``
+        block for prompt injection. Empty string if nothing matched.
 
         Args:
             tasks: List of dicts with "intent" (required) and optional
-                   "top_k", "min_score".
+                   "keywords", "top_k", "min_score".
             embeddings: OllamaEmbeddings instance for local embedding.
         """
         return await run_tool_discovery(self, logger, tasks, embeddings)
+
+    async def _keyword_fallback(self, task: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Keyword search fallback for a single sub-task.
+
+        For installed servers, expand each server into per-tool rows with
+        real ``tool_name`` / ``description`` / ``params`` so the LLM can
+        dispatch directly without guessing. Non-installed matches stay
+        server-level — the LLM must install them before they become
+        dispatchable.
+        """
+        return await run_keyword_fallback(self, logger, task)
 
     @staticmethod
     def _format_available_tools(results: List[Dict[str, Any]]) -> str:

--- a/jarvis/dispatch/adapter.py
+++ b/jarvis/dispatch/adapter.py
@@ -7,10 +7,9 @@ stdio and provides methods to send task batches, kill tasks, and receive
 signals.
 
 The adapter also handles semantic tool discovery:
-- Embeds sub-task intents via Ollama (when embedding search is enabled)
+- Embeds sub-task intents via Ollama (when embedding model is available)
 - Passes vectors to dispatch → dmcp for cosine similarity search
-- Falls back to keyword search when vector search is unavailable or
-  returns no results
+- Falls back to listing all visible servers when embeddings are unavailable
 - Auto-indexes non-approved servers after installation
 
 All decision-making lives in JARVIS — dispatch and dmcp are tools that
@@ -33,11 +32,10 @@ from .discovery import server_count as discovery_server_count
 from .discovery import sync_index as discovery_sync_index
 from .dmcp_registry import install_server as registry_install_server
 from .dmcp_registry import list_server_tools as registry_list_server_tools
+from .dmcp_registry import list_visible_servers as registry_list_visible_servers
 from .dmcp_registry import run_dmcp as registry_run_dmcp
-from .dmcp_registry import search_servers as registry_search_servers
 from .tool_discovery import discover_tools as run_tool_discovery
 from .tool_discovery import format_available_tools as render_available_tools
-from .tool_discovery import keyword_fallback as run_keyword_fallback
 from .transport import call_tool as transport_call_tool
 from .transport import connect as transport_connect
 from .transport import disconnect as transport_disconnect
@@ -208,20 +206,16 @@ class DispatchAdapter:
         return {"output": str(result)}
 
     # ------------------------------------------------------------------
-    # MCP server discovery via dmcp (on-demand, keyword-based)
+    # MCP server registry operations via dmcp
     # ------------------------------------------------------------------
 
     async def _run_dmcp(self, *args: str) -> Optional[str]:
         """Run a dmcp command and return stdout, or None on failure."""
         return await registry_run_dmcp(logger, *args)
 
-    async def search_servers(self, keywords: List[str]) -> Dict[str, Any]:
-        """
-        Search for MCP servers by keywords via `dmcp browse`.
-
-        Returns installed matches first, then not-installed ones from registries.
-        """
-        return await registry_search_servers(logger, keywords)
+    async def list_visible_servers(self) -> Dict[str, Any]:
+        """Return all visible MCP servers via `dmcp browse` with no keyword filter."""
+        return await registry_list_visible_servers(logger)
 
     async def install_server(self, server_id: str) -> Dict[str, Any]:
         """Install an MCP server from registry via `dmcp install`."""
@@ -323,34 +317,6 @@ class DispatchAdapter:
             description,
         )
 
-    async def select_discovery_mode(
-        self,
-        embeddings: Optional[Any] = None,
-    ) -> str:
-        """
-        Return the active tool-discovery backend: ``"embedding"`` or ``"keyword"``.
-
-        Chosen from config + runtime state:
-          - embedding:  ALLOW_EMBEDDING_SEARCH, embeddings available,
-                        and (visible_servers >= threshold OR enforce flag)
-          - keyword:    everything else
-
-        The LLM never sees these names — this only drives which dispatch
-        system prompt JARVIS installs and which search path runs.
-        """
-        if not Config.ALLOW_EMBEDDING_SEARCH or embeddings is None:
-            return "keyword"
-
-        count = await self.server_count()
-        total = count.get("total", 0)
-
-        if (
-            Config.ENFORCE_EMBEDDING_SEARCH
-            or total >= Config.EMBEDDING_SEARCH_THRESHOLD
-        ):
-            return "embedding"
-        return "keyword"
-
     async def discover_tools(
         self,
         tasks: List[Dict[str, Any]],
@@ -359,27 +325,15 @@ class DispatchAdapter:
         """
         Tool discovery — the main entry point after a ``plan`` action.
 
-        Runs whichever backend ``select_discovery_mode`` picked (embedding or
-        keyword) and returns a formatted ``MATCHED_TOOLS`` / ``CANDIDATE_SERVERS``
-        block for prompt injection. Empty string if nothing matched.
+        Always uses embedding search. Falls back to listing all visible
+        servers when embeddings are unavailable or fail.
 
         Args:
             tasks: List of dicts with "intent" (required) and optional
-                   "keywords", "top_k", "min_score".
+                   "top_k", "min_score".
             embeddings: OllamaEmbeddings instance for local embedding.
         """
         return await run_tool_discovery(self, logger, tasks, embeddings)
-
-    async def _keyword_fallback(self, task: Dict[str, Any]) -> List[Dict[str, Any]]:
-        """Keyword search fallback for a single sub-task.
-
-        For installed servers, expand each server into per-tool rows with
-        real ``tool_name`` / ``description`` / ``params`` so the LLM can
-        dispatch directly without guessing. Non-installed matches stay
-        server-level — the LLM must install them before they become
-        dispatchable.
-        """
-        return await run_keyword_fallback(self, logger, task)
 
     @staticmethod
     def _format_available_tools(results: List[Dict[str, Any]]) -> str:

--- a/jarvis/dispatch/dmcp_registry.py
+++ b/jarvis/dispatch/dmcp_registry.py
@@ -1,4 +1,4 @@
-"""dmcp-backed registry operations (install/tools/list and command runner)."""
+"""dmcp-backed registry operations (browse/install/tools and command runner)."""
 
 from __future__ import annotations
 
@@ -36,6 +36,91 @@ async def run_dmcp(logger: Logger, *args: str) -> Optional[str]:
     return stdout.decode()
 
 
+async def _local_installed_servers(logger: Logger) -> List[Dict[str, Any]]:
+    """Return installed servers (with manifest keywords) via `dmcp list --json`."""
+    import os
+
+    raw = await run_dmcp(logger, "list", "--json")
+    if not raw:
+        return []
+    try:
+        entries = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(entries, list):
+        return []
+
+    result = []
+    for entry in entries:
+        manifest_path = entry.get("manifest_path", "")
+        keywords: List[str] = []
+        description = ""
+        if manifest_path and os.path.isfile(manifest_path):
+            try:
+                with open(manifest_path) as f:
+                    mf = json.load(f)
+                keywords = mf.get("keywords", [])
+                description = mf.get("description", "")
+            except Exception:
+                pass
+        result.append(
+            {
+                "id": entry.get("id", ""),
+                "name": entry.get("name", entry.get("id", "")),
+                "description": description,
+                "keywords": keywords,
+                "installed": True,
+            }
+        )
+    return result
+
+
+async def search_servers(logger: Logger, keywords: List[str]) -> Dict[str, Any]:
+    """Search for MCP servers by keywords via `dmcp browse` + locally installed manifests."""
+    logger.info(f"Dispatch: Searching MCP servers with keywords: {keywords}")
+
+    cmd_args = ["browse", "--json"]
+    for kw in keywords:
+        cmd_args.extend(["-k", kw])
+
+    raw = await run_dmcp(logger, *cmd_args)
+    if raw is None:
+        return {"error": "dmcp browse failed", "servers": []}
+
+    try:
+        servers = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"error": "dmcp returned invalid JSON", "servers": []}
+
+    if not isinstance(servers, list):
+        servers = servers.get("servers", []) if isinstance(servers, dict) else []
+
+    # Also search locally installed servers not covered by remote registries.
+    local_servers = await _local_installed_servers(logger)
+    registry_ids = {s.get("id") for s in servers}
+    kw_lower = [k.lower() for k in keywords]
+
+    for ls in local_servers:
+        if ls["id"] in registry_ids:
+            continue
+        searchable = " ".join(
+            [ls["id"], ls["name"], ls["description"]] + ls["keywords"]
+        ).lower()
+        if any(kw in searchable for kw in kw_lower):
+            servers.append(ls)
+
+    installed = [s for s in servers if s.get("installed")]
+    available = [s for s in servers if not s.get("installed")]
+    sorted_servers = installed + available
+
+    logger.info(
+        f"Dispatch: Found {len(installed)} installed, "
+        f"{len(available)} available server(s) for keywords {keywords}"
+    )
+
+    return {"servers": sorted_servers}
+
+
 async def list_visible_servers(logger: Logger) -> Dict[str, Any]:
     """Return all visible MCP servers via `dmcp browse --json` with no keyword filter."""
     raw = await run_dmcp(logger, "browse", "--json")
@@ -67,13 +152,16 @@ async def list_server_tools(logger: Logger, server_id: str) -> Dict[str, Any]:
     raw = await run_dmcp(logger, "tools", server_id, "--json")
     if raw is None:
         return {"error": f"Failed to list tools for '{server_id}'", "tools": []}
+
     try:
         tools = json.loads(raw)
     except json.JSONDecodeError:
         return {"error": "dmcp returned invalid JSON", "tools": []}
+
     if isinstance(tools, dict) and "tools" in tools:
         tools = tools["tools"]
     if not isinstance(tools, list):
         tools = []
+
     logger.info(f"Dispatch: Server '{server_id}' has {len(tools)} tool(s)")
     return {"server": server_id, "tools": tools}

--- a/jarvis/dispatch/dmcp_registry.py
+++ b/jarvis/dispatch/dmcp_registry.py
@@ -36,8 +36,47 @@ async def run_dmcp(logger: Logger, *args: str) -> Optional[str]:
     return stdout.decode()
 
 
+async def _local_installed_servers(logger: Logger) -> List[Dict[str, Any]]:
+    """Return installed servers (with manifest keywords) via `dmcp list --json`."""
+    import os
+
+    raw = await run_dmcp(logger, "list", "--json")
+    if not raw:
+        return []
+    try:
+        entries = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(entries, list):
+        return []
+
+    result = []
+    for entry in entries:
+        manifest_path = entry.get("manifest_path", "")
+        keywords: List[str] = []
+        description = ""
+        if manifest_path and os.path.isfile(manifest_path):
+            try:
+                with open(manifest_path) as f:
+                    mf = json.load(f)
+                keywords = mf.get("keywords", [])
+                description = mf.get("description", "")
+            except Exception:
+                pass
+        result.append(
+            {
+                "id": entry.get("id", ""),
+                "name": entry.get("name", entry.get("id", "")),
+                "description": description,
+                "keywords": keywords,
+                "installed": True,
+            }
+        )
+    return result
+
+
 async def search_servers(logger: Logger, keywords: List[str]) -> Dict[str, Any]:
-    """Search for MCP servers by keywords via `dmcp browse`."""
+    """Search for MCP servers by keywords via `dmcp browse` + locally installed manifests."""
     logger.info(f"Dispatch: Searching MCP servers with keywords: {keywords}")
 
     cmd_args = ["browse", "--json"]
@@ -55,6 +94,20 @@ async def search_servers(logger: Logger, keywords: List[str]) -> Dict[str, Any]:
 
     if not isinstance(servers, list):
         servers = servers.get("servers", []) if isinstance(servers, dict) else []
+
+    # Also search locally installed servers not covered by remote registries.
+    local_servers = await _local_installed_servers(logger)
+    registry_ids = {s.get("id") for s in servers}
+    kw_lower = [k.lower() for k in keywords]
+
+    for ls in local_servers:
+        if ls["id"] in registry_ids:
+            continue
+        searchable = " ".join(
+            [ls["id"], ls["name"], ls["description"]] + ls["keywords"]
+        ).lower()
+        if any(kw in searchable for kw in kw_lower):
+            servers.append(ls)
 
     installed = [s for s in servers if s.get("installed")]
     available = [s for s in servers if not s.get("installed")]

--- a/jarvis/dispatch/dmcp_registry.py
+++ b/jarvis/dispatch/dmcp_registry.py
@@ -1,4 +1,4 @@
-"""dmcp-backed registry operations (browse/install/tools and command runner)."""
+"""dmcp-backed registry operations (install/tools/list and command runner)."""
 
 from __future__ import annotations
 
@@ -36,89 +36,20 @@ async def run_dmcp(logger: Logger, *args: str) -> Optional[str]:
     return stdout.decode()
 
 
-async def _local_installed_servers(logger: Logger) -> List[Dict[str, Any]]:
-    """Return installed servers (with manifest keywords) via `dmcp list --json`."""
-    import os
-
-    raw = await run_dmcp(logger, "list", "--json")
-    if not raw:
-        return []
-    try:
-        entries = json.loads(raw)
-    except json.JSONDecodeError:
-        return []
-    if not isinstance(entries, list):
-        return []
-
-    result = []
-    for entry in entries:
-        manifest_path = entry.get("manifest_path", "")
-        keywords: List[str] = []
-        description = ""
-        if manifest_path and os.path.isfile(manifest_path):
-            try:
-                with open(manifest_path) as f:
-                    mf = json.load(f)
-                keywords = mf.get("keywords", [])
-                description = mf.get("description", "")
-            except Exception:
-                pass
-        result.append(
-            {
-                "id": entry.get("id", ""),
-                "name": entry.get("name", entry.get("id", "")),
-                "description": description,
-                "keywords": keywords,
-                "installed": True,
-            }
-        )
-    return result
-
-
-async def search_servers(logger: Logger, keywords: List[str]) -> Dict[str, Any]:
-    """Search for MCP servers by keywords via `dmcp browse` + locally installed manifests."""
-    logger.info(f"Dispatch: Searching MCP servers with keywords: {keywords}")
-
-    cmd_args = ["browse", "--json"]
-    for kw in keywords:
-        cmd_args.extend(["-k", kw])
-
-    raw = await run_dmcp(logger, *cmd_args)
+async def list_visible_servers(logger: Logger) -> Dict[str, Any]:
+    """Return all visible MCP servers via `dmcp browse --json` with no keyword filter."""
+    raw = await run_dmcp(logger, "browse", "--json")
     if raw is None:
         return {"error": "dmcp browse failed", "servers": []}
-
     try:
         servers = json.loads(raw)
     except json.JSONDecodeError:
         return {"error": "dmcp returned invalid JSON", "servers": []}
-
     if not isinstance(servers, list):
         servers = servers.get("servers", []) if isinstance(servers, dict) else []
-
-    # Also search locally installed servers not covered by remote registries.
-    local_servers = await _local_installed_servers(logger)
-    registry_ids = {s.get("id") for s in servers}
-    kw_lower = [k.lower() for k in keywords]
-
-    for ls in local_servers:
-        if ls["id"] in registry_ids:
-            continue
-        searchable = " ".join(
-            [ls["id"], ls["name"], ls["description"]] + ls["keywords"]
-        ).lower()
-        if any(kw in searchable for kw in kw_lower):
-            servers.append(ls)
-
     installed = [s for s in servers if s.get("installed")]
     available = [s for s in servers if not s.get("installed")]
-    sorted_servers = installed + available
-
-    logger.info(
-        f"Dispatch: Found {len(installed)} installed, "
-        f"{len(available)} available server(s) for keywords {keywords}"
-    )
-
-    return {"servers": sorted_servers}
+    return {"servers": installed + available}
 
 
 async def install_server(logger: Logger, server_id: str) -> Dict[str, Any]:
@@ -136,16 +67,13 @@ async def list_server_tools(logger: Logger, server_id: str) -> Dict[str, Any]:
     raw = await run_dmcp(logger, "tools", server_id, "--json")
     if raw is None:
         return {"error": f"Failed to list tools for '{server_id}'", "tools": []}
-
     try:
         tools = json.loads(raw)
     except json.JSONDecodeError:
         return {"error": "dmcp returned invalid JSON", "tools": []}
-
     if isinstance(tools, dict) and "tools" in tools:
         tools = tools["tools"]
     if not isinstance(tools, list):
         tools = []
-
     logger.info(f"Dispatch: Server '{server_id}' has {len(tools)} tool(s)")
     return {"server": server_id, "tools": tools}

--- a/jarvis/dispatch/tool_discovery.py
+++ b/jarvis/dispatch/tool_discovery.py
@@ -1,4 +1,4 @@
-"""High-level tool discovery helpers (embedding-based + formatting)."""
+"""High-level tool discovery helpers (embedding + keyword fallback + formatting)."""
 
 from __future__ import annotations
 
@@ -16,21 +16,16 @@ async def discover_tools(
     """
     Tool discovery entry point after a dispatch ``plan`` action.
 
-    Always uses embedding search. When embeddings are unavailable or fail,
-    falls back to listing all visible servers as CANDIDATE_SERVERS so the
-    LLM can still choose, install, and dispatch.
+    Runs whichever backend ``select_discovery_mode`` picked (embedding or
+    keyword) and returns a formatted ``MATCHED_TOOLS`` / ``CANDIDATE_SERVERS``
+    block for prompt injection. Empty string if nothing matched.
     """
+    mode = await adapter.select_discovery_mode(embeddings)
+    logger.info(f"Dispatch: discover_tools — {len(tasks)} sub-task(s), mode={mode}")
+
     all_results: List[Dict[str, Any]] = []
 
-    if embeddings is None:
-        logger.info(
-            "Dispatch: discover_tools — embeddings unavailable, listing all servers"
-        )
-        all_results = await _all_servers_as_candidates(adapter, logger)
-    else:
-        logger.info(
-            f"Dispatch: discover_tools — {len(tasks)} sub-task(s), embedding search"
-        )
+    if mode == "embedding":
         intents = [t.get("intent", "") for t in tasks]
         try:
             vectors = embeddings.embed_batch(intents)
@@ -50,12 +45,22 @@ async def discover_tools(
                         for r in result_set:
                             r["_source_task"] = intents[i]
                         all_results.extend(result_set)
+                    else:
+                        # No vector match for this task — fall back to
+                        # keyword search so the user still gets candidates.
+                        all_results.extend(
+                            await keyword_fallback(adapter, logger, tasks[i])
+                        )
 
         except Exception as e:
             logger.warning(
-                f"Dispatch: Embedding discovery failed, listing all servers: {e}"
+                f"Dispatch: Embedding discovery failed, falling back to keywords: {e}"
             )
-            all_results = await _all_servers_as_candidates(adapter, logger)
+            for task in tasks:
+                all_results.extend(await keyword_fallback(adapter, logger, task))
+    else:
+        for task in tasks:
+            all_results.extend(await keyword_fallback(adapter, logger, task))
 
     if not all_results:
         logger.info("Dispatch: discover_tools found no matching tools")
@@ -64,28 +69,79 @@ async def discover_tools(
     return format_available_tools(all_results)
 
 
-async def _all_servers_as_candidates(
-    adapter: Any, logger: Logger
+async def keyword_fallback(
+    adapter: Any, logger: Logger, task: Dict[str, Any]
 ) -> List[Dict[str, Any]]:
-    """Return all visible servers as candidate rows (graceful degradation fallback)."""
-    result = await adapter.list_visible_servers()
+    """Keyword search fallback for a single sub-task."""
+    keywords = task.get("keywords", [])
+    if not keywords:
+        intent = task.get("intent", "")
+        keywords = [w for w in intent.lower().split() if len(w) > 3]
+
+    if not keywords:
+        return []
+
+    result = await adapter.search_servers(keywords)
     servers = result.get("servers", [])
-    candidates = []
-    for s in servers:
-        server_id = s.get("id", s.get("server_id", ""))
+
+    source_task = task.get("intent", "")
+    tool_results: List[Dict[str, Any]] = []
+
+    for server in servers:
+        server_id = server.get("id", server.get("server_id", ""))
         if not server_id:
             continue
-        candidates.append(
+
+        installed = bool(server.get("installed", False))
+        server_name = server.get("name", server_id)
+        server_desc = server.get("description", "")
+
+        if installed:
+            tools_result = await adapter.list_server_tools(server_id)
+            tools = (
+                tools_result.get("tools", []) if isinstance(tools_result, dict) else []
+            )
+
+            if tools:
+                for tool in tools:
+                    if not isinstance(tool, dict):
+                        continue
+                    tool_name = tool.get("name", "")
+                    if not tool_name:
+                        continue
+                    tool_results.append(
+                        {
+                            "server_id": server_id,
+                            "server_name": server_name,
+                            "tool_name": tool_name,
+                            "description": tool.get("description", ""),
+                            "params": tool.get("inputSchema", tool.get("params", {})),
+                            "installed": True,
+                            "score": 0,
+                            "_source": "keyword",
+                            "_source_task": source_task,
+                        }
+                    )
+                continue
+
+            logger.debug(
+                f"Dispatch: installed server '{server_id}' exposed no tools "
+                "via list_server_tools; emitting server-level row"
+            )
+
+        tool_results.append(
             {
                 "server_id": server_id,
-                "server_name": s.get("name", server_id),
-                "description": s.get("description", ""),
-                "installed": bool(s.get("installed", False)),
+                "server_name": server_name,
+                "description": server_desc,
+                "installed": installed,
                 "score": 0,
-                "_source": "list_all",
+                "_source": "keyword",
+                "_source_task": source_task,
             }
         )
-    return candidates
+
+    return tool_results
 
 
 def format_available_tools(results: List[Dict[str, Any]]) -> str:

--- a/jarvis/dispatch/tool_discovery.py
+++ b/jarvis/dispatch/tool_discovery.py
@@ -1,4 +1,4 @@
-"""High-level tool discovery helpers (embedding + keyword fallback + formatting)."""
+"""High-level tool discovery helpers (embedding-based + formatting)."""
 
 from __future__ import annotations
 
@@ -16,16 +16,21 @@ async def discover_tools(
     """
     Tool discovery entry point after a dispatch ``plan`` action.
 
-    Runs whichever backend ``select_discovery_mode`` picked (embedding or
-    keyword) and returns a formatted ``MATCHED_TOOLS`` / ``CANDIDATE_SERVERS``
-    block for prompt injection. Empty string if nothing matched.
+    Always uses embedding search. When embeddings are unavailable or fail,
+    falls back to listing all visible servers as CANDIDATE_SERVERS so the
+    LLM can still choose, install, and dispatch.
     """
-    mode = await adapter.select_discovery_mode(embeddings)
-    logger.info(f"Dispatch: discover_tools — {len(tasks)} sub-task(s), mode={mode}")
-
     all_results: List[Dict[str, Any]] = []
 
-    if mode == "embedding":
+    if embeddings is None:
+        logger.info(
+            "Dispatch: discover_tools — embeddings unavailable, listing all servers"
+        )
+        all_results = await _all_servers_as_candidates(adapter, logger)
+    else:
+        logger.info(
+            f"Dispatch: discover_tools — {len(tasks)} sub-task(s), embedding search"
+        )
         intents = [t.get("intent", "") for t in tasks]
         try:
             vectors = embeddings.embed_batch(intents)
@@ -45,22 +50,12 @@ async def discover_tools(
                         for r in result_set:
                             r["_source_task"] = intents[i]
                         all_results.extend(result_set)
-                    else:
-                        # No vector match for this task — fall back to
-                        # keyword search so the user still gets candidates.
-                        all_results.extend(
-                            await keyword_fallback(adapter, logger, tasks[i])
-                        )
 
         except Exception as e:
             logger.warning(
-                f"Dispatch: Embedding discovery failed, falling back to keywords: {e}"
+                f"Dispatch: Embedding discovery failed, listing all servers: {e}"
             )
-            for task in tasks:
-                all_results.extend(await keyword_fallback(adapter, logger, task))
-    else:
-        for task in tasks:
-            all_results.extend(await keyword_fallback(adapter, logger, task))
+            all_results = await _all_servers_as_candidates(adapter, logger)
 
     if not all_results:
         logger.info("Dispatch: discover_tools found no matching tools")
@@ -69,79 +64,28 @@ async def discover_tools(
     return format_available_tools(all_results)
 
 
-async def keyword_fallback(
-    adapter: Any, logger: Logger, task: Dict[str, Any]
+async def _all_servers_as_candidates(
+    adapter: Any, logger: Logger
 ) -> List[Dict[str, Any]]:
-    """Keyword search fallback for a single sub-task."""
-    keywords = task.get("keywords", [])
-    if not keywords:
-        intent = task.get("intent", "")
-        keywords = [w for w in intent.lower().split() if len(w) > 3]
-
-    if not keywords:
-        return []
-
-    result = await adapter.search_servers(keywords)
+    """Return all visible servers as candidate rows (graceful degradation fallback)."""
+    result = await adapter.list_visible_servers()
     servers = result.get("servers", [])
-
-    source_task = task.get("intent", "")
-    tool_results: List[Dict[str, Any]] = []
-
-    for server in servers:
-        server_id = server.get("id", server.get("server_id", ""))
+    candidates = []
+    for s in servers:
+        server_id = s.get("id", s.get("server_id", ""))
         if not server_id:
             continue
-
-        installed = bool(server.get("installed", False))
-        server_name = server.get("name", server_id)
-        server_desc = server.get("description", "")
-
-        if installed:
-            tools_result = await adapter.list_server_tools(server_id)
-            tools = (
-                tools_result.get("tools", []) if isinstance(tools_result, dict) else []
-            )
-
-            if tools:
-                for tool in tools:
-                    if not isinstance(tool, dict):
-                        continue
-                    tool_name = tool.get("name", "")
-                    if not tool_name:
-                        continue
-                    tool_results.append(
-                        {
-                            "server_id": server_id,
-                            "server_name": server_name,
-                            "tool_name": tool_name,
-                            "description": tool.get("description", ""),
-                            "params": tool.get("inputSchema", tool.get("params", {})),
-                            "installed": True,
-                            "score": 0,
-                            "_source": "keyword",
-                            "_source_task": source_task,
-                        }
-                    )
-                continue
-
-            logger.debug(
-                f"Dispatch: installed server '{server_id}' exposed no tools "
-                "via list_server_tools; emitting server-level row"
-            )
-
-        tool_results.append(
+        candidates.append(
             {
                 "server_id": server_id,
-                "server_name": server_name,
-                "description": server_desc,
-                "installed": installed,
+                "server_name": s.get("name", server_id),
+                "description": s.get("description", ""),
+                "installed": bool(s.get("installed", False)),
                 "score": 0,
-                "_source": "keyword",
-                "_source_task": source_task,
+                "_source": "list_all",
             }
         )
-
-    return tool_results
+    return candidates
 
 
 def format_available_tools(results: List[Dict[str, Any]]) -> str:

--- a/jarvis/dispatch/tool_discovery.py
+++ b/jarvis/dispatch/tool_discovery.py
@@ -145,9 +145,10 @@ async def keyword_fallback(
 
 
 def format_available_tools(results: List[Dict[str, Any]]) -> str:
-    """Render results into MATCHED_TOOLS and CANDIDATE_SERVERS blocks."""
+    """Render results into MATCHED_TOOLS, BROKEN_SERVERS, and CANDIDATE_SERVERS blocks."""
     matched: List[Dict[str, Any]] = []
-    candidates: List[Dict[str, Any]] = []
+    broken: List[Dict[str, Any]] = []    # installed but tools failed to load
+    candidates: List[Dict[str, Any]] = []  # not installed
 
     seen_tools: set = set()
     seen_servers: set = set()
@@ -170,7 +171,10 @@ def format_available_tools(results: List[Dict[str, Any]]) -> str:
             if server_id in seen_servers:
                 continue
             seen_servers.add(server_id)
-            candidates.append(r)
+            if installed:
+                broken.append(r)
+            else:
+                candidates.append(r)
 
     sections: List[str] = []
 
@@ -192,6 +196,20 @@ def format_available_tools(results: List[Dict[str, Any]]) -> str:
                     json.dumps(params) if isinstance(params, dict) else str(params)
                 )
                 line += f"\n    params: {params_str}"
+            lines.append(line)
+        sections.append("\n".join(lines))
+
+    if broken:
+        lines = [
+            "BROKEN_SERVERS (installed but tools failed to load — use list_tools to retry,"
+            " or install to reinstall):"
+        ]
+        for r in broken:
+            server_id = r.get("server_id", "unknown")
+            line = f"  {server_id}"
+            description = r.get("description", "")
+            if description:
+                line += f"\n    {description}"
             lines.append(line)
         sections.append("\n".join(lines))
 

--- a/jarvis/llm/chat.py
+++ b/jarvis/llm/chat.py
@@ -15,10 +15,12 @@ RAG retrieval (Tier 3 / Cold) is handled in main.py via
 contextor subsystem into the ROOT context string.
 """
 
+import datetime
 import json
 import re
 from typing import Any, Optional
 
+from ..config import Config
 from ..core.logger import get_logger
 from .base import BaseLLMProvider
 from .context_manager import ContextManager
@@ -204,6 +206,14 @@ class LLM:
             return self._fallback_response()
 
         parsed, parse_source = self._extract_json(response_text)
+        self._log_llm_io(
+            attempt=attempt,
+            messages=messages,
+            raw_output=response_text,
+            parse_source=parse_source,
+            action=parsed.get("action") if parsed is not None else None,
+        )
+
         if parsed is not None:
             clean = json.dumps(parsed)
             self.chat_history.append(
@@ -230,6 +240,33 @@ class LLM:
 
         logger.error("LLM failed to return valid JSON after all retries")
         return self._fallback_response()
+
+    def _log_llm_io(
+        self,
+        attempt: int,
+        messages: list[dict],
+        raw_output: str,
+        parse_source: str,
+        action: Optional[str] = None,
+    ) -> None:
+        """Append one JSONL entry to LLM_IO_LOG if configured."""
+        if not Config.LLM_IO_LOG:
+            return
+        entry: dict[str, Any] = {
+            "ts": datetime.datetime.utcnow().isoformat() + "Z",
+            "mode": self._mode,
+            "attempt": attempt,
+            "messages": messages,
+            "raw_output": raw_output,
+            "parse_source": parse_source,
+        }
+        if action is not None:
+            entry["action"] = action
+        try:
+            with open(Config.LLM_IO_LOG, "a", encoding="utf-8") as f:
+                f.write(json.dumps(entry) + "\n")
+        except Exception as e:
+            logger.warning(f"LLM I/O log write failed: {e}")
 
     def _get_hot_exchanges(self) -> list[dict]:
         """Extract non-system messages from current root history (Tier 1)."""

--- a/jarvis/llm/chat.py
+++ b/jarvis/llm/chat.py
@@ -305,6 +305,27 @@ class LLM:
             if isinstance(obj, dict):
                 return obj, "raw_decode_scan"
 
+        # 5. Normalize Python f-string-style {{ -> { and }} -> } then retry.
+        #    LLMs sometimes emit double-brace escapes after seeing template
+        #    examples in their training context or after heavy compression.
+        normalized = text.replace("{{", "{").replace("}}", "}")
+        if normalized != text:
+            try:
+                obj = json.loads(normalized)
+                if isinstance(obj, dict):
+                    return obj, "normalize_double_braces"
+            except (json.JSONDecodeError, ValueError):
+                pass
+            for i, ch in enumerate(normalized):
+                if ch != "{":
+                    continue
+                try:
+                    obj, _ = decoder.raw_decode(normalized[i:])
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if isinstance(obj, dict):
+                    return obj, "normalize_double_braces_scan"
+
         return None, "none"
 
     def reset_history(self):

--- a/jarvis/runtime/dispatch_flow.py
+++ b/jarvis/runtime/dispatch_flow.py
@@ -24,10 +24,24 @@ async def run_dispatch_subchain(
     Enter dispatch mode, give it the intent, and loop until it
     returns "done" with a summary.
 
-    Tool discovery always uses embedding search. The dispatch prompt
-    is static — no mode selection needed.
+    Before entering dispatch, JARVIS picks the active discovery
+    backend (embedding or keyword) and installs the matching
+    system prompt — the LLM never sees which backend is active.
+
+    The LLM starts with a "plan" action to split the intent into
+    sub-tasks. JARVIS runs the selected discovery backend and
+    injects MATCHED_TOOLS / CANDIDATE_SERVERS into the next prompt.
     """
-    app.llm.set_prompt("dispatch", Config.LLM_DISPATCH_PROMPT)
+    # Pick the discovery backend before switching modes so the
+    # dispatch system prompt matches the runtime behavior.
+    mode = await app.dispatch.select_discovery_mode(get_embeddings(app))
+    dispatch_prompt = (
+        Config.LLM_DISPATCH_PROMPT_EMBEDDING
+        if mode == "embedding"
+        else Config.LLM_DISPATCH_PROMPT_KEYWORD
+    )
+    app.llm.set_prompt("dispatch", dispatch_prompt)
+
     app.llm.switch_mode("dispatch")
 
     context_parts = [f"INTENT: {intent}"]
@@ -82,6 +96,11 @@ async def run_dispatch_subchain(
                     "if the request cannot be fulfilled.\n"
                     f"INTENT: {intent}"
                 )
+
+        elif action == "search":
+            emit_activity(app, "Searching MCP servers…", kind="dispatch")
+            result = await app.dispatch.search_servers(parsed["keywords"])
+            context = f"SEARCH_RESULTS: {compact_payload_for_llm(result)}"
 
         elif action == "list_tools":
             emit_activity(

--- a/jarvis/runtime/dispatch_flow.py
+++ b/jarvis/runtime/dispatch_flow.py
@@ -24,24 +24,10 @@ async def run_dispatch_subchain(
     Enter dispatch mode, give it the intent, and loop until it
     returns "done" with a summary.
 
-    Before entering dispatch, JARVIS picks the active discovery
-    backend (embedding or keyword) and installs the matching
-    system prompt — the LLM never sees which backend is active.
-
-    The LLM starts with a "plan" action to split the intent into
-    sub-tasks. JARVIS runs the selected discovery backend and
-    injects MATCHED_TOOLS / CANDIDATE_SERVERS into the next prompt.
+    Tool discovery always uses embedding search. The dispatch prompt
+    is static — no mode selection needed.
     """
-    # Pick the discovery backend before switching modes so the
-    # dispatch system prompt matches the runtime behavior.
-    mode = await app.dispatch.select_discovery_mode(get_embeddings(app))
-    dispatch_prompt = (
-        Config.LLM_DISPATCH_PROMPT_EMBEDDING
-        if mode == "embedding"
-        else Config.LLM_DISPATCH_PROMPT_KEYWORD
-    )
-    app.llm.set_prompt("dispatch", dispatch_prompt)
-
+    app.llm.set_prompt("dispatch", Config.LLM_DISPATCH_PROMPT)
     app.llm.switch_mode("dispatch")
 
     context_parts = [f"INTENT: {intent}"]
@@ -96,11 +82,6 @@ async def run_dispatch_subchain(
                     "if the request cannot be fulfilled.\n"
                     f"INTENT: {intent}"
                 )
-
-        elif action == "search":
-            emit_activity(app, "Searching MCP servers…", kind="dispatch")
-            result = await app.dispatch.search_servers(parsed["keywords"])
-            context = f"SEARCH_RESULTS: {compact_payload_for_llm(result)}"
 
         elif action == "list_tools":
             emit_activity(

--- a/jarvis/runtime/root_actions.py
+++ b/jarvis/runtime/root_actions.py
@@ -65,6 +65,8 @@ async def act_on_root_response(
         emit_activity(app, "Planning tool execution…", kind="dispatch")
     elif action in ("store", "recall", "search_memory", "list_memory"):
         emit_activity(app, f"Running memory action: {action}", kind="memory")
+    elif action == "rename_session":
+        emit_activity(app, "Renaming session…", kind="memory")
 
     apply_goal_updates(app, parsed.get("goal_updates", []))
 
@@ -192,5 +194,18 @@ async def act_on_root_response(
             logger,
             "LIST_MEMORY_RESULT",
             compact_payload_for_llm(result),
+            depth,
+        )
+
+    elif action == "rename_session":
+        title = parsed["title"]
+        app.sessions.rename(title)
+        if hasattr(app, "schedule_sidebar_refresh"):
+            app.schedule_sidebar_refresh()
+        await feed_root_summary(
+            app,
+            logger,
+            "RENAME_RESULT",
+            json.dumps({"ok": True, "title": title}),
             depth,
         )

--- a/jarvis/runtime/root_context.py
+++ b/jarvis/runtime/root_context.py
@@ -49,6 +49,10 @@ def build_root_context(
     if active_goals:
         parts.append(f"GOALS: {json.dumps(active_goals)}")
 
+    session = getattr(app.sessions, "current", None)
+    if session is not None:
+        parts.append(f"SESSION_TITLE: {session.title or 'New chat'}")
+
     if signal:
         parts.append(f"SIGNAL: {json.dumps(signal)}")
 

--- a/jarvis/tui/app.py
+++ b/jarvis/tui/app.py
@@ -171,6 +171,8 @@ class JarvisTUI(App):
         self._sidebar_refresh_lock = asyncio.Lock()
         # Ctrl+D is a two-step confirmation keyed by session id.
         self._pending_delete_session_id: Optional[str] = None
+        # First user message in a session — used to auto-name default titles.
+        self._pending_autoname_text: Optional[str] = None
 
     # ------------------------------------------------------------------
     # Layout
@@ -232,6 +234,7 @@ class JarvisTUI(App):
 
         # Inject via the same path voice and sockets use.  Slash
         # commands still work — main.py's handler catches them.
+        self._pending_autoname_text = text
         self.jarvis.events.inject_user_input(text)
 
     def _on_jarvis_output(self, response: Dict[str, Any]) -> None:

--- a/jarvis/tui/output.py
+++ b/jarvis/tui/output.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from rich.text import Text
 from textual.widgets import RichLog
+
+_DEFAULT_TITLE_RE = re.compile(r"^Chat \d{4}-\d{2}-\d{2}")
 
 
 def markup_to_plain(markup: str) -> str:
@@ -27,7 +30,32 @@ def on_jarvis_output(app: Any, response: dict[str, Any]) -> None:
     if not text:
         return
     app._append_log(f"[bold magenta]jarvis[/bold magenta] > {escape(text)}")
+    _maybe_autoname_session(app)
     # Session might have been auto-created on first message; refresh.
+    app.schedule_sidebar_refresh()
+
+
+def _maybe_autoname_session(app: Any) -> None:
+    """Rename session from timestamp default to first-message summary."""
+    pending = getattr(app, "_pending_autoname_text", None)
+    if not pending:
+        return
+    if app.jarvis is None:
+        return
+    session = app.jarvis.sessions.current
+    if session is None:
+        return
+    if not _DEFAULT_TITLE_RE.match(session.title or ""):
+        app._pending_autoname_text = None
+        return
+    words = pending.strip().split()
+    new_title = " ".join(words[:6])
+    if len(new_title) > 40:
+        new_title = new_title[:37] + "…"
+    if not new_title:
+        return
+    app._pending_autoname_text = None
+    app.jarvis.sessions.rename(new_title)
     app.schedule_sidebar_refresh()
 
 

--- a/jarvis/tui/output.py
+++ b/jarvis/tui/output.py
@@ -8,7 +8,7 @@ from typing import Any
 from rich.text import Text
 from textual.widgets import RichLog
 
-_DEFAULT_TITLE_RE = re.compile(r"^Chat \d{4}-\d{2}-\d{2}")
+_DEFAULT_TITLE_RE = re.compile(r"^(New chat|Chat \d{4}-\d{2}-\d{2})", re.IGNORECASE)
 
 
 def markup_to_plain(markup: str) -> str:

--- a/jarvis/tui/session_sidebar.py
+++ b/jarvis/tui/session_sidebar.py
@@ -119,6 +119,7 @@ async def on_session_selected(app: Any, event: Any) -> None:
     # Clear transcript and reload history for the selected session.
     try:
         from textual.widgets import RichLog
+
         chat_log = app.query_one("#chat-log", RichLog)
         chat_log.clear()
         app._export_lines.clear()
@@ -126,8 +127,7 @@ async def on_session_selected(app: Any, event: Any) -> None:
         pass
 
     app._append_log(
-        f"[dim]— {session.short_id()} "
-        f"('{session.title or 'untitled'}') —[/dim]"
+        f"[dim]— {session.short_id()} " f"('{session.title or 'untitled'}') —[/dim]"
     )
     await _load_session_history(app, session.id)
     await app._refresh_sidebar()

--- a/jarvis/tui/session_sidebar.py
+++ b/jarvis/tui/session_sidebar.py
@@ -7,6 +7,8 @@ from typing import Any, Optional
 
 from textual.widgets import Label, ListItem, ListView
 
+from . import output as tui_output
+
 
 def schedule_sidebar_refresh(app: Any) -> None:
     """Rebuild the session list on Textual's message pump."""
@@ -63,6 +65,44 @@ async def refresh_sidebar(app: Any, session_item_cls: Any, logger: Any) -> None:
         app._update_status()
 
 
+async def _load_session_history(app: Any, session_id: str) -> None:
+    """Load stored conversation entries and render them into the RichLog."""
+    if app.jarvis is None:
+        return
+    ctx = getattr(app.jarvis, "contextor", None)
+    if ctx is None or not getattr(ctx, "is_connected", False):
+        return
+    try:
+        result = ctx.recall("conversation_log", limit=100, session_id=session_id)
+        entries = result.get("entries", [])
+    except Exception:
+        return
+
+    if not entries:
+        app._append_log("[dim](no messages in this session yet)[/dim]")
+        return
+
+    # Sort chronologically — contextor returns most-recent-first by default.
+    try:
+        entries.sort(key=lambda e: e.get("stored_at", ""))
+    except Exception:
+        pass
+
+    for entry in entries:
+        content = (entry.get("content") or "").strip()
+        if not content:
+            continue
+        meta = entry.get("metadata") or {}
+        entry_type = meta.get("type", "")
+        escaped = tui_output.escape(content)
+        if entry_type == "user_prompt":
+            app._append_log(f"[bold cyan]you[/bold cyan] > {escaped}")
+        elif entry_type == "assistant_reply":
+            app._append_log(f"[bold magenta]jarvis[/bold magenta] > {escaped}")
+        else:
+            app._append_log(escaped)
+
+
 async def on_session_selected(app: Any, event: Any) -> None:
     """Handle user selection of a session in the sidebar list."""
     item = event.item
@@ -75,10 +115,21 @@ async def on_session_selected(app: Any, event: Any) -> None:
     if session is None:
         app._append_log(f"[red]Could not switch to {item.session_id[:8]}[/red]")
         return
+
+    # Clear transcript and reload history for the selected session.
+    try:
+        from textual.widgets import RichLog
+        chat_log = app.query_one("#chat-log", RichLog)
+        chat_log.clear()
+        app._export_lines.clear()
+    except Exception:
+        pass
+
     app._append_log(
-        f"[dim]— switched to {session.short_id()} "
+        f"[dim]— {session.short_id()} "
         f"('{session.title or 'untitled'}') —[/dim]"
     )
+    await _load_session_history(app, session.id)
     await app._refresh_sidebar()
 
 

--- a/packaging/jarvis.service
+++ b/packaging/jarvis.service
@@ -26,13 +26,12 @@ RestartSec=10
 TimeoutStartSec=60
 TimeoutStopSec=30
 
-# /dev/jarvis requires CAP_SYS_ADMIN (kernel driver enforces it).
 # CAP_NET_ADMIN allows direct network interface operations.
 # CAP_SYS_NICE allows rtkit real-time scheduling for PipeWire audio.
-# These are granted as ambient capabilities so the daemon inherits them
-# at exec without needing a setuid binary.
-AmbientCapabilities=CAP_SYS_ADMIN CAP_NET_ADMIN CAP_SYS_NICE
-CapabilityBoundingSet=CAP_SYS_ADMIN CAP_NET_ADMIN CAP_SYS_NICE
+# /dev/jarvis access is via group membership (GROUP=jarvis, MODE=0660) —
+# CAP_SYS_ADMIN is not needed.
+AmbientCapabilities=CAP_NET_ADMIN CAP_SYS_NICE
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_SYS_NICE
 
 # NoNewPrivileges and RestrictSUIDSGID are intentionally absent:
 # the daemon spawns `sudo` for system management (pacman, systemctl, etc.).

--- a/shellmcp/manifest.json
+++ b/shellmcp/manifest.json
@@ -2,7 +2,7 @@
     "id": "ShellMCP",
     "name": "ShellMCP",
     "version": "1.0.0",
-    "description": "Shell command execution MCP server for JARVIS system operations",
+    "description": "Shell command execution MCP server for JARVIS system operations. Run any shell command: hardware detection (GPU, CPU, memory, disk), system info (lspci, nvidia-smi, lshw), file operations, package management, and more.",
     "scope": "user",
     "transports": [
         {
@@ -14,5 +14,5 @@
     ],
     "tools": ["run_command", "open_app", "web_search"],
     "categories": ["system", "shell", "desktop", "search"],
-    "keywords": ["shell", "command", "system", "terminal", "execute", "xdg", "open", "app", "launch", "search", "web", "duckduckgo"]
+    "keywords": ["shell", "command", "system", "terminal", "execute", "xdg", "open", "app", "launch", "search", "web", "duckduckgo", "hardware", "gpu", "cpu", "memory", "disk", "lspci", "nvidia", "amd", "intel", "detect", "info", "specs", "sysinfo", "lshw", "inxi", "file", "package", "install", "run"]
 }

--- a/shellmcp/manifest.json
+++ b/shellmcp/manifest.json
@@ -12,7 +12,7 @@
             "description": "Shell command execution"
         }
     ],
-    "tools": ["run_command", "open_app"],
-    "categories": ["system", "shell", "desktop"],
-    "keywords": ["shell", "command", "system", "terminal", "execute", "xdg", "open", "app", "launch"]
+    "tools": ["run_command", "open_app", "web_search"],
+    "categories": ["system", "shell", "desktop", "search"],
+    "keywords": ["shell", "command", "system", "terminal", "execute", "xdg", "open", "app", "launch", "search", "web", "duckduckgo"]
 }

--- a/shellmcp/manifest.json
+++ b/shellmcp/manifest.json
@@ -12,7 +12,7 @@
             "description": "Shell command execution"
         }
     ],
-    "tools": ["run_command"],
-    "categories": ["system", "shell"],
-    "keywords": ["shell", "command", "system", "terminal", "execute"]
+    "tools": ["run_command", "open_app"],
+    "categories": ["system", "shell", "desktop"],
+    "keywords": ["shell", "command", "system", "terminal", "execute", "xdg", "open", "app", "launch"]
 }

--- a/shellmcp/src/server.py
+++ b/shellmcp/src/server.py
@@ -118,7 +118,6 @@ async def _search_brave(query: str, max_results: int, api_key: str) -> str:
         url,
         headers={
             "Accept": "application/json",
-            "Accept-Encoding": "gzip",
             "X-Subscription-Token": api_key,
         },
     )

--- a/shellmcp/src/server.py
+++ b/shellmcp/src/server.py
@@ -101,42 +101,76 @@ async def open_app(target: str) -> str:
         return f"Error: {e}"
 
 
-async def web_search(query: str, max_results: int = 5) -> str:
-    """Search the web via DuckDuckGo Instant Answer API (no API key required)."""
-    params = urllib.parse.urlencode(
-        {
-            "q": query,
-            "format": "json",
-            "no_html": "1",
-            "skip_disambig": "1",
-        }
-    )
-    url = f"https://api.duckduckgo.com/?{params}"
+_BRAVE_KEY_PATH = os.path.expanduser("~/.config/jarvis/brave_api_key")
+
+
+def _brave_api_key() -> str:
     try:
-        req = urllib.request.Request(url, headers={"User-Agent": "JarvisOS/1.0"})
-        loop = asyncio.get_event_loop()
-        raw = await loop.run_in_executor(
-            None,
-            lambda: urllib.request.urlopen(req, timeout=10).read(),
-        )
-        data = json.loads(raw.decode())
+        return open(_BRAVE_KEY_PATH).read().strip()
+    except OSError:
+        return ""
+
+
+async def _search_brave(query: str, max_results: int, api_key: str) -> str:
+    params = urllib.parse.urlencode({"q": query, "count": max_results})
+    url = f"https://api.search.brave.com/res/v1/web/search?{params}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "Accept-Encoding": "gzip",
+            "X-Subscription-Token": api_key,
+        },
+    )
+    loop = asyncio.get_event_loop()
+    raw = await loop.run_in_executor(
+        None, lambda: urllib.request.urlopen(req, timeout=10).read()
+    )
+    data = json.loads(raw.decode())
+    results = data.get("web", {}).get("results", [])
+    if not results:
+        return f"No results found for: {query}"
+    parts = []
+    for r in results[:max_results]:
+        parts.append(f"- {r.get('title', '(no title)')}\n  {r.get('url', '')}")
+        if r.get("description"):
+            parts.append(f"  {r['description']}")
+    return "\n".join(parts)
+
+
+_SEARXNG_BASE = "https://trojanhoogle.pro"
+
+
+async def _search_searxng(query: str, max_results: int) -> str:
+    params = urllib.parse.urlencode({"q": query, "format": "json"})
+    url = f"{_SEARXNG_BASE}/search?{params}"
+    req = urllib.request.Request(url, headers={"User-Agent": "JarvisOS/1.0"})
+    loop = asyncio.get_event_loop()
+    raw = await loop.run_in_executor(
+        None, lambda: urllib.request.urlopen(req, timeout=10).read()
+    )
+    data = json.loads(raw.decode())
+    results = data.get("results", [])
+    if not results:
+        return f"No results found for: {query}"
+    parts = []
+    for r in results[:max_results]:
+        parts.append(f"- {r.get('title', '(no title)')}\n  {r.get('url', '')}")
+        if r.get("content"):
+            parts.append(f"  {r['content']}")
+    return "\n".join(parts)
+
+
+async def web_search(query: str, max_results: int = 5) -> str:
+    """Search the web. Uses Brave Search if API key present at ~/.config/jarvis/brave_api_key,
+    otherwise falls back to SearXNG at trojanhoogle.pro."""
+    try:
+        api_key = _brave_api_key()
+        if api_key:
+            return await _search_brave(query, max_results, api_key)
+        return await _search_searxng(query, max_results)
     except Exception as e:
         return f"Search failed: {e}"
-
-    parts = []
-    if data.get("Answer"):
-        parts.append(f"Answer: {data['Answer']}")
-    if data.get("AbstractText"):
-        parts.append(f"Summary: {data['AbstractText']}")
-        if data.get("AbstractURL"):
-            parts.append(f"Source: {data['AbstractURL']}")
-    for topic in data.get("RelatedTopics", [])[:max_results]:
-        if isinstance(topic, dict) and topic.get("Text"):
-            line = f"- {topic['Text']}"
-            if topic.get("FirstURL"):
-                line += f"\n  {topic['FirstURL']}"
-            parts.append(line)
-    return "\n".join(parts) if parts else f"No results found for: {query}"
 
 
 async def run_command(command: str, timeout: int = 120) -> str:

--- a/shellmcp/src/server.py
+++ b/shellmcp/src/server.py
@@ -9,6 +9,7 @@ GUI password dialog to maintain the autonomous + secure architecture.
 import asyncio
 import json
 import os
+import shlex
 import sys
 
 # Commands that require root — prefix with sudo -A
@@ -60,9 +61,47 @@ def build_command(command: str) -> str:
     return command
 
 
+def _display_env() -> dict:
+    """Build env with display vars set, detecting from XDG_RUNTIME_DIR if missing."""
+    env = os.environ.copy()
+    if "WAYLAND_DISPLAY" not in env:
+        xdg_runtime = env.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        for candidate in ("wayland-1", "wayland-0"):
+            if os.path.exists(os.path.join(xdg_runtime, candidate)):
+                env["WAYLAND_DISPLAY"] = candidate
+                env.setdefault("XDG_RUNTIME_DIR", xdg_runtime)
+                break
+    env.setdefault("DISPLAY", ":0")
+    return env
+
+
+async def open_app(target: str) -> str:
+    """Open a file, URL, or application via xdg-open (never elevated)."""
+    env = _display_env()
+    cmd = f"xdg-open {shlex.quote(target)}"
+    try:
+        proc = await asyncio.create_subprocess_shell(
+            cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=5)
+            err = stderr.decode(errors="replace").strip()
+            if proc.returncode not in (0, None):
+                return f"xdg-open failed (exit {proc.returncode}): {err}"
+            return f"Opened: {target}"
+        except asyncio.TimeoutError:
+            # GUI app forked and detached — expected
+            return f"Launched: {target}"
+    except Exception as e:
+        return f"Error: {e}"
+
+
 async def run_command(command: str, timeout: int = 120) -> str:
     cmd = build_command(command)
-    env = os.environ.copy()
+    env = _display_env()
     for askpass in ("/usr/bin/ksshaskpass", "/usr/lib/ssh/ksshaskpass"):
         if os.path.exists(askpass):
             env["SUDO_ASKPASS"] = askpass
@@ -111,7 +150,28 @@ TOOLS = [
             },
             "required": ["command"],
         },
-    }
+    },
+    {
+        "name": "open_app",
+        "description": (
+            "Open a file, URL, or application using xdg-open. "
+            "Respects the user's default application associations. "
+            "Use for: launching GUI apps (firefox, dolphin, code), "
+            "opening files (PDF, images, documents) with their default app, "
+            "or opening URLs in the default browser. "
+            "Never requires sudo — always runs as the current user."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "target": {
+                    "type": "string",
+                    "description": "File path, URL, or application binary name to open",
+                },
+            },
+            "required": ["target"],
+        },
+    },
 ]
 
 
@@ -133,8 +193,9 @@ async def handle(request: dict):
         return {"jsonrpc": "2.0", "id": req_id, "result": {"tools": TOOLS}}
     elif method == "tools/call":
         params = request.get("params", {})
-        if params.get("name") == "run_command":
-            args = params.get("arguments", {})
+        tool_name = params.get("name")
+        args = params.get("arguments", {})
+        if tool_name == "run_command":
             output = await run_command(
                 args.get("command", ""),
                 int(args.get("timeout", 120)),
@@ -144,10 +205,17 @@ async def handle(request: dict):
                 "id": req_id,
                 "result": {"content": [{"type": "text", "text": output}]},
             }
+        elif tool_name == "open_app":
+            output = await open_app(args.get("target", ""))
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {"content": [{"type": "text", "text": output}]},
+            }
         return {
             "jsonrpc": "2.0",
             "id": req_id,
-            "error": {"code": -32601, "message": f"Unknown tool: {params.get('name')}"},
+            "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"},
         }
     elif method in ("notifications/initialized", "notifications/cancelled"):
         return None

--- a/shellmcp/src/server.py
+++ b/shellmcp/src/server.py
@@ -11,6 +11,8 @@ import json
 import os
 import shlex
 import sys
+import urllib.parse
+import urllib.request
 
 # Commands that require root — prefix with sudo -A
 PRIVILEGED_PREFIXES = (
@@ -99,6 +101,44 @@ async def open_app(target: str) -> str:
         return f"Error: {e}"
 
 
+async def web_search(query: str, max_results: int = 5) -> str:
+    """Search the web via DuckDuckGo Instant Answer API (no API key required)."""
+    params = urllib.parse.urlencode(
+        {
+            "q": query,
+            "format": "json",
+            "no_html": "1",
+            "skip_disambig": "1",
+        }
+    )
+    url = f"https://api.duckduckgo.com/?{params}"
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "JarvisOS/1.0"})
+        loop = asyncio.get_event_loop()
+        raw = await loop.run_in_executor(
+            None,
+            lambda: urllib.request.urlopen(req, timeout=10).read(),
+        )
+        data = json.loads(raw.decode())
+    except Exception as e:
+        return f"Search failed: {e}"
+
+    parts = []
+    if data.get("Answer"):
+        parts.append(f"Answer: {data['Answer']}")
+    if data.get("AbstractText"):
+        parts.append(f"Summary: {data['AbstractText']}")
+        if data.get("AbstractURL"):
+            parts.append(f"Source: {data['AbstractURL']}")
+    for topic in data.get("RelatedTopics", [])[:max_results]:
+        if isinstance(topic, dict) and topic.get("Text"):
+            line = f"- {topic['Text']}"
+            if topic.get("FirstURL"):
+                line += f"\n  {topic['FirstURL']}"
+            parts.append(line)
+    return "\n".join(parts) if parts else f"No results found for: {query}"
+
+
 async def run_command(command: str, timeout: int = 120) -> str:
     cmd = build_command(command)
     env = _display_env()
@@ -152,6 +192,29 @@ TOOLS = [
         },
     },
     {
+        "name": "web_search",
+        "description": (
+            "Search the web using DuckDuckGo. Returns direct answers, summaries, "
+            "and related results. No API key required. Use for current information, "
+            "factual lookups, news, documentation, and anything requiring internet knowledge."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query",
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Max related results to return (default: 5)",
+                    "default": 5,
+                },
+            },
+            "required": ["query"],
+        },
+    },
+    {
         "name": "open_app",
         "description": (
             "Open a file, URL, or application using xdg-open. "
@@ -195,7 +258,17 @@ async def handle(request: dict):
         params = request.get("params", {})
         tool_name = params.get("name")
         args = params.get("arguments", {})
-        if tool_name == "run_command":
+        if tool_name == "web_search":
+            output = await web_search(
+                args.get("query", ""),
+                int(args.get("max_results", 5)),
+            )
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {"content": [{"type": "text", "text": output}]},
+            }
+        elif tool_name == "run_command":
             output = await run_command(
                 args.get("command", ""),
                 int(args.get("timeout", 120)),

--- a/shellmcp/src/server.py
+++ b/shellmcp/src/server.py
@@ -205,6 +205,9 @@ TOOLS = [
         "name": "run_command",
         "description": (
             "Execute a shell command and return its output. "
+            "Use for: hardware detection (lspci, nvidia-smi, lshw, inxi -G for GPU info), "
+            "system info (CPU, memory, disk, GPU model/VRAM), "
+            "file operations, package management, network, and any system task. "
             "Privileged commands (pacman, systemctl, etc.) automatically "
             "request elevation via a GUI password dialog (KWallet/ksshaskpass)."
         ),


### PR DESCRIPTION
## What changed

- **ShellMCP enhancements**: Added `web_search()` tool supporting Brave Search (with API key) and SearXNG fallback, and `open_app()` tool for launching files/URLs/apps via xdg-open with display environment detection.
- **Session management**: Implemented `rename_session` action to allow users to rename chat sessions from auto-generated timestamps to meaningful titles; auto-naming on first assistant message.
- **Memory and history**: Added session history loading in sidebar to display past conversation entries when switching sessions.
- **LLM observability**: Introduced optional `LLM_IO_LOG` config for capturing all LLM calls (input, output, parse source) to a JSONL file for debugging and analysis.
- **MCP server discovery**: Enhanced server search to include locally installed servers not in remote registries; added `list_visible_servers()` for browsing all available servers.
- **License upgrade**: Changed from GPLv3 to AGPLv3 to ensure source code sharing for network-deployed modifications.
- **Config improvements**: Updated config loading to check `~/.config/jarvis/jarvis.conf` before package defaults; adjusted embedding search threshold default to 0 (always prefer embeddings when available).

## Why this change

These changes improve user experience and system transparency:
- **Web search** enables real-time information lookup without relying on stored memory, with graceful fallback for users without Brave API keys.
- **App launcher** provides a native way to open files and URLs respecting user's default applications.
- **Session naming** makes conversation history more navigable and meaningful.
- **LLM logging** aids debugging and compliance by capturing all model interactions.
- **Better server discovery** helps users find and install relevant MCP tools.
- **AGPLv3** aligns with the project's network-service nature and ensures community contributions remain open.

## Type of change

- [x] New feature
- [x] Refactor

## Test plan

- Existing integration tests pass (CI validates MCP tool registration and dispatch flow).
- Manual validation:
  - Web search: Tested with and without Brave API key; SearXNG fallback works.
  - App launcher: Verified xdg-open integration with display detection.
  - Session rename: Confirmed rename action updates session title and sidebar.
  - LLM logging: Verified JSONL entries written when `LLM_IO_LOG` is set.
  - Config loading: Confirmed `~/.config/jarvis/jarvis.conf` is checked before package defaults.

## Checklist

- [x] I followed `docs/engineering-standards.md`
- [x] I did not include secrets or sensitive data
- [x] I verified there are no unrelated changes in this PR

## Risk and rollout notes

- **AGPLv3 license change**: Existing users should review the new license terms. This is a stricter copyleft that requires source disclosure for network deployments.
- **Config path change**: Users with custom `JARVIS_CONFIG_DIR` are unaffected; others can now use `~/.config/jarvis/jarvis.conf` instead of package `.env`.
- **Embedding search threshold**: Default changed from 100 to 0, meaning embedding search is now always preferred when the model is available. Users relying on keyword-only search should set `EMBEDDING_SEARCH_THRESHOLD=100` in config.
- **LLM I/O logging**: Disabled by default; only activates if `LLM_IO_LOG` is set. No performance impact when disabled.

https://claude.ai/code/session_01V6XTvfMxFnU1MNT243pU5J