### PR TITLE
fix: keyword fallback when embedding index is empty (no installed servers)

### DIFF
--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -3,7 +3,7 @@ import os
 
 from dotenv import load_dotenv
 
-# Load config: JARVIS_CONFIG_DIR > ~/.config/jarvis/jarvis.conf > package .env
+# Load config: JARVIS_CONFIG_DIR (system install) or jarvis/.env (dev)
 _config_dir = os.getenv("JARVIS_CONFIG_DIR")
 if _config_dir:
     _env_path = os.path.join(_config_dir, "jarvis.conf")
@@ -12,11 +12,6 @@ if _config_dir:
     else:
         load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 else:
-    _user_conf = os.path.join(
-        os.path.expanduser("~"), ".config", "jarvis", "jarvis.conf"
-    )
-    if os.path.isfile(_user_conf):
-        load_dotenv(_user_conf)
     load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 
 
@@ -103,11 +98,15 @@ class Config:
     CONTEXTOR_ENABLED = os.getenv("CONTEXTOR_ENABLED", "true").lower() == "true"
 
     # Sudo Access Configuration
+    # Note: This is a preference setting. Actual sudo access is managed by sudo_manager
+    # This setting tracks whether sudo should be enabled (for installation/configuration purposes)
     JARVIS_SUDO_ENABLED = os.getenv("JARVIS_SUDO_ENABLED", "false").lower() == "true"
 
     # Dispatch Configuration
-    DISPATCH_BINARY = os.getenv("DISPATCH_BINARY", "dispatch")
-    DMCP_BINARY = os.getenv("DMCP_BINARY", "dmcp")
+    DISPATCH_BINARY = os.getenv(
+        "DISPATCH_BINARY", "dispatch"
+    )  # Path to dispatch binary
+    DMCP_BINARY = os.getenv("DMCP_BINARY", "dmcp")  # Path to dmcp binary
     DISPATCH_TIMEOUT = int(os.getenv("DISPATCH_TIMEOUT", "60"))  # seconds
 
     # Contextor (memory) binary — Rust subprocess over stdio
@@ -121,21 +120,32 @@ class Config:
     MAX_ENTRIES_PER_THEME = int(os.getenv("MAX_ENTRIES_PER_THEME", "500"))
 
     # --- Context Retrieval (RAG) ---
+    # Embedding model for semantic search (runs on Ollama)
     EMBED_MODEL = os.getenv("EMBED_MODEL", "nomic-embed-text")
+    # Ollama URL for embeddings — defaults to local instance, NOT LLM_URL
+    # (the LLM may live on a remote server; embeddings always need local Ollama)
     EMBED_URL = os.getenv("EMBED_URL", "http://localhost:11434")
+    # Enable semantic search via contextor binary (requires embed model)
     RAG_ENABLED = os.getenv("RAG_ENABLED", "true").lower() == "true"
+    # Number of memories to retrieve per RAG query
     RAG_TOP_K = int(os.getenv("RAG_TOP_K", "5"))
+    # Minimum cosine similarity for RAG results (0.0-1.0)
     RAG_MIN_SCORE = float(os.getenv("RAG_MIN_SCORE", "0.3"))
 
     # --- Semantic Tool Discovery ---
+    # Master switch for vector-based tool search via dispatch/dmcp
     ALLOW_EMBEDDING_SEARCH = (
         os.getenv("ALLOW_EMBEDDING_SEARCH", "true").lower() == "true"
     )
+    # Bypass threshold — use vector search regardless of server count
     ENFORCE_EMBEDDING_SEARCH = (
         os.getenv("ENFORCE_EMBEDDING_SEARCH", "false").lower() == "true"
     )
-    EMBEDDING_SEARCH_THRESHOLD = int(os.getenv("EMBEDDING_SEARCH_THRESHOLD", "0"))
+    # Minimum visible servers before vector search auto-enables
+    EMBEDDING_SEARCH_THRESHOLD = int(os.getenv("EMBEDDING_SEARCH_THRESHOLD", "100"))
 
