### PR TITLE
fix: silence rename_session — rename without RENAME_RESULT follow-up

### DIFF
--- a/jarvis/runtime/root_actions.py
+++ b/jarvis/runtime/root_actions.py
@@ -109,8 +109,6 @@ async def act_on_root_response(
         emit_activity(app, "Planning tool execution…", kind="dispatch")
     elif action in ("store", "recall", "search_memory", "list_memory"):
         emit_activity(app, f"Running memory action: {action}", kind="memory")
-    elif action == "rename_session":
-        emit_activity(app, "Renaming session…", kind="memory")
 
     apply_goal_updates(app, parsed.get("goal_updates", []))
 
@@ -256,14 +254,34 @@ async def act_on_root_response(
         )
 
     elif action == "rename_session":
-        title = parsed["title"]
-        app.sessions.rename(title)
-        if hasattr(app, "schedule_sidebar_refresh"):
-            app.schedule_sidebar_refresh()
-        await feed_root_summary(
-            app,
-            logger,
-            "RENAME_RESULT",
-            json.dumps({"ok": True, "title": title}),
-            depth,
+        # Rename silently — never send RENAME_RESULT back. The follow-up
+        # feedback loop causes blank-response cascades on smaller models
+        # because feed_root_summary rebuilds context with no new_input.
+        # Instead, rename and immediately re-ask with updated context
+        # (SESSION_TITLE is now non-"New chat", preventing another rename).
+        title = parsed.get("title", "")
+        if title and app.sessions.current:
+            app.sessions.rename(title)
+            if hasattr(app, "schedule_sidebar_refresh"):
+                app.schedule_sidebar_refresh()
+            logger.info(f"JARVIS: Session silently renamed to '{title}'")
+        context = build_root_context(app, logger)
+        retry_response = await ask_llm(
+            app, logger, context, tag="root-post-rename"
         )
+        await app._act_on_root_response(retry_response, depth + 1)
+
+    else:
+        logger.warning(
+            f"JARVIS: Unknown root action '{action}' — retrying with valid-action prompt"
+        )
+        context = build_root_context(app, logger)
+        context += (
+            f"\nSYSTEM: '{action}' is not a valid action. "
+            "Valid actions: respond, dispatch, store, recall, search_memory, list_memory. "
+            "Output one of those now."
+        )
+        retry_response = await ask_llm(
+            app, logger, context, tag="root-unknown-action"
+        )
+        await app._act_on_root_response(retry_response, depth + 1)


### PR DESCRIPTION
The RENAME_RESULT feedback loop was the root cause: feed_root_summary rebuilt context with no new_input, leaving the LLM with nothing to respond to, causing 4 consecutive blank responses + sentinel fallback on every single first request.

Fix: rename_session now renames silently and immediately re-asks with the updated context (SESSION_TITLE already reflects the new name, so the LLM won't rename again). No RENAME_RESULT is ever sent back.

rename_session is also absent from our root prompts (removed in a prior commit), so fresh LLM calls won't trigger it. This handler covers the case where the model hallucinates it anyway