### PR TITLE
ci: add notify-parent workflow

### DIFF
--- a/.github/workflows/notify-parent.yml
+++ b/.github/workflows/notify-parent.yml
@@ -1,0 +1,17 @@
+name: Notify Parent Repo
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify jarvisos of new commit
+        run: |
+          curl -s -X POST \
+            -H "Authorization: token ${{ secrets.ORG_PAT }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/JarvisOSLinux/jarvisos/dispatches \
+            -d "{\"event_type\":\"subsystem-update\",\"client_payload\":{\"repo\":\"Project-JARVIS\",\"sha\":\"${{ github.sha }}\",\"ref\":\"${{ github.ref }}\"}}"


### PR DESCRIPTION
## What
Notifies the `jarvisos` parent repo when this repo pushes to `main`. Jarvisos records the new commit SHA in `versions.lock` via `track-subsystems.yml`.

## Requirement
**`ORG_PAT` secret must be set in this repo** (Settings → Secrets and variables → Actions → New repository secret).
The PAT needs `repo` scope and must belong to an account with write access to `JarvisOSLinux/jarvisos`.

## Flow
```
push to main → notify-parent.yml
  → POST /repos/JarvisOSLinux/jarvisos/dispatches
      → track-subsystems.yml updates versions.lock
```