+    # Data directory — when set (e.g. systemd JARVIS_DATA_DIR=/var/lib/jarvis),
+    # memory, goal archive, and default socket use this base path
     _DEFAULT_DATA_DIR = os.path.join(
         os.getenv(
             "XDG_DATA_HOME", os.path.join(os.path.expanduser("~"), ".local", "share")
@@ -144,165 +154,77 @@ class Config:
     )
     JARVIS_DATA_DIR = os.getenv("JARVIS_DATA_DIR", _DEFAULT_DATA_DIR)
 
+    # Dual input — Unix socket for "jarvis send" and app integration
+    # Default: JARVIS_DATA_DIR/input.sock (or ~/.jarvis/input.sock)
     JARVIS_INPUT_SOCKET = os.getenv(
         "JARVIS_INPUT_SOCKET",
         os.path.join(JARVIS_DATA_DIR, "input.sock"),
     )
+
+    # Output IPC — Unix socket for apps/widgets to receive responses
+    # Clients connect and receive JSON lines: {"output": "...", ...}
     JARVIS_OUTPUT_SOCKET = os.getenv(
         "JARVIS_OUTPUT_SOCKET",
         os.path.join(JARVIS_DATA_DIR, "output.sock"),
     )
 
+    # Tool-Level Action (TLA) Confirmation
+    # - "allow_all": never ask, run everything (power users / trusted environments)
+    # - "smart":     only ask when tool has confirmation_required=true (default)
+    # - "ask_all":   ask for every tool call, regardless of metadata
     CONFIRMATION_MODE = os.getenv("CONFIRMATION_MODE", "smart")
+
+    # Default notification style for confirmation prompts:
+    # - false: show desktop notification (notify-send)
+    # - true:  suppress desktop notification; only use socket/CLI
+    #          (lets external apps render their own confirmation UI)
     NOTIFICATION_SILENT = os.getenv("NOTIFICATION_SILENT", "false").lower() == "true"
+
+    # Timeout (seconds) for user to respond to a confirmation prompt
     CONFIRMATION_TIMEOUT = int(os.getenv("CONFIRMATION_TIMEOUT", "30"))
 
-    LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
-    LOG_FILE = os.getenv("LOG_FILE", "")
-    LOG_COLORS = os.getenv("LOG_COLORS", "true").lower() == "true"
-    LLM_IO_LOG = os.getenv("LLM_IO_LOG", "")
+    # Logging Configuration
+    LOG_LEVEL = os.getenv(
+        "LOG_LEVEL", "INFO"
+    ).upper()  # DEBUG, INFO, WARNING, ERROR, CRITICAL
+    LOG_FILE = os.getenv(
+        "LOG_FILE", ""
+    )  # Optional: path to log file (empty = no file logging)
+    LOG_COLORS = (
+        os.getenv("LOG_COLORS", "true").lower() == "true"
+    )  # Enable colored console output
+
+    # os.environ["OLLAMA_NO_GPU"] = "1"
+    # os.environ["OLLAMA_NUM_THREADS"] = str(multiprocessing.cpu_count())
 
     # ------------------------------------------------------------------
-    # Prompt system — unified root mode handles all tool + memory ops.
+    # Hierarchical prompt system: ROOT → DISPATCH
+    # Memory actions (store, recall, search, list) are ROOT-level —
+    # no separate CONTEXTOR LLM sub-chain.
     # ------------------------------------------------------------------
 
     LLM_WRONG_JSON_FORMAT_MESSAGE = """\
-BAD RESPONSE. You must output a JSON object with an "action" field.
+Your response was not valid JSON. Output ONLY a single JSON object — nothing else.
+No thinking, no explanation, no markdown fences. Just the JSON.
 
-COMMON MISTAKE — WRONG (missing action):
-  {{"intent": "check python version"}}
+Valid formats:
 
-CORRECT:
-  {{"action": "run", "intent": "check python version"}}
+{{"action": "respond", "output": "your message", "goal_updates": []}}
 
-Valid action values: respond, run, find_tools, list_tools, install, dispatch,
-  wait, kill, defer, store, recall, search_memory, list_memory.
+{{"action": "dispatch", "intent": "what to accomplish"}}
 
-Output ONLY the corrected JSON object. First char {{, last char }}."""
+{{"action": "store", "theme": "topic", "content": "fact", "goal_updates": []}}
 
-    LLM_ROOT_PROMPT_UNIFIED = """\
-You are JARVIS, a personal AI assistant. Respond in JSON only.
+{{"action": "recall", "theme": "topic", "goal_updates": []}}
 
-OS: {system} {release} ({machine}), Shell: {shell}
+{{"action": "search_memory", "query": "natural language query", "goal_updates": []}}
 
-=== CRITICAL RULE ===
-Every response MUST be a JSON object where the FIRST key is "action".
+{{"action": "list_memory", "goal_updates": []}}
 
-WRONG — never output this:
-  {{"intent": "check python version"}}
+{{"action": "done", "summary": "result summary"}}
 
-CORRECT — always include action:
-  {{"action": "run", "intent": "check python version"}}
-
-=== ACTIONS ===
-
-For talking to the user:
-  {{"action": "respond", "output": "<message>", "goal_updates": [...]}}
-
-For running external tools / system commands / web / files / anything live:
-  {{"action": "run", "intent": "check python version"}}
-  The system finds and executes the right tool automatically.
-  You receive the result and then respond to the user.
-
-For memory:
-  {{"action": "store", "theme": "<topic>", "content": "<fact>", "goal_updates": []}}
-  {{"action": "recall", "theme": "<topic>", "goal_updates": []}}
-  {{"action": "search_memory", "query": "<query>", "top_k": 5, "goal_updates": []}}
-  {{"action": "list_memory", "goal_updates": []}}
-{data_consent_note}
-For session naming (use when SESSION_TITLE is "New chat"):
-  {{"action": "rename_session", "title": "<2-5 words>", "goal_updates": []}}
-
-Advanced tool actions (for multi-step or parallel tasks):
-  {{"action": "find_tools", "intent": "<specific task>"}}
-  {{"action": "dispatch", "tasks": [{{"server": "<id>", "tool": "<name>", "params": {{}}}}]}}
-  {{"action": "wait"}}
-  {{"action": "install", "server_id": "<id>"}}
-  {{"action": "list_tools", "server_id": "<id>"}}
-  {{"action": "kill", "pids": [1, 2]}}
-  {{"action": "defer", "goal_id": "<id>", "duration": 1800}}
-
-=== WORKFLOW ===
-1. Use "run" for all tool tasks. System returns WAIT_RESULT or DISPATCH_RESULT.
-2. Respond to the user with the result.
-3. If NO_TOOLS_FOUND: tell the user the tool is not available.
-
-=== CONTEXT ===
-GOALS, SESSION_TITLE, NEW INPUT, RELEVANT MEMORIES (auto-injected).
-After run: WAIT_RESULT or DISPATCH_RESULT or NO_TOOLS_FOUND.
-After memory ops: STORE_RESULT, RECALL_RESULT, SEARCH_MEMORY_RESULT, LIST_MEMORY_RESULT.
-
-=== RULES ===
-- "action" key is REQUIRED in every response. Never omit it.
-- Never invent tool names. Only use names from MATCHED_TOOLS or list_tools output.
-- Always use absolute paths in shell commands (/home/user/file.txt, not ./file.txt).
-- If a task fails, tell the user honestly. Never fabricate output.
-- Include goal_updates in respond to mark goals completed or failed.
-- Use search_memory for stored memories only, not internet searches.
-
-Output exactly one JSON object. First char {{, last char }}.
-"""
-
-    LLM_ROOT_PROMPT_UNIFIED_NO_CONTEXTOR = """\
-You are JARVIS, a personal AI assistant. Respond in JSON only.
-
-OS: {system} {release} ({machine}), Shell: {shell}
-
-=== CRITICAL RULE ===
-Every response MUST be a JSON object where the FIRST key is "action".
-
-WRONG — never output this:
-  {{"intent": "check python version"}}
-
-CORRECT — always include action:
-  {{"action": "run", "intent": "check python version"}}
-
-=== ACTIONS ===
-
-For talking to the user:
-  {{"action": "respond", "output": "<message>", "goal_updates": [...]}}
-
-For running external tools / system commands / web / files / anything live:
-  {{"action": "run", "intent": "check python version"}}
-  The system finds and executes the right tool automatically.
-  You receive the result and then respond to the user.
-
-Memory is disabled. Do not use store, recall, search_memory, or list_memory.
-
-For session naming (use when SESSION_TITLE is "New chat"):
-  {{"action": "rename_session", "title": "<2-5 words>", "goal_updates": []}}
-
-Advanced tool actions (for multi-step or parallel tasks):
-  {{"action": "find_tools", "intent": "<specific task>"}}
-  {{"action": "dispatch", "tasks": [{{"server": "<id>", "tool": "<name>", "params": {{}}}}]}}
-  {{"action": "wait"}}
-  {{"action": "install", "server_id": "<id>"}}
-  {{"action": "list_tools", "server_id": "<id>"}}
-  {{"action": "kill", "pids": [1, 2]}}
-  {{"action": "defer", "goal_id": "<id>", "duration": 1800}}
-
-=== WORKFLOW ===
-1. Use "run" for all tool tasks. System returns WAIT_RESULT or DISPATCH_RESULT.
-2. Respond to the user with the result.
-3. If NO_TOOLS_FOUND: tell the user the tool is not available.
-
-=== CONTEXT ===
-GOALS, SESSION_TITLE, NEW INPUT.
-After run: WAIT_RESULT or DISPATCH_RESULT or NO_TOOLS_FOUND.
-
-=== RULES ===
-- "action" key is REQUIRED in every response. Never omit it.
-- Never invent tool names. Only use names from MATCHED_TOOLS or list_tools output.
-- Always use absolute paths in shell commands (/home/user/file.txt, not ./file.txt).
-- If a task fails, tell the user honestly. Never fabricate output.
-- Include goal_updates in respond to mark goals completed or failed.
-
-Output exactly one JSON object. First char {{, last char }}.
-"""
-
-    # ------------------------------------------------------------------
-    # Legacy two-mode prompts kept for reference / rollback.
-    # ------------------------------------------------------------------
+The very first character must be {{ and the very last must be }}.
+Now, return ONLY the corrected JSON."""
 
     LLM_ROOT_PROMPT = """\
 You are JARVIS, a personal assistant. Route or respond. Output ONLY valid JSON — no text before or after.
@@ -311,14 +233,17 @@ OS: {system} {release} ({machine}), Shell: {shell}
 
 --- When to use each action ---
 
-respond — Direct reply. Use for chat, greetings, general knowledge, or after a subsystem returns a result.
-store — Remember a personal fact or preference under a topic theme.
+respond — Direct reply. Use for chat, greetings, or after a result comes back.
+store — Remember a personal fact or preference.
 recall — Recall stored facts by exact theme name.
-search_memory — Search JARVIS's own stored memories by meaning. Use ONLY when looking for something previously remembered/stored. NOT for internet or web searches.
+search_memory — Search all memories by meaning. Use when you need context.
 list_memory — List all stored memory themes.
-rename_session — Rename the current chat session. Use after the first substantive exchange when SESSION_TITLE is "New chat" — pick a short (2–5 word) title that captures the topic.
 {data_consent_note}
-dispatch — Run external tools. Use for: web/internet search, shell commands, opening apps, calculator, file operations, anything requiring live data or system actions. Web search goes here, NOT to search_memory.
+run — Execute a task using external tools (shell, files, web, etc.).
+      The system finds and runs the right tool automatically.
+      intent = SPECIFIC TASK, NOT the tool type.
+      WRONG:   {{"action": "run", "intent": "run shell command"}}
+      CORRECT: {{"action": "run", "intent": "check python version"}}
 
 --- Actions (exact format) ---
 
@@ -326,6 +251,12 @@ dispatch — Run external tools. Use for: web/internet search, shell commands, o
     "action": "respond",
     "output": "<your message>",
     "goal_updates": [{{"id": "<goal_id>", "status": "completed", "result": "summary"}}]
+}}
+
+{{
+    "action": "run",
+    "intent": "<specific task to accomplish>",
+    "goal_updates": []
 }}
 
 {{
@@ -355,24 +286,18 @@ dispatch — Run external tools. Use for: web/internet search, shell commands, o
     "goal_updates": []
 }}
 
-{{
-    "action": "rename_session",
-    "title": "<short descriptive title, 2-5 words>",
-    "goal_updates": []
-}}
-
-{{
-    "action": "dispatch",
-    "intent": "<what to accomplish>"
-}}
-
 --- Context ---
-You receive: GOALS (with IDs), SESSION_TITLE (current chat name), NEW INPUT, and optionally DISPATCH_SUMMARY from dispatch.
-If DISPATCH_SUMMARY reports that a tool was unavailable or the task could not be completed, tell the user that honestly — do NOT infer, guess, or fabricate any result.
+You receive: GOALS (with IDs), NEW INPUT, and optionally WAIT_RESULT/DISPATCH_RESULT from tool execution.
 Memory operation results appear as STORE_RESULT, RECALL_RESULT, SEARCH_MEMORY_RESULT, LIST_MEMORY_RESULT.
