### PR TITLE
fix: force in-memory title after rename to break rename loop

### DIFF
--- a/jarvis/runtime/root_actions.py
+++ b/jarvis/runtime/root_actions.py
@@ -255,13 +255,16 @@ async def act_on_root_response(
 
     elif action == "rename_session":
         # Rename silently — never send RENAME_RESULT back. The follow-up
-        # feedback loop causes blank-response cascades on smaller models
-        # because feed_root_summary rebuilds context with no new_input.
-        # Instead, rename and immediately re-ask with updated context
-        # (SESSION_TITLE is now non-"New chat", preventing another rename).
+        # feedback loop caused blank-response cascades on smaller models.
+        # After renaming, force the in-memory title so build_root_context
+        # immediately reflects the new name. Without this, update_session
+        # may return a session dict with an empty title (backend timing),
+        # leaving SESSION_TITLE as "New chat" and triggering an infinite
+        # rename loop.
         title = parsed.get("title", "")
         if title and app.sessions.current:
             app.sessions.rename(title)
+            app.sessions.current.title = title
             if hasattr(app, "schedule_sidebar_refresh"):
                 app.schedule_sidebar_refresh()
             logger.info(f"JARVIS: Session silently renamed to '{title}'")


### PR DESCRIPTION
manager.rename() refreshes self._current from update_session's response, but the Rust contextor may return an empty title in that response. When Session.from_dict gets title="" the dataclass stores it as "", and build_root_context renders "" as "New chat" — so the LLM sees the old title and renames again indefinitely.

Fix: after app.sessions.rename(), directly set current.title = title. Session is a plain mutable dataclass so this is safe and immediate.