### PR TITLE
fix: handle unknown root actions + require absolute paths in dispatch

### DIFF
--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -417,6 +417,10 @@ Return to root with results:
 - If only CANDIDATE_SERVERS is present, install + list_tools first.
 - If nothing matched, try search with different keywords, or done with a failure summary.
 - You can dispatch multiple tasks in one action for parallelism.
+- When running shell or filesystem commands (ls, cat, find, cp, etc.), always use absolute
+  paths. Bare `ls` with no argument runs in the MCP server's install directory, not the
+  user's home folder. Always specify the full path: `ls /home/<username>`,
+  `cat /home/<username>/file.txt`, etc.
 - Output exactly one JSON object — no preamble, no trailing text.
 
 The very first character of your response must be {{ and the very last must be }}.
@@ -502,6 +506,10 @@ Return to root with results:
 - If nothing matched, re-plan with more specific sub-task intents,
   or done with a failure summary.
 - You can dispatch multiple tasks in one action for parallelism.
+- When running shell or filesystem commands (ls, cat, find, cp, etc.), always use absolute
+  paths. Bare `ls` with no argument runs in the MCP server's install directory, not the
+  user's home folder. Always specify the full path: `ls /home/<username>`,
+  `cat /home/<username>/file.txt`, etc.
 - Output exactly one JSON object — no preamble, no trailing text.
 
 The very first character of your response must be {{ and the very last must be }}.

--- a/jarvis/runtime/root_actions.py
+++ b/jarvis/runtime/root_actions.py
@@ -252,3 +252,18 @@ async def act_on_root_response(
             compact_payload_for_llm(result),
             depth,
         )
+
+    else:
+        logger.warning(
+            f"JARVIS: Unknown root action '{action}' — retrying with valid-action prompt"
+        )
+        context = build_root_context(app, logger)
+        context += (
+            f"\nSYSTEM: '{action}' is not a valid action. "
+            "Valid actions: respond, dispatch, store, recall, search_memory, list_memory. "
+            "Output one of those now."
+        )
+        retry_response = await ask_llm(
+            app, logger, context, tag="root-unknown-action"
+        )
+        await app._act_on_root_response(retry_response, depth + 1)


### PR DESCRIPTION
- root_actions: add else clause to act_on_root_response — unknown actions (e.g. rename_session hallucinated from training) now trigger a retry with an explicit list of valid actions instead of silently dropping the user's request
- config: add absolute-path rule to both dispatch prompts — bare `ls` (and other shell commands without a path) run in the MCP server's install directory, not the user's home; LLM must always specify full paths like `ls /home/<username>` or `ls ~`