-RENAME_RESULT confirms the rename succeeded — then respond to the user normally.
 RELEVANT MEMORIES may be included automatically based on user input (RAG retrieval).
 Include goal_updates in respond: "completed" or "failed" with result.
+NO_TOOLS_FOUND means retry run with a more specific intent — MUST retry at least twice before giving up.
+
+--- Memory guidelines ---
+- Choose descriptive theme names (e.g. "user_preferences", "school_schedule")
+- When storing, extract the key fact — be concise
+- Use search_memory with natural language — it searches by meaning, not keywords
+- If search results aren't relevant, try again with a higher offset to dig deeper
 
 Output exactly one JSON object. First char {{, last char }}.
 """
@@ -382,20 +307,45 @@ You are JARVIS, a personal assistant. Route or respond. Output ONLY valid JSON �
 
 OS: {system} {release} ({machine}), Shell: {shell}
 
-respond — Direct reply.
-rename_session — Rename the current chat session when SESSION_TITLE is "New chat".
-dispatch — Run tools (calc, files, web, etc.).
-Memory is disabled.
+--- When to use each action ---
 
-{{"action": "respond", "output": "<message>", "goal_updates": [...]}}
-{{"action": "rename_session", "title": "<2-5 words>", "goal_updates": []}}
-{{"action": "dispatch", "intent": "<what to accomplish>"}}
+respond — Direct reply. Use for chat, greetings, or after a result comes back.
+Memory is disabled. Do not use store, recall, search_memory, or list_memory.
+run — Execute a task using external tools (shell, files, web, etc.).
+      The system finds and runs the right tool automatically.
+      intent = SPECIFIC TASK, NOT the tool type.
+      WRONG:   {{"action": "run", "intent": "run shell command"}}
+      CORRECT: {{"action": "run", "intent": "check python version"}}
+
+--- Actions (exact format) ---
+
+{{
+    "action": "respond",
+    "output": "<your message>",
+    "goal_updates": [{{"id": "<goal_id>", "status": "completed", "result": "summary"}}]
+}}
+
+{{
+    "action": "run",
+    "intent": "<specific task to accomplish>",
+    "goal_updates": []
+}}
+
+--- Context ---
+You receive: GOALS (with IDs), NEW INPUT, and optionally WAIT_RESULT/DISPATCH_RESULT from tool execution.
+Include goal_updates in respond: "completed" or "failed" with result.
+NO_TOOLS_FOUND means retry run with a more specific intent — MUST retry at least twice before giving up.
 
 Output exactly one JSON object. First char {{, last char }}.
 """
 
     # ------------------------------------------------------------------
-    # Legacy dispatch-mode prompts (kept for sub-chain fallback).
+    # Dispatch mode: two variants selected per-turn by the system.
+    #
+    # JARVIS picks which prompt is active based on the current tool-
+    # discovery backend (see DispatchAdapter.select_discovery_mode).
+    # The LLM never sees the words "embedding", "semantic", "vector",
+    # or "keyword" — it just follows whichever schema is in front of it.
     # ------------------------------------------------------------------
 
     LLM_DISPATCH_PROMPT_KEYWORD = """\
@@ -460,24 +410,25 @@ Return to root with results:
 - MATCHED_TOOLS: Tools ready to dispatch — server_id/tool_name plus params schema
 - CANDIDATE_SERVERS: Servers that look relevant but are NOT installed —
                      use install + list_tools to make them dispatchable
-- NO_TOOLS_FOUND: No tools or servers matched. You MUST respond with either a new
-                  "plan" action using different keywords, or "done" with a failure summary.
-                  Never return an empty response when you see this.
 - TOOLS: Tool listings from a server (after list_tools)
 - SEARCH_RESULTS: Server search results (after search)
 - INSTALL_RESULT: Installation outcome
 - DISPATCH_RESULT / DISPATCH_ERROR: Task execution results
 - SIGNAL: Dispatch event (INIT, EXIT, REMIND, WAIT, KILL)
 
+--- Signal types ---
+- INIT: Task started (includes PID)
+- EXIT: Task finished (includes output or error)
+- REMIND: Task exceeded its reminder threshold
+- WAIT: You previously chose to wait
+- KILL: Task was terminated
+
 --- Rules ---
 - ALWAYS start with "plan" — even for a single task.
 - If MATCHED_TOOLS is present, dispatch those. Never invent tool names.
 - If only CANDIDATE_SERVERS is present, install + list_tools first.
-- If NO_TOOLS_FOUND, try a new plan with different keywords or use done.
-- When done due to failure, the summary must be specific: "UNAVAILABLE: <reason>" or
-  "FAILED: <error>". Never write vague summaries like "please try again".
+- If nothing matched, try search with different keywords, or done with a failure summary.
 - You can dispatch multiple tasks in one action for parallelism.
-- Always use absolute paths in shell/filesystem commands.
 - Output exactly one JSON object — no preamble, no trailing text.
 
 The very first character of your response must be {{ and the very last must be }}.
@@ -544,25 +495,25 @@ Return to root with results:
 - MATCHED_TOOLS: Tools ready to dispatch — server_id/tool_name plus params schema
 - CANDIDATE_SERVERS: Servers that look relevant but are NOT installed —
                      use install + list_tools to make them dispatchable
-- NO_TOOLS_FOUND: No tools or servers matched. You MUST respond with either a new
-                  "plan" action using a more specific or differently worded intent,
-                  or "done" with a failure summary. Never return an empty response
-                  when you see this.
 - TOOLS: Tool listings from a server (after list_tools)
 - INSTALL_RESULT: Installation outcome
 - DISPATCH_RESULT / DISPATCH_ERROR: Task execution results
 - SIGNAL: Dispatch event (INIT, EXIT, REMIND, WAIT, KILL)
 
+--- Signal types ---
+- INIT: Task started (includes PID)
+- EXIT: Task finished (includes output or error)
+- REMIND: Task exceeded its reminder threshold
+- WAIT: You previously chose to wait
+- KILL: Task was terminated
+
 --- Rules ---
 - ALWAYS start with "plan" — even for a single task.
 - If MATCHED_TOOLS is present, dispatch those. Never invent tool names.
 - If only CANDIDATE_SERVERS is present, install + list_tools first.
-- If NO_TOOLS_FOUND, re-plan with a more specific or differently worded intent,
-  or use done with a clear failure summary.
-- When done due to failure, the summary must be specific: "UNAVAILABLE: <reason>" or
-  "FAILED: <error>". Never write vague summaries.
+- If nothing matched, re-plan with more specific sub-task intents,
+  or done with a failure summary.
 - You can dispatch multiple tasks in one action for parallelism.
-- Always use absolute paths in shell/filesystem commands.
 - Output exactly one JSON object — no preamble, no trailing text.
 
 The very first character of your response must be {{ and the very last must be }}.

--- a/jarvis/core/command_parser.py
+++ b/jarvis/core/command_parser.py
@@ -1,16 +1,12 @@
 """
-Task parser for JARVIS unified prompt system.
+Task parser for JARVIS hierarchical prompt system.
 
 Validates and parses LLM responses into structured actions.
 
