### PR TITLE
fix(lifecycle): correct event merger start call

### DIFF
--- a/jarvis/runtime/lifecycle.py
+++ b/jarvis/runtime/lifecycle.py
@@ -75,7 +75,7 @@ async def start_runtime_services(
     """Start event sources and optional socket/voice runtime services."""
     user_source = resolve_user_source(app)
     app.events.start(
-        signal_source=app._await_dispatch_signal,
+        signal_window_source=app.dispatch.get_signal_window,
         user_source=user_source,
     )
 


### PR DESCRIPTION
signal_source → signal_window_source (correct kwarg name) app._await_dispatch_signal → app.dispatch.get_signal_window (correct method)

https://claude.ai/code/session_01LtSUNQhUVnpY2dmPsydsP3