-All actions are now ROOT-level — the unified prompt handles tool discovery,
-installation, and execution directly without a separate dispatch sub-chain.
-
-Actions:
-  respond, store, recall, search_memory, list_memory, rename_session
-  run                          (primary: discover + dispatch + wait in one step)
-  find_tools, list_tools, install, dispatch, wait, kill, defer  (advanced)
-  plan, search, done           (legacy dispatch-mode, kept for fallback)
+ROOT mode actions:  respond, dispatch (route),
+                    store, recall, search_memory, list_memory (memory)
+DISPATCH mode actions: plan, search, list_tools, install, dispatch (tasks),
+                       wait, kill, defer, done
 """
 
 from typing import Any, Dict
@@ -23,25 +19,20 @@ VALID_ACTIONS = {
     # Root — core
     "respond",
     "dispatch",
-    # Root — primary tool execution (discover + dispatch + wait in one action)
     "run",
-    # Root — memory
+    # Root — memory (direct operations, no sub-chain)
     "store",
     "recall",
     "search_memory",
     "list_memory",
-    # Root — session
-    "rename_session",
-    # Root — advanced tool actions
-    "find_tools",
+    # Dispatch subsystem
+    "plan",
+    "search",
     "list_tools",
     "install",
     "wait",
     "kill",
     "defer",
-    # Legacy dispatch subsystem (kept for fallback / sub-chain rollback)
-    "plan",
-    "search",
     "done",
 }
 
@@ -65,11 +56,9 @@ class TaskParser:
     def parse(response: Dict[str, Any]) -> Dict[str, Any]:
         action = response.get("action")
 
-        # Some models omit the "action" key but include "intent" — treat as run.
+        # Some models omit "action" but include "intent" — treat as run.
         if action is None and response.get("intent"):
-            logger.info(
-                "TaskParser: Inferred action='run' from bare intent field"
-            )
+            logger.info("TaskParser: Inferred action='run' from bare intent field")
             response = dict(response)
             response["action"] = "run"
             action = "run"
@@ -100,10 +89,6 @@ class TaskParser:
     @staticmethod
     def _summarize(result: Dict[str, Any]) -> str:
         action = result.get("action", "")
-        if action in ("run", "find_tools"):
-            intent = result.get("intent", "")
-            preview = (intent[:80] + "...") if len(intent) > 80 else intent
-            return f", intent='{preview}'"
         if action == "dispatch":
             tasks = result.get("tasks")
             if tasks:
@@ -130,6 +115,10 @@ class TaskParser:
             tasks = result.get("tasks", [])
             intents = [t.get("intent", "")[:40] for t in tasks]
             return f", tasks={intents}"
+        if action == "run":
+            intent = result.get("intent", "")
+            preview = (intent[:80] + "...") if len(intent) > 80 else intent
+            return f", intent='{preview}'"
         if action == "search":
             return f", keywords={result.get('keywords', [])}"
         if action == "list_tools":
@@ -164,31 +153,19 @@ def _parse_respond(response: Dict[str, Any]) -> Dict[str, Any]:
 
 @_parser("run")
 def _parse_run(response: Dict[str, Any]) -> Dict[str, Any]:
-    """Parse run — single action that discovers, dispatches, and waits."""
     intent = response.get("intent", "")
     if not intent:
         return {"error": "run action requires 'intent'", "raw": response}
     return {
         "action": "run",
         "intent": str(intent),
-    }
-
-
-@_parser("find_tools")
-def _parse_find_tools(response: Dict[str, Any]) -> Dict[str, Any]:
-    """Parse find_tools — advanced: root LLM searches for tools by intent."""
-    intent = response.get("intent", "")
-    if not intent:
-        return {"error": "find_tools action requires 'intent'", "raw": response}
-    return {
-        "action": "find_tools",
-        "intent": str(intent),
+        "goal_updates": response.get("goal_updates", []),
     }
 
 
 @_parser("dispatch")
 def _parse_dispatch(response: Dict[str, Any]) -> Dict[str, Any]:
-    """Parse dispatch — either concrete tasks or legacy intent routing."""
+    """Parse dispatch — either a ROOT routing intent or DISPATCH-mode tasks."""
     tasks = response.get("tasks")
     intent = response.get("intent")
 
@@ -237,85 +214,13 @@ def _parse_dispatch(response: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # ------------------------------------------------------------------
-# Tool actions (unified root)
-# ------------------------------------------------------------------
-
-
-@_parser("list_tools")
-def _parse_list_tools(response: Dict[str, Any]) -> Dict[str, Any]:
-    server_id = response.get("server_id")
-    if not server_id:
-        return {"error": "list_tools action requires 'server_id'", "raw": response}
-    return {
-        "action": "list_tools",
-        "server_id": str(server_id),
-        "goal_updates": response.get("goal_updates", []),
-    }
-
-
-@_parser("install")
-def _parse_install(response: Dict[str, Any]) -> Dict[str, Any]:
-    server_id = response.get("server_id")
-    if not server_id:
-        return {"error": "Install action requires 'server_id'", "raw": response}
-    return {
-        "action": "install",
-        "server_id": str(server_id),
-        "goal_updates": response.get("goal_updates", []),
-    }
-
-
-@_parser("wait")
-def _parse_wait(response: Dict[str, Any]) -> Dict[str, Any]:
-    return {
-        "action": "wait",
-        "pids": response.get("pids"),
-        "goal_updates": response.get("goal_updates", []),
-    }
-
-
-@_parser("kill")
-def _parse_kill(response: Dict[str, Any]) -> Dict[str, Any]:
-    pids = response.get("pids", [])
-    if not isinstance(pids, list) or not pids:
-        return {
-            "error": "Kill action requires a non-empty 'pids' list",
-            "raw": response,
-        }
-    return {
-        "action": "kill",
-        "pids": [int(p) for p in pids],
-        "goal_updates": response.get("goal_updates", []),
-    }
-
-
-@_parser("defer")
-def _parse_defer(response: Dict[str, Any]) -> Dict[str, Any]:
-    goal_id = response.get("goal_id")
-    duration = response.get("duration")
-    if not goal_id:
-        return {"error": "Defer action requires 'goal_id'", "raw": response}
-    if not duration or not isinstance(duration, (int, float)) or duration <= 0:
-        return {
-            "error": "Defer action requires a positive 'duration' (seconds)",
-            "raw": response,
-        }
-    return {
-        "action": "defer",
-        "goal_id": str(goal_id),
-        "duration": int(duration),
-        "reason": response.get("reason", ""),
-        "goal_updates": response.get("goal_updates", []),
-    }
-
-
-# ------------------------------------------------------------------
-# Legacy dispatch subsystem actions (kept for sub-chain fallback)
+# DISPATCH subsystem actions
 # ------------------------------------------------------------------
 
 
 @_parser("plan")
 def _parse_plan(response: Dict[str, Any]) -> Dict[str, Any]:
+    """Parse plan action — LLM breaks intent into sub-tasks for tool discovery."""
     tasks = response.get("tasks", [])
     if not isinstance(tasks, list) or not tasks:
         return {
@@ -368,8 +273,76 @@ def _parse_search(response: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+@_parser("list_tools")
+def _parse_list_tools(response: Dict[str, Any]) -> Dict[str, Any]:
+    server_id = response.get("server_id")
+    if not server_id:
+        return {"error": "list_tools action requires 'server_id'", "raw": response}
+    return {
+        "action": "list_tools",
+        "server_id": str(server_id),
+        "goal_updates": response.get("goal_updates", []),
+    }
+
+
+@_parser("install")
+def _parse_install(response: Dict[str, Any]) -> Dict[str, Any]:
+    server_id = response.get("server_id")
+    if not server_id:
+        return {"error": "Install action requires 'server_id'", "raw": response}
+    return {
+        "action": "install",
+        "server_id": str(server_id),
+        "goal_updates": response.get("goal_updates", []),
+    }
+
+
+@_parser("wait")
+def _parse_wait(response: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "action": "wait",
+        "goal_updates": response.get("goal_updates", []),
+    }
+
+
+@_parser("kill")
+def _parse_kill(response: Dict[str, Any]) -> Dict[str, Any]:
+    pids = response.get("pids", [])
+    if not isinstance(pids, list) or not pids:
+        return {
+            "error": "Kill action requires a non-empty 'pids' list",
+            "raw": response,
+        }
+    return {
+        "action": "kill",
+        "pids": [int(p) for p in pids],
+        "goal_updates": response.get("goal_updates", []),
+    }
+
+
+@_parser("defer")
+def _parse_defer(response: Dict[str, Any]) -> Dict[str, Any]:
+    goal_id = response.get("goal_id")
+    duration = response.get("duration")
+    if not goal_id:
+        return {"error": "Defer action requires 'goal_id'", "raw": response}
+    if not duration or not isinstance(duration, (int, float)) or duration <= 0:
+        return {
+            "error": "Defer action requires a positive 'duration' (seconds)",
+            "raw": response,
+        }
+    return {
+        "action": "defer",
+        "goal_id": str(goal_id),
+        "duration": int(duration),
+        "reason": response.get("reason", ""),
+        "goal_updates": response.get("goal_updates", []),
+    }
+
+
 @_parser("done")
 def _parse_done(response: Dict[str, Any]) -> Dict[str, Any]:
+    """Subsystem signals completion and returns a summary to root."""
     summary = response.get("summary", "")
     return {
         "action": "done",
@@ -378,7 +351,7 @@ def _parse_done(response: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # ------------------------------------------------------------------
-# Memory actions
+# ROOT-level memory actions (direct operations, no sub-chain)
 # ------------------------------------------------------------------
 
 
@@ -392,7 +365,6 @@ def _parse_store(response: Dict[str, Any]) -> Dict[str, Any]:
         "action": "store",
         "theme": str(theme),
         "content": str(content),
-        "scope": response.get("scope", "session"),
         "goal_updates": response.get("goal_updates", []),
     }
 
@@ -411,6 +383,7 @@ def _parse_recall(response: Dict[str, Any]) -> Dict[str, Any]:
 
 @_parser("search_memory")
 def _parse_search_memory(response: Dict[str, Any]) -> Dict[str, Any]:
+    """Parse search_memory — semantic search with natural language query."""
     query = response.get("query", "")
     if not query:
         return {"error": "search_memory requires a 'query' string", "raw": response}
@@ -428,17 +401,5 @@ def _parse_search_memory(response: Dict[str, Any]) -> Dict[str, Any]:
 def _parse_list_memory(response: Dict[str, Any]) -> Dict[str, Any]:
     return {
         "action": "list_memory",
-        "goal_updates": response.get("goal_updates", []),
-    }
-
-
-@_parser("rename_session")
-def _parse_rename_session(response: Dict[str, Any]) -> Dict[str, Any]:
-    title = response.get("title", "").strip()
-    if not title:
-        return {"error": "rename_session requires 'title'", "raw": response}
-    return {
-        "action": "rename_session",
-        "title": title,
         "goal_updates": response.get("goal_updates", []),
     }

--- a/jarvis/dispatch/tool_discovery.py
+++ b/jarvis/dispatch/tool_discovery.py
@@ -46,9 +46,26 @@ async def discover_tools(
                             r["_source_task"] = intents[i]
                         all_results.extend(result_set)
                     else:
+                        # Per-task fallback when embedding returns empty for this task.
                         all_results.extend(
                             await keyword_fallback(adapter, logger, tasks[i])
                         )
+                # If embedding returned fewer result sets than tasks, cover the rest.
+                for i in range(len(result_sets), len(tasks)):
+                    all_results.extend(
+                        await keyword_fallback(adapter, logger, tasks[i])
+                    )
+
+            # Global fallback: embedding search ran but returned nothing at all
+            # (e.g. vector index is empty because no servers are installed yet).
+            # Keyword search hits the full server catalog including uninstalled
+            # servers, so this is the path that surfaces CANDIDATE_SERVERS.
+            if not all_results:
+                logger.info(
+                    "Dispatch: Embedding index empty — falling back to keyword search"
+                )
+                for task in tasks:
+                    all_results.extend(await keyword_fallback(adapter, logger, task))
 
         except Exception as e:
             logger.warning(

--- a/jarvis/dispatch/tool_discovery.py
+++ b/jarvis/dispatch/tool_discovery.py
@@ -77,6 +77,13 @@ async def discover_tools(
         for task in tasks:
             all_results.extend(await keyword_fallback(adapter, logger, task))
 
+    # Global fallback: embedding index was empty (result_sets=[]) so the
+    # per-task fallback loop never ran.
+    if not all_results and mode == "embedding":
+        logger.info("Dispatch: Embedding index empty — falling back to keyword search")
+        for task in tasks:
+            all_results.extend(await keyword_fallback(adapter, logger, task))
+
     if not all_results:
         logger.info("Dispatch: discover_tools found no matching tools")
         return ""

--- a/jarvis/runtime/lifecycle.py
+++ b/jarvis/runtime/lifecycle.py
@@ -22,6 +22,8 @@ def install_signal_handlers(
         try:
             loop.add_signal_handler(sig, stop_callback)
         except (ValueError, OSError):
+            # Some environments (e.g. non-main thread/platform constraints)
+            # do not allow adding custom signal handlers.
             pass
 
 
@@ -37,17 +39,15 @@ async def connect_dispatch_nonfatal(dispatch: Any, logger: Logger) -> None:
 async def bootstrap_tool_index_nonfatal(
     dispatch: Any, embeddings: Any, logger: Logger
 ) -> None:
-    """Sync tool embedding index on every startup when servers are available."""
+    """Ensure embedding model and sync tool index when dispatch is available."""
     if not (dispatch.is_connected and embeddings):
         return
 
     try:
         await dispatch.ensure_embedding_model(embeddings)
         count = await dispatch.server_count()
+        # registry count is always 0 through the MCP layer; use total instead.
         total = count.get("total", 0)
-        # Always sync when there are known servers. The registry count coming
-        # through the MCP layer is always 0 (dmcp count without --json), so
-        # the old `registry > 0` check caused the index to stay stale forever.
         if total > 0:
             await dispatch.sync_index()
             logger.info(f"JARVIS: Tool vector index synced ({total} servers)")
@@ -75,7 +75,7 @@ async def start_runtime_services(
     """Start event sources and optional socket/voice runtime services."""
     user_source = resolve_user_source(app)
     app.events.start(
-        signal_window_source=app.dispatch.get_signal_window,
+        signal_source=app._await_dispatch_signal,
         user_source=user_source,
     )
 
@@ -94,10 +94,12 @@ async def start_runtime_services(
         from ..core.socket_security import harden_socket_path, warn_if_allow_all
 
         harden_socket_path(Config.JARVIS_INPUT_SOCKET)
-        warn_if_allow_all(Config.CONFIRMATION_MODE)
+        warn_if_allow_all()
         input_socket_task = asyncio.create_task(app._run_socket_listener())
         logger.info(f"JARVIS: Socket listener at {Config.JARVIS_INPUT_SOCKET}")
 
+    # Wire confirmation manager's event injector so responses flow
+    # through the event loop instead of blocking.
     app.confirmation.set_event_injector(app.events.inject_confirmation_response)
 
     output_socket_task: Optional[asyncio.Task] = None

--- a/jarvis/runtime/root_actions.py
+++ b/jarvis/runtime/root_actions.py
@@ -1,41 +1,17 @@
-"""ROOT-mode response action handling — unified tool + memory dispatch."""
+"""ROOT-mode response action handling helpers."""
 
 from __future__ import annotations
 
 import json
 from logging import Logger
-from typing import Any, Optional
+from typing import Any
 
 from ..config import Config
+from .dispatch_flow import dispatch_send
 from .goal_updates import apply_goal_updates
 from .llm_bridge import ask_llm
 from .output_hooks import emit_activity, get_embeddings, persist_assistant_turn
 from .root_context import build_root_context, compact_payload_for_llm
-
-# Emitted by the LLM retry fallback when all attempts return empty.
-_DISPATCH_FAILURE_SENTINEL = "I had trouble formatting my response."
-
-_FAILURE_WORDS = ("error", "fail", "couldn't", "unable", "timed out", "exception")
-
-
-def _is_failure_summary(summary: str) -> bool:
-    lower = summary.lower()
-    return any(w in lower for w in _FAILURE_WORDS)
-
-
-async def _continue_root(
-    app: Any,
-    logger: Logger,
-    extra_context: str,
-    depth: int,
-    tag: str,
-    max_chain_depth: int,
-) -> None:
-    """Re-enter the root LLM loop with additional context appended."""
-    context = build_root_context(app, logger)
-    context += f"\n{extra_context}"
-    response = await ask_llm(app, logger, context, tag=tag)
-    await app._act_on_root_response(response, depth + 1)
 
 
 async def feed_root_summary(
@@ -44,42 +20,153 @@ async def feed_root_summary(
     label: str,
     summary: str,
     depth: int,
-    intent: Optional[str] = None,
 ) -> None:
     """Feed a subsystem summary back into ROOT for the next decision."""
+    app.llm.switch_mode("root")
     context = build_root_context(app, logger)
-
-    if label == "DISPATCH_SUMMARY" and _DISPATCH_FAILURE_SENTINEL in summary:
-        intent_clause = f' while trying to: "{intent}"' if intent else ""
-        msg = (
-            f"I ran into a problem{intent_clause} and couldn't complete the task. "
-            "Please try again."
-        )
-        logger.warning("JARVIS: Dispatch failure sentinel — short-circuiting root LLM")
-        app.output_manager.handle_response({"output": msg})
-        persist_assistant_turn(app, msg)
-        dismissed = app.goals.dismiss_completed()
-        if dismissed:
-            logger.info(f"JARVIS: Dismissed {len(dismissed)} completed goal(s)")
-        return
-
-    actual_label = label
-    if label == "DISPATCH_SUMMARY" and intent:
-        context += f"\nATTEMPTED_INTENT: {intent}"
-        if _is_failure_summary(summary):
-            actual_label = "DISPATCH_FAILED"
-
-    context += f"\n{actual_label}: {summary}"
-
-    if actual_label == "DISPATCH_FAILED":
-        context += (
-            "\nSYSTEM: The task above failed. Tell the user what was attempted "
-            "(see ATTEMPTED_INTENT) and that it did not succeed. "
-            "Do not fabricate a success."
-        )
+    context += f"\n{label}: {summary}"
 
     response = await ask_llm(app, logger, context, tag="root-chain")
     await app._act_on_root_response(response, depth + 1)
+
+
+async def _continue_root(
+    app: Any,
+    logger: Logger,
+    extra: str,
+    depth: int,
+    tag: str,
+    max_chain_depth: int,
+) -> None:
+    """Re-enter ROOT with extra context injected (used by run handler)."""
+    app.llm.switch_mode("root")
+    context = build_root_context(app, logger)
+    context += f"\n{extra}"
+    response = await ask_llm(app, logger, context, tag=tag)
+    await app._act_on_root_response(response, depth + 1)
+
+
+async def _run_handle(
+    app: Any,
+    logger: Logger,
+    parsed: dict,
+    depth: int,
+    max_chain_depth: int,
+) -> None:
+    """Handle the 'run' action: discover → (auto-install) → dispatch → wait → respond."""
+    from ..dispatch.tool_discovery import discover_tools as _discover_tools
+
+    intent = parsed.get("intent", "")
+    emit_activity(app, f"Running: {intent[:60]}…", kind="dispatch")
+
+    # Phase 1: discover tools
+    tool_results = await _discover_tools(
+        adapter=app.dispatch,
+        logger=logger,
+        tasks=[{"intent": intent}],
+        embeddings=get_embeddings(app),
+    )
+
+    if not tool_results:
+        logger.warning(f"JARVIS: run — no tools found for '{intent}'")
+        await _continue_root(
+            app, logger,
+            f"NO_TOOLS_FOUND: Could not find any tool for '{intent}'. "
+            "MUST retry with a more specific or different intent. "
+            "Only give up and respond to the user after 2+ retries.",
+            depth, "root-run-no-tools", max_chain_depth,
+        )
+        return
+
+    # Phase 1b: if only CANDIDATE_SERVERS returned, auto-install the first one
+    if "MATCHED_TOOLS" not in tool_results and "CANDIDATE_SERVERS" in tool_results:
+        server_id = _first_candidate_id(tool_results)
+        if server_id:
+            emit_activity(app, f"Installing {server_id}…", kind="dispatch")
+            install_result = await app.dispatch.install_server(server_id)
+            if "error" not in install_result:
+                logger.info(f"JARVIS: run — auto-installed '{server_id}'")
+                await app.dispatch.auto_index_server(
+                    server_id=server_id,
+                    embeddings=get_embeddings(app),
+                )
+                # Re-discover now that server is installed
+                tool_results = await _discover_tools(
+                    adapter=app.dispatch,
+                    logger=logger,
+                    tasks=[{"intent": intent}],
+                    embeddings=get_embeddings(app),
+                )
+            else:
+                logger.warning(
+                    f"JARVIS: run — auto-install failed for '{server_id}': "
+                    f"{install_result.get('error')}"
+                )
+
+    if not tool_results or "MATCHED_TOOLS" not in tool_results:
+        await _continue_root(
+            app, logger,
+            f"NO_TOOLS_FOUND: Could not find any installed tool for '{intent}'. "
+            "MUST retry with a more specific or different intent. "
+            "Only give up and respond to the user after 2+ retries.",
+            depth, "root-run-no-tools-after-install", max_chain_depth,
+        )
+        return
+
+    # Phase 2: hidden LLM dispatch call — produce concrete tasks
+    dispatch_context = build_root_context(app, logger)
+    dispatch_context += f"\n{tool_results}"
+    dispatch_context += (
+        f"\nSYSTEM: Tools found for '{intent}'. "
+        "Output a dispatch action with concrete tasks now. "
+        "Use only tool names from MATCHED_TOOLS above. "
+        "Format: {{\"action\": \"dispatch\", \"tasks\": [{{\"server\": \"<id>\", "
+        "\"tool\": \"<name>\", \"params\": {{}}}}]}}"
+    )
+    app.llm.switch_mode("root")
+    dispatch_response = await ask_llm(app, logger, dispatch_context, tag="root-run-dispatch")
+    dispatch_parsed = app.task_parser.parse(dispatch_response)
+
+    tasks = dispatch_parsed.get("tasks") if dispatch_parsed.get("action") == "dispatch" else None
+    if not tasks:
+        logger.warning("JARVIS: run — dispatch step didn't yield tasks; falling back")
+        await _continue_root(app, logger, tool_results, depth, "root-run-fallback", max_chain_depth)
+        return
+
+    # Phase 3: execute dispatch
+    result = await dispatch_send(app, logger, tasks)
+    if isinstance(result, dict) and result.get("awaiting_confirmation"):
+        return
+
+    # Phase 4: auto-wait if dispatch returned PIDs
+    pids = []
+    if isinstance(result, dict):
+        pids = result.get("pids", [])
+
+    if pids and app.dispatch.is_connected:
+        app._pending_dispatch_pids = pids
+        wait_result = await app.dispatch.wait_task(pids)
+        extra = f"WAIT_RESULT: {compact_payload_for_llm(wait_result)}"
+    elif isinstance(result, dict) and "error" in result:
+        extra = f"DISPATCH_ERROR: {compact_payload_for_llm(result)}"
+    else:
+        extra = f"DISPATCH_RESULT: {compact_payload_for_llm(result)}"
+
+    await _continue_root(app, logger, extra, depth, "root-run-result", max_chain_depth)
+
+
+def _first_candidate_id(tool_results: str) -> str:
+    """Extract the first server ID from a CANDIDATE_SERVERS block."""
+    in_candidates = False
+    for line in tool_results.splitlines():
+        if line.startswith("CANDIDATE_SERVERS"):
+            in_candidates = True
+            continue
+        if in_candidates and line.startswith("  ") and not line.startswith("   "):
+            candidate_id = line.strip().split()[0]
+            if candidate_id:
+                return candidate_id
+    return ""
 
 
 async def act_on_root_response(
@@ -89,15 +176,13 @@ async def act_on_root_response(
     depth: int,
     max_chain_depth: int,
 ) -> None:
-    """Handle a ROOT-mode LLM response.
-
-    Unified mode: the root LLM handles all actions in a single loop.
-    Primary path: run(intent) -> system discovers+dispatches+waits -> respond.
-    """
+    """Handle a ROOT-mode LLM response."""
     if depth >= max_chain_depth:
         logger.error("JARVIS: Max chain depth reached, forcing respond")
         app.output_manager.handle_response(
-            {"output": "I got stuck in a loop. Could you try again?"}
+            {
+                "output": "I got stuck in a loop. Could you try again?",
+            }
         )
         return
 
@@ -105,42 +190,28 @@ async def act_on_root_response(
 
     if "error" in parsed:
         logger.warning(f"JARVIS: Root parse error: {parsed['error']}")
-        context = build_root_context(app, logger)
-        context += (
-            "\nSYSTEM: Your last response was not a recognised action. "
-            "You MUST output a JSON object with an \"action\" field. "
-            'Valid actions: respond, run, find_tools, list_tools, install, dispatch, '
-            'wait, kill, defer, store, recall, search_memory, list_memory. '
-            'Example: {"action": "run", "intent": "what you need to do"}'
+        app.output_manager.handle_response(
+            {
+                "output": "I had trouble processing that. Could you try again?",
+            }
         )
-        retry_response = await ask_llm(
-            app, logger, context, tag="root-parse-error-retry"
-        )
-        retry_parsed = app.task_parser.parse(retry_response)
-        if "error" in retry_parsed:
-            logger.error("JARVIS: Root parse error on retry — giving up")
-            app.output_manager.handle_response(
-                {"output": "I had trouble processing that. Could you try again?"}
-            )
-        else:
-            await act_on_root_response(
-                app, logger, retry_response, depth + 1, max_chain_depth
-            )
         return
 
     action = parsed["action"]
     logger.info(f"JARVIS: Root action='{action}'")
-
     if action == "respond":
         emit_activity(app, "Composing response…", kind="llm")
-    elif action in ("run", "find_tools", "list_tools", "install", "dispatch", "wait", "kill", "defer"):
-        emit_activity(app, f"Tool action: {action}…", kind="dispatch")
+    elif action == "dispatch":
+        emit_activity(app, "Planning tool execution…", kind="dispatch")
     elif action in ("store", "recall", "search_memory", "list_memory"):
         emit_activity(app, f"Running memory action: {action}", kind="memory")
 
     apply_goal_updates(app, parsed.get("goal_updates", []))
 
-    # ------------------------------------------------------------------ respond
+    if action == "run":
+        await _run_handle(app, logger, parsed, depth, max_chain_depth)
+        return
+
     if action == "respond":
         output = parsed["output"]
         if not output.strip():
@@ -158,357 +229,14 @@ async def act_on_root_response(
         if Config.RESET_HISTORY_AFTER_RESPONSE:
             app.llm.reset_history()
 
-    # ----------------------------------------------------------------------- run
-    elif action == "run":
-        from ..dispatch.tool_discovery import discover_tools as _discover_tools
-        from .dispatch_flow import (
-            _extract_pids_from_result,
-            _signals_from_result,
-            dispatch_send,
-        )
-
-        intent = parsed.get("intent", "")
-        emit_activity(app, f"Running: {intent[:60]}…", kind="dispatch")
-        logger.info(f"JARVIS: run intent='{intent}'")
-
-        # Phase 1: discover tools
-        tool_results = await _discover_tools(
-            adapter=app.dispatch,
-            logger=logger,
-            tasks=[{"intent": intent}],
-            embeddings=get_embeddings(app),
-        )
-
-        if not tool_results:
-            await _continue_root(
-                app,
-                logger,
-                f"NO_TOOLS_FOUND: No tools available for '{intent}'. "
-                "Tell the user this task cannot be completed right now.",
-                depth,
-                "root-run-no-tools",
-                max_chain_depth,
-            )
-            return
-
-        # Phase 2: hidden LLM call — ask model to dispatch with the discovered tools
-        dispatch_context = build_root_context(app, logger)
-        dispatch_context += f"\n{tool_results}"
-        dispatch_context += (
-            f"\nSYSTEM: Tools found for '{intent}'. "
-            "Output a dispatch action with the correct params now. "
-            "Use only tool names from MATCHED_TOOLS above."
-        )
-        dispatch_response = await ask_llm(
-            app, logger, dispatch_context, tag="root-run-dispatch"
-        )
-        dispatch_parsed = app.task_parser.parse(dispatch_response)
-
-        tasks = (
-            dispatch_parsed.get("tasks")
-            if dispatch_parsed.get("action") == "dispatch"
-            else None
-        )
-        if not tasks:
-            # Model didn't dispatch — fall back to showing tools normally
-            logger.warning(
-                f"JARVIS: run — dispatch step didn't yield tasks "
-                f"(got action='{dispatch_parsed.get('action')}')"
-            )
-            await _continue_root(
-                app, logger, tool_results, depth, "root-run-fallback", max_chain_depth
-            )
-            return
-
-        # Phase 3: execute dispatch
-        emit_activity(app, f"Dispatching {len(tasks)} task(s)…", kind="dispatch")
-        result = await dispatch_send(app, logger, tasks)
-
-        if isinstance(result, dict) and result.get("awaiting_confirmation"):
-            logger.info(
-                f"JARVIS: run — paused for confirmation id={result['confirmation_id']}"
-            )
-            emit_activity(
-                app, "Waiting for your confirmation before running tools.", kind="dispatch"
-            )
-            return
-
-        pending_pids = _extract_pids_from_result(result)
-
-        # Phase 4: auto-wait for result (no LLM call needed)
-        if pending_pids and app.dispatch.is_connected:
-            app._pending_dispatch_pids = pending_pids
-            emit_activity(app, "Waiting for task to complete…", kind="dispatch")
-            logger.info(f"JARVIS: run — auto-waiting for PIDs {pending_pids}")
-            wait_result = await app.dispatch.wait_task(pending_pids)
-            returned_signals = _signals_from_result(wait_result)
-            if returned_signals and hasattr(app, "events"):
-                app.events.mark_signals_seen(returned_signals)
-            if isinstance(wait_result, dict) and "error" in wait_result:
-                extra = f"WAIT_ERROR: {compact_payload_for_llm(wait_result)}"
-            else:
-                extra = f"WAIT_RESULT: {compact_payload_for_llm(wait_result)}"
-        elif isinstance(result, dict) and "error" in result:
-            extra = f"DISPATCH_ERROR: {compact_payload_for_llm(result)}"
-        else:
-            extra = f"DISPATCH_RESULT: {compact_payload_for_llm(result)}"
-
-        emit_activity(app, "Task complete.", kind="dispatch")
-        await _continue_root(
-            app, logger, extra, depth, "root-run-result", max_chain_depth
-        )
-
-    # --------------------------------------------------------------- find_tools
-    elif action == "find_tools":
-        from ..dispatch.tool_discovery import discover_tools as _discover_tools
-
-        intent = parsed.get("intent", "")
-        emit_activity(app, f"Searching for tools: {intent[:60]}…", kind="dispatch")
-        logger.info(f"JARVIS: find_tools intent='{intent}'")
-
-        tool_results = await _discover_tools(
-            adapter=app.dispatch,
-            logger=logger,
-            tasks=[{"intent": intent}],
-            embeddings=get_embeddings(app),
-        )
-
-        if tool_results:
-            await _continue_root(
-                app, logger, tool_results, depth, "root-find-tools", max_chain_depth
-            )
-        else:
-            _no_found = (
-                f"NO_TOOLS_FOUND: Searching for '{intent}' found no tools.\n"
-                "IMPORTANT: You MUST retry with find_tools using a more specific intent.\n"
-                "Use the EXACT TASK GOAL as intent — e.g. 'check python version', "
-                "'open Firefox', 'search web for X'.\n"
-                "Do NOT use generic tool types like 'run shell command'.\n"
-                "Only use respond if you have retried at least twice with different intents."
-            )
-            await _continue_root(
-                app,
-                logger,
-                _no_found,
-                depth,
-                "root-find-tools-empty",
-                max_chain_depth,
-            )
-
-    # --------------------------------------------------------------- list_tools
-    elif action == "list_tools":
-        server_id = parsed.get("server_id", "")
-        emit_activity(app, f"Listing tools for {server_id}…", kind="dispatch")
-        result = await app.dispatch.list_server_tools(server_id)
-        await _continue_root(
-            app,
-            logger,
-            f"TOOLS: {compact_payload_for_llm(result)}",
-            depth,
-            "root-list-tools",
-            max_chain_depth,
-        )
-
-    # ----------------------------------------------------------------- install
-    elif action == "install":
-        from .dispatch_flow import _collect_server_config
-
-        server_id = parsed.get("server_id", "")
-        emit_activity(app, f"Installing {server_id}…", kind="dispatch")
-        result = await app.dispatch.install_server(server_id)
-        extra = f"INSTALL_RESULT: {compact_payload_for_llm(result)}"
-        if "error" not in result and server_id:
-            await _collect_server_config(app, logger, server_id)
-            await app.dispatch.auto_index_server(
-                server_id=server_id,
-                embeddings=get_embeddings(app),
-            )
-        await _continue_root(app, logger, extra, depth, "root-install", max_chain_depth)
-
-    # --------------------------------------------------------------- dispatch
     elif action == "dispatch":
-        from .dispatch_flow import _extract_pids_from_result, dispatch_send
-
-        tasks = parsed.get("tasks", [])
-
-        # Graceful fallback: old-style dispatch with intent only (no tasks).
-        if not tasks:
-            intent = parsed.get("intent", "")
-            if intent:
-                logger.info(
-                    f"JARVIS: dispatch without tasks — routing to run: '{intent}'"
-                )
-                from ..dispatch.tool_discovery import discover_tools as _discover_tools
-
-                tool_results = await _discover_tools(
-                    adapter=app.dispatch,
-                    logger=logger,
-                    tasks=[{"intent": intent}],
-                    embeddings=get_embeddings(app),
-                )
-                if tool_results:
-                    await _continue_root(
-                        app, logger, tool_results, depth, "root-find-tools", max_chain_depth
-                    )
-                else:
-                    _no_found = (
-                        f"NO_TOOLS_FOUND: Searching for '{intent}' found no tools.\n"
-                        "IMPORTANT: You MUST retry with find_tools using a more specific intent.\n"
-                        "Do NOT use generic types like 'run shell command'.\n"
-                        "Only use respond if you have retried at least twice."
-                    )
-                    await _continue_root(
-                        app,
-                        logger,
-                        _no_found,
-                        depth,
-                        "root-find-tools-empty",
-                        max_chain_depth,
-                    )
-            else:
-                await _continue_root(
-                    app,
-                    logger,
-                    "SYSTEM: dispatch requires a tasks array. Use run first "
-                    "to discover and execute tools automatically.",
-                    depth,
-                    "root-dispatch-no-tasks",
-                    max_chain_depth,
-                )
-            return
-
-        emit_activity(app, f"Dispatching {len(tasks)} task(s)…", kind="dispatch")
-        result = await dispatch_send(app, logger, tasks)
-
-        if isinstance(result, dict) and result.get("awaiting_confirmation"):
-            logger.info(
-                f"JARVIS: Dispatch paused for confirmation "
-                f"id={result['confirmation_id']}"
-            )
-            emit_activity(
-                app,
-                "Waiting for your confirmation before running tools.",
-                kind="dispatch",
-            )
-            return
-
-        pending_pids = _extract_pids_from_result(result)
-        if pending_pids:
-            app._pending_dispatch_pids = pending_pids
-            logger.info(
-                f"JARVIS: Tracking {len(pending_pids)} dispatched PID(s): {pending_pids}"
-            )
-
-        if isinstance(result, dict) and "error" in result:
-            extra = f"DISPATCH_ERROR: {compact_payload_for_llm(result)}"
+        if "tasks" in parsed:
+            await app._dispatch_execute_tasks(parsed["tasks"], depth)
         else:
-            extra = f"DISPATCH_RESULT: {compact_payload_for_llm(result)}"
-            if pending_pids:
-                extra += f"\nRUNNING_PIDS: {pending_pids}"
+            summary = await app._run_dispatch_subchain(parsed["intent"])
+            await feed_root_summary(app, logger, "DISPATCH_SUMMARY", summary, depth)
 
-        emit_activity(app, "Tool results received.", kind="dispatch")
-        await _continue_root(app, logger, extra, depth, "root-dispatch-result", max_chain_depth)
-
-    # -------------------------------------------------------------------- wait
-    elif action == "wait":
-        from .dispatch_flow import (
-            _find_exits_for_pids,
-            _signals_from_result,
-        )
-
-        pids = parsed.get("pids") or getattr(app, "_pending_dispatch_pids", [])
-
-        if pids and app.dispatch.is_connected:
-            emit_activity(app, "Waiting for tasks to complete…", kind="dispatch")
-
-            current_window = await app.dispatch.get_signal_window()
-            already_done = _find_exits_for_pids(current_window, pids)
-
-            if already_done:
-                logger.info(
-                    f"JARVIS: PIDs {[s['pid'] for s in already_done]} already "
-                    "completed — using EXIT from window"
-                )
-                if hasattr(app, "events"):
-                    app.events.mark_signals_seen(already_done)
-                await _continue_root(
-                    app,
-                    logger,
-                    f"WAIT_RESULT: {compact_payload_for_llm({'signals': already_done})}",
-                    depth,
-                    "root-wait-done",
-                    max_chain_depth,
-                )
-            else:
-                logger.info(f"JARVIS: Blocking via wait_task for PIDs {pids}")
-                wait_result = await app.dispatch.wait_task(pids)
-                returned_signals = _signals_from_result(wait_result)
-                if returned_signals and hasattr(app, "events"):
-                    app.events.mark_signals_seen(returned_signals)
-
-                if isinstance(wait_result, dict) and "error" in wait_result:
-                    await _continue_root(
-                        app,
-                        logger,
-                        f"WAIT_ERROR: {compact_payload_for_llm(wait_result)}",
-                        depth,
-                        "root-wait-error",
-                        max_chain_depth,
-                    )
-                else:
-                    await _continue_root(
-                        app,
-                        logger,
-                        f"WAIT_RESULT: {compact_payload_for_llm(wait_result)}",
-                        depth,
-                        "root-wait-result",
-                        max_chain_depth,
-                    )
-        else:
-            logger.info("JARVIS: wait — no pids or dispatch not connected")
-            await _continue_root(
-                app,
-                logger,
-                "WAIT_RESULT: No active tasks to wait for.",
-                depth,
-                "root-wait-noop",
-                max_chain_depth,
-            )
-
-    # -------------------------------------------------------------------- kill
-    elif action == "kill":
-        from .dispatch_flow import do_kill
-
-        pids = parsed.get("pids", [])
-        emit_activity(app, f"Stopping task(s) {pids}…", kind="dispatch")
-        await do_kill(app, logger, pids)
-        await _continue_root(
-            app,
-            logger,
-            f"KILL_RESULT: Killed PID(s) {pids}",
-            depth,
-            "root-kill",
-            max_chain_depth,
-        )
-
-    # ------------------------------------------------------------------- defer
-    elif action == "defer":
-        from .dispatch_flow import do_defer
-
-        emit_activity(
-            app,
-            f"Setting reminder for {parsed['duration']}s (goal {parsed['goal_id']})…",
-            kind="dispatch",
-        )
-        await do_defer(
-            app,
-            logger,
-            parsed["goal_id"],
-            parsed["duration"],
-            parsed.get("reason", ""),
-        )
-
-    # ------------------------------------------------------------------- store
+    # -- Memory actions (direct, no sub-chain) --
     elif action == "store":
         if not app.contextor:
             await feed_root_summary(
@@ -519,6 +247,8 @@ async def act_on_root_response(
                 depth,
             )
             return
+        # Global scope when LLM explicitly sets scope="global";
+        # otherwise file under the active session.
         scope = parsed.get("scope", "session")
         sid = None if scope == "global" else app.sessions.current_id
         result = app.contextor.store(
@@ -527,10 +257,13 @@ async def act_on_root_response(
             session_id=sid,
         )
         await feed_root_summary(
-            app, logger, "STORE_RESULT", compact_payload_for_llm(result), depth
+            app,
+            logger,
+            "STORE_RESULT",
+            compact_payload_for_llm(result),
+            depth,
         )
 
-    # ------------------------------------------------------------------ recall
     elif action == "recall":
         if not app.contextor:
             await feed_root_summary(
@@ -546,10 +279,13 @@ async def act_on_root_response(
             session_id=app.sessions.current_id,
         )
         await feed_root_summary(
-            app, logger, "RECALL_RESULT", compact_payload_for_llm(result), depth
+            app,
+            logger,
+            "RECALL_RESULT",
+            compact_payload_for_llm(result),
+            depth,
         )
 
-    # ---------------------------------------------------------- search_memory
     elif action == "search_memory":
         if not app.contextor:
             await feed_root_summary(
@@ -557,7 +293,11 @@ async def act_on_root_response(
                 logger,
                 "SEARCH_MEMORY_RESULT",
                 json.dumps(
-                    {"results": [], "available": False, "reason": "Memory is disabled"}
+                    {
+                        "results": [],
+                        "available": False,
+                        "reason": "Memory is disabled",
+                    }
                 ),
                 depth,
             )
@@ -571,10 +311,13 @@ async def act_on_root_response(
             include_global=True,
         )
         await feed_root_summary(
-            app, logger, "SEARCH_MEMORY_RESULT", compact_payload_for_llm(result), depth
+            app,
+            logger,
+            "SEARCH_MEMORY_RESULT",
+            compact_payload_for_llm(result),
+            depth,
         )
 
-    # ------------------------------------------------------------- list_memory
     elif action == "list_memory":
         if not app.contextor:
             await feed_root_summary(
@@ -585,37 +328,13 @@ async def act_on_root_response(
                 depth,
             )
             return
-        result = app.contextor.list_themes(session_id=app.sessions.current_id)
+        result = app.contextor.list_themes(
+            session_id=app.sessions.current_id,
+        )
         await feed_root_summary(
-            app, logger, "LIST_MEMORY_RESULT", compact_payload_for_llm(result), depth
+            app,
+            logger,
+            "LIST_MEMORY_RESULT",
+            compact_payload_for_llm(result),
+            depth,
         )
-
-    # ---------------------------------------------------------- rename_session
-    elif action == "rename_session":
-        title = parsed.get("title", "")
-        if title and app.sessions.current:
-            app.sessions.rename(title)
-            app.sessions.current.title = title
-            if hasattr(app, "schedule_sidebar_refresh"):
-                app.schedule_sidebar_refresh()
-            logger.info(f"JARVIS: Session silently renamed to '{title}'")
-        context = build_root_context(app, logger)
-        retry_response = await ask_llm(app, logger, context, tag="root-post-rename")
-        await app._act_on_root_response(retry_response, depth + 1)
-
-    # ---------------------------------------------------------- unknown action
-    else:
-        logger.warning(
-            f"JARVIS: Unknown root action '{action}' — retrying with valid-action prompt"
-        )
-        context = build_root_context(app, logger)
-        context += (
-            f"\nSYSTEM: '{action}' is not a valid action. "
-            "Valid actions: respond, run, find_tools, list_tools, install, dispatch, "
-            "wait, kill, defer, store, recall, search_memory, list_memory. "
-            "Output one of those now."
-        )
-        retry_response = await ask_llm(
-            app, logger, context, tag="root-unknown-action"
-        )
-        await app._act_on_root_response(retry_response, depth + 1)


### PR DESCRIPTION
When browse_vectors_batch returns {"results": []} (empty outer list rather than [[]]), the per-task fallback loop never ran and discover_tools returned nothing even with 19 known servers. Added a global fallback: if embedding search produces zero results, run keyword_fallback for all tasks. Keyword search hits search_servers which queries the full catalog including uninstalled servers, surfacing them as CANDIDATE_SERVERS so the run handler can install and dispatch.