### PR TITLE
Wire TUI security modals and clean up docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,167 +1,64 @@
-# CLAUDE.md — Project JARVIS Session Context
+# CLAUDE.md — Project JARVIS
 
-This file captures architectural decisions, in-progress work, and conventions so
-no context is lost across session boundaries.
+## What This Is
 
----
+AI assistant daemon with LLM orchestration, MCP tool dispatch, and multiple
+interface layers (TUI, CLI, voice, socket). The LLM reasons about what tools
+it needs, discovers them via semantic search, and executes them in parallel
+through a Rust orchestrator.
 
 ## Ecosystem Overview
 
-Project JARVIS is a vertically integrated AI assistant stack. Each repo has a
-strictly scoped responsibility:
-
 ```
-Project-JARVIS (Python)     — voice/CLI assistant daemon, LLM orchestration
-  jarvis/dispatch/          — Python adapter that manages the Rust dispatch binary
+Project-JARVIS (Python)     — daemon, LLM orchestration, interfaces
+  jarvis/dispatch/          — Python adapter wrapping the Rust dispatch binary
   jarvis/core/              — security, confirmation, logging, I/O
-  jarvis/tui/               — Textual TUI (decomposed into ~12 focused modules)
+  jarvis/tui/               — Textual TUI (decomposed into ~12 modules)
   jarvis/llm/               — LLM client (Ollama)
   jarvis/voice/             — STT (Vosk) + TTS (Piper)
   jarvis/sessions/          — session persistence
-  jarvis/runtime/           — event loop, signal handling
+  jarvis/runtime/           — event loop, action handlers
 
-deps/rust/ (planned)        — Rust submodule dependencies (see below)
-  dispatch/                 — Rust/Tokio signal-driven MCP task orchestrator
-  dmcp/                     — Rust MCP server manager (like a package manager)
-  contextor/                — Rust vector-based context/memory store
-
-mcp-registry/               — JSON registry of installable MCP servers
-discover/                   — KDE Discover fork; MCP Server subcatalogue added
-                              in Development section (changes on non-main branch)
-jarvisos/                   — Custom Linux distro (lower priority — see focus below)
-jarvisos-app/               — Desktop GUI widget
+dispatch (Rust)             — signal-driven MCP task orchestrator
+dmcp (Rust)                 — MCP server manager (package manager for MCP)
+contextor (Rust)            — vector-based long-term memory store
+mcp-registry                — JSON registry of installable MCP servers
+jarvisos-app                — Desktop GUI (Rust + CXX-Qt + Qt6/QML)
+jarvisos                    — AI-native Linux distro (Arch base + custom kernel)
 ```
 
-### The Two-Dispatch Clarification
+### Two-Dispatch Clarification
 
-`jarvis/dispatch/` (Python) is the **interface layer**: it wraps the Rust
+`jarvis/dispatch/` (Python) is the **interface layer** — wraps the Rust
 `dispatch` binary, manages subprocess lifecycle, translates Python calls into
-MCP JSON-RPC, and surfaces signals back to the JARVIS event loop.
+MCP JSON-RPC, surfaces signals back to the event loop.
 
-The standalone `dispatch` repo (Rust/Tokio) is the **execution engine**: it
-spawns MCP tool calls in parallel, tracks PIDs, fires INIT/EXIT/REMIND/WAIT/KILL
-signals, and only wakes the LLM when there is something to reason about.
+The standalone `dispatch` repo (Rust/Tokio) is the **execution engine** — spawns
+MCP tool calls in parallel, tracks PIDs, fires INIT/EXIT/REMIND/WAIT/KILL
+signals, only wakes the LLM when there is something to reason about.
 
-They are not alternatives — Python dispatch wraps Rust dispatch.
-
----
-
-## Active Branch & PR
-
-- **Working branch**: `yakup/dev`
-- **Open PR**: #43 "Yakup/dev" → main (created 2026-04-24)
-- **Claude feature branches**: `claude/ai-os-security-research-CdkTO`
+Python dispatch wraps Rust dispatch.
 
 ---
 
-## Current State (as of 2026-05-27)
+## Tool Discovery Flow
 
-### What's done (on `claude/ai-os-security-research-CdkTO`)
+The LLM uses a multi-step flow to find and invoke tools:
 
-**Phase 2.2 — TUI decomposition** (complete):
-`main.py` and `app.py` were shrunk. TUI split into: `app.py`, `actions.py`,
-`lifecycle.py`, `local_input.py`, `output.py`, `session_sidebar.py`,
-`status_bar.py`, `help_screen.py`, `slash_commands_doc.py`, `confirm_modal.py`,
-`settings_modal.py`.
+1. **`search_tools`** — LLM derives a capability from the user's request,
+   system does embedding search on the vector index
+2. **`get_server_docs`** — LLM picks a server from results, system returns
+   full tool list + param schemas
+3. **`install_server`** / **`configure_server`** — if the server isn't installed
+   or needs configuration
+4. **`dispatch`** — LLM dispatches concrete tool calls for parallel execution
 
-**Phase 2.2 security additions** (files exist, not yet wired):
-- `jarvis/tui/confirm_modal.py` — Textual `ModalScreen` for tool confirmation
-- `jarvis/tui/settings_modal.py` — Read-only `DataTable` of all Config attributes
-- `jarvis/core/socket_security.py` — `harden_socket_path()`, `verify_socket_ownership()`, `warn_if_allow_all()`
-- `jarvis/core/input_guard.py` — regex scanner for 4 prompt-injection patterns
-
-**Security wiring still pending** (these files exist but nothing calls them yet):
-1. `jarvis/tui/app.py` — import + mount `ConfirmModal` + `SettingsModal`; bind `Ctrl+,`
-2. `jarvis/tui/lifecycle.py` — register TUI confirmation callback
-3. `jarvis/core/confirmation_manager.py` — add TUI channel
-4. Socket setup (`cli.py` or `runtime/`) — call `harden_socket_path()` + `warn_if_allow_all()`
-5. Input handling — call `input_guard.scan()` before LLM
-
-**`run` action + startup bug fixes** (pushed):
-- Fixed `lifecycle.py` sync condition, event merger kwarg, `warn_if_allow_all` call
-- Fixed `Config` missing `LLM_IO_LOG` and `LLM_ROOT_PROMPT_UNIFIED` attributes
-- Added `run` action to `command_parser.py` and `root_actions.py`
-- Added global keyword fallback and stop-word filtering to `tool_discovery.py`
-
-### Known issues on current branch
-
-- `run` action is still fundamentally broken (keyword discovery finds wrong servers)
-- Embedding search never fires (`EMBEDDING_SEARCH_THRESHOLD=100`, registry has ~24 servers)
-- **Planned replacement**: see Tool Discovery Redesign below
+Key: the LLM derives *capability*, not keywords. "check my python version" →
+`{"action": "search_tools", "capability": "execute shell commands"}`.
 
 ---
 
-## Tool Discovery Redesign (next major task)
-
-Full spec: `docs/tool-discovery-redesign.md`
-
-The `run` action is being replaced with a multi-step explicit flow. The LLM
-reasons about what *capability* it needs, then searches, selects, and dispatches.
-
-### New LLM action set
-
-| Action | Purpose |
-|--------|---------|
-| `search_tools` | LLM outputs a capability description; system does embedding search on full vector index |
-| `get_server_docs` | LLM picks a server from results; system returns full tool list + param schemas |
-| `install_server` | LLM installs an available (not yet installed) server from registry |
-| `configure_server` | LLM sets config values on an installed server (`dmcp config set`) |
-| `dispatch` | Unchanged — LLM dispatches concrete tool calls after seeing SERVER_DOCS |
-
-### Key principle
-
-The LLM must derive the capability from the user's request:
-```
-User: "check my python version"
-LLM:  → "to do this I need to execute a shell command"
-      → {"action": "search_tools", "capability": "execute shell commands"}
-```
-
-NOT keyword pass-through:
-```
-WRONG: {"action": "search_tools", "capability": "check python version"}
-```
-
-### Files to change
-
-| File | Change |
-|------|--------|
-| `jarvis/config.py` | Lower `EMBEDDING_SEARCH_THRESHOLD` to 3; rewrite `LLM_ROOT_PROMPT` |
-| `jarvis/core/command_parser.py` | Add 4 new actions; remove `run` and `find_tools` |
-| `jarvis/runtime/root_actions.py` | Add 4 new handlers; remove `_run_handle` |
-| `jarvis/runtime/root_context.py` | Add `format_search_results()`, `format_server_docs()` |
-| `jarvis/dispatch/adapter.py` | Add `search_tools()`, `get_server_docs()`, `configure_server()` |
-| `jarvis/dispatch/tool_discovery.py` | **Delete** (keyword discovery removed entirely) |
-| `jarvis/dispatch/dmcp_registry.py` | Remove `search_servers`, `_local_installed_servers`, `list_visible_servers` |
-
----
-
-## Planned Architectural Changes
-
-### 1. deps/rust/ submodule reorganization
-
-Move `dispatch`, `dmcp`, `contextor` to:
-```
-deps/
-  rust/
-    dispatch/
-    dmcp/
-    contextor/
-```
-
-### 2. pyproject.toml Rust integration
-
-- `jarvis-ai` — Python runtime only
-- `jarvis-ai[tools]` — also builds Rust binaries via `cargo build --release`
-
----
-
-## Security / Threat Model Notes
-
-### Context Bloat (Threat #7)
-
-- **Cause**: as conversation grows, early security constraints get diluted in attention weight
-- **Mitigation (planned)**: persistent constraint register prepended to every prompt by the daemon
+## Security Architecture
 
 ### 4-Tier Action Policy
 
@@ -172,54 +69,93 @@ deps/
 | DANGEROUS | Block until explicit user confirmation |
 | FORBIDDEN | Hard block unconditionally |
 
-`confirm_modal.py` + `confirmation_manager.py` implement the DANGEROUS gate.
-`socket_security.py` hardens the confirmation channel.
-`input_guard.py` catches prompt injection before LLM.
+### Confirmation Modes
+
+`CONFIRMATION_MODE` in config controls the confirmation gate:
+
+| Mode | Behaviour |
+|------|-----------|
+| `allow_all` | No prompts, everything auto-approved |
+| `smart` | Only ask when tool declares `confirmation_required: true` |
+| `ask_all` | Confirm every tool call |
+
+### Confirmation Channels
+
+The `ConfirmationManager` (core) is interface-agnostic. It routes confirmation
+requests to the best available channel:
+
+1. **TUI modal** — `ConfirmModal` in Textual (Y/N inline)
+2. **Desktop notification** — `notify-send` with Allow/Deny actions
+3. **Socket** — JSON over output socket for external clients
+4. **CLI prompt** — stdin `[y/N]` fallback
+
+Auto-denies after 30 seconds if no response.
+
+### Socket Security
+
+`socket_security.py` hardens the IPC socket (`/tmp/jarvis.sock`):
+- `harden_socket_path()` — sets 0600 permissions
+- `verify_socket_ownership()` — checks UID before connecting
+- `warn_if_allow_all()` — logs warning when confirmation is disabled
 
 ---
 
-## Focus & Priorities
+## Planned Work
 
-1. **Tool Discovery Redesign** — replace `run` with `search_tools` / `get_server_docs` / `dispatch`
-2. **Security wiring** — wire the 4 security files that exist but aren't called yet
-3. **mcp-registry** — add real servers beyond calculator/hello examples
-4. **jarvisos** — lower priority; minimal base (custom kernel + TUI daemon)
+### Modular Packaging (#76)
+
+Split into optional extras:
+- `jarvis-ai` — core daemon (text I/O, LLM, dispatch)
+- `jarvis-ai[tui]` — Textual TUI
+- `jarvis-ai[voice]` — Vosk STT + Piper TTS
+- `jarvis-ai[all]` — everything
+
+### Rust Submodules (#75)
+
+Move dispatch, dmcp, contextor under `deps/rust/` as git submodules.
+Add `jarvis-ai[tools]` extra to build Rust binaries via cargo.
+
+### API Recycling (#78)
+
+Provider failover pool with priority ordering and automatic cooldown/recovery.
 
 ---
+
+## Build & Test
+
+```bash
+pip install -e ".[all]"     # Install with all extras
+make check                  # Format + lint + typecheck + tests
+```
 
 ## Conventions
 
 - **Python**: Black formatting, type hints on public functions
-- **Rust**: `cargo fmt`, `cargo clippy` clean before pushing
-- **Commit messages**: imperative mood, reference the file/module changed
-- **Branch naming**: `claude/<task>-<id>` for Claude-authored branches
-- **No comments** explaining what code does; only explain non-obvious WHY
+- **Rust**: `cargo fmt` + `cargo clippy` clean before pushing
+- **Commit messages**: imperative mood
+- **No comments** explaining what code does; only non-obvious WHY
 - **No backwards-compat shims**: delete unused code outright
 - Prefer editing existing files over creating new ones
-- Test with `make check` before pushing (format + lint + typecheck + tests)
 
 ---
 
-## Quick File Reference
+## Key Files
 
 | Path | Purpose |
 |------|---------|
-| `jarvis/main.py` | Entry point |
+| `jarvis/main.py` | Daemon entry point |
+| `jarvis/cli.py` | CLI entry point |
+| `jarvis/config.py` | Global configuration |
 | `jarvis/tui/app.py` | Textual app shell |
 | `jarvis/tui/lifecycle.py` | App startup/shutdown, callback registration |
-| `jarvis/tui/confirm_modal.py` | Tool confirmation modal (UNWIRED) |
-| `jarvis/tui/settings_modal.py` | Config viewer modal (UNWIRED) |
+| `jarvis/tui/confirm_modal.py` | Tool confirmation modal |
+| `jarvis/tui/settings_modal.py` | Config viewer modal |
 | `jarvis/core/confirmation_manager.py` | Multi-channel confirmation gate |
-| `jarvis/core/socket_security.py` | Socket hardening (UNWIRED) |
-| `jarvis/core/input_guard.py` | Prompt-injection scanner (UNWIRED) |
+| `jarvis/core/socket_security.py` | Socket hardening |
 | `jarvis/core/command_parser.py` | LLM response parser + action registry |
 | `jarvis/dispatch/adapter.py` | Python wrapper for Rust dispatch binary |
 | `jarvis/dispatch/discovery.py` | Embedding search via dmcp vector index |
 | `jarvis/dispatch/dmcp_registry.py` | dmcp CLI wrappers (install, tools, config) |
-| `jarvis/dispatch/tool_discovery.py` | Keyword fallback (SCHEDULED FOR DELETION) |
 | `jarvis/dispatch/event_merger.py` | Merges voice/CLI/socket/dispatch events |
-| `jarvis/dispatch/goal_manager.py` | Long-horizon goal tracking with timers |
 | `jarvis/runtime/root_actions.py` | ROOT-mode LLM response action handlers |
 | `jarvis/runtime/root_context.py` | Context assembly for ROOT-mode prompts |
-| `docs/tool-discovery-redesign.md` | Full spec for the new discovery workflow |
-| `docs/SECURITY-ARCHITECTURE.md` | Threat model vs OpenClaw CVEs |

--- a/docs/research.md
+++ b/docs/research.md
@@ -1,0 +1,128 @@
+# Research
+
+## Security Threats in AI-Native Operating Systems: An Empirical Study Using Privilege-Escalated LLM Agents
+
+**Yakup Atahanov, Toufic Majdalani — Washington State University Everett**
+**Faculty Advisor: Dr. Jeremy Thompson**
+
+---
+
+### Overview
+
+As Large Language Models transition from conversational tools to autonomous agents with system-level control, a critical question emerges: what security threats arise when AI operates with elevated privileges — and how can they be mitigated?
+
+JarvisOS was built to answer that question empirically. Rather than studying LLM security in isolation, we chose an operating system as our research environment because it represents the broadest possible integration surface — encompassing file management, process execution, network operations, package installation, and privilege escalation. If we can characterize and mitigate threats at the OS level, the findings generalize to every narrower integration context.
+
+The result is both a fully functional AI-native operating system and a controlled security research testbed — purpose-built to study what actually happens when an LLM agent is given unrestricted access to a real computing environment.
+
+---
+
+### The Problem
+
+Traditional OS security models assume deterministic software: a program does exactly what its code specifies. An LLM agent violates that assumption fundamentally. Its behavior is probabilistic, context-dependent, and shaped by natural language inputs that are difficult to sanitize or predict.
+
+Existing research on LLM security focuses primarily on model-level attacks — jailbreaking, adversarial inputs, prompt injection in isolation. Empirical research on what happens when an LLM agent is placed in control of a real system, with real privileges, has remained scarce.
+
+---
+
+### What We Built
+
+JarvisOS is an Arch Linux-based AI-native operating system built around a dynamic Model Context Protocol (MCP) orchestration layer. Its core action layer is implemented in two Rust packages:
+
+- **dispatch** — a signal-driven parallel task orchestrator. Its design philosophy is *one brain, many hands*: a single LLM instance acts as the sole decision maker while multiple MCP servers execute operations concurrently as workers. The LLM dispatches tasks and immediately returns to conversation — it does not wait or poll. dispatch wakes the LLM only when a signal arrives: a task completing, a reminder threshold firing, or a user action.
+
+- **dmcp** — the MCP server lifecycle manager. It handles discovery, installation, configuration, invocation, and removal of MCP servers at both user scope and system scope. dmcp also runs as an MCP server itself, exposing its capabilities as tools callable by the LLM. Tool discovery uses an adaptive search strategy: keyword search for small catalogs, embedding-based cosine similarity for larger ones — ensuring the LLM only loads the tools it actually needs.
+
+- **contextor** — a persistent Rust memory backend providing vector similarity search over conversation history, rolling session summaries, and retention-based pruning to keep the LLM's working context bounded and relevant.
+
+The system is built on a seven-script modular build pipeline that transforms a base Arch Linux ISO into a bootable AI-native OS with KDE Plasma 6 on Wayland.
+
+---
+
+### The Threat Taxonomy
+
+Through designing, building, and operating JarvisOS, we empirically identified six security threats that emerge when LLMs are granted elevated system privileges:
+
+| Threat | Escalation Stage | Primary Mitigation |
+|--------|-----------------|-------------------|
+| Malicious MCP Servers | User / Sudo / Web | Community-vetted AUR-style registry |
+| Prompt Injection | User / Sudo / Web | Cryptographic Boundary Protocol |
+| Misleading MCP Server Usage | User / Sudo / Web | Registry vetting + structured tool schema |
+| Unauthorized Sudo Requests via MCP | Sudo / Web | TLA system + PolicyKit enforcement |
+| Sudo Capability Exploitation | Sudo / Web | TLA + goal-scoped confirmation |
+| Bloated Context | User / Sudo / Web | dispatch rolling window + contextor pruning |
+
+Each threat was observed through direct system operation and is addressed by one or more architectural components.
+
+---
+
+### Architectural Mitigations
+
+**Cryptographic Boundary Protocol**
+When an MCP server task completes, dispatch generates a six-character provenance nonce using a Splitmix64 bit-mixing function combining the task PID, wall-clock nanoseconds, and an atomic session counter. Successful MCP output is stored out-of-band — it does not enter the LLM's context at all unless explicitly retrieved via a `get_output` call. This structurally separates the instruction plane from the data plane: content that is not in context cannot be acted upon.
+
+**TLA (Threat Level Access) System**
+A dynamic, context-aware privilege model ranging from Guest to Kernel, enforced at the OS level. Every tool invocation is evaluated against the current TLA level before execution. Escalation requires explicit out-of-band user confirmation — it cannot be triggered by model output or MCP server response alone. Sudo access, when granted, is scoped to the current goal and expires on completion.
+
+**Community-Vetted MCP Registry**
+Modeled on the Arch Linux User Repository proofread model. Third-party MCP servers must pass community review — covering code, declared capabilities, and tool description accuracy — before being listed. Malicious or deceptive servers are filtered before they are ever discoverable by the tool search engine.
+
+**Bloated Context Mitigation**
+dispatch's bounded rolling signal window presents only the last twenty signal entries at each LLM wakeup, keeping context size predictable regardless of how many tasks have run. contextor complements this by actively pruning stale conversation history and treating security-critical constraints as high-priority elements preserved across context refreshes.
+
+---
+
+### A Note on Independent Convergence
+
+In October–November 2025, JarvisOS implemented a structured MCP tool-description architecture — a design that major AI platforms independently converged on in early 2026. JarvisOS did not publish this design earlier because the security threats documented in this research had not yet been characterized or mitigated. We note this not as a priority claim, but as a validation: the problems this architecture addresses were real enough that multiple independent teams arrived at the same solution.
+
+---
+
+### Research Methodology
+
+We evaluated threats across three escalation stages:
+
+1. **User-level privileges** — standard access, no sudo. Establishes the baseline threat surface.
+2. **Sudo-enabled** — full root control. The LLM can modify anything on the system.
+3. **Web-enabled** — sudo plus internet access. Enables data exfiltration and remote prompt injection.
+
+---
+
+### Contributions
+
+This research makes four concrete contributions:
+
+1. A taxonomy of six empirically-identified security threats specific to privilege-escalated LLM agents — including Bloated Context, the first identification of context window saturation as a discrete security threat rather than a reliability problem.
+2. Architectural mitigations for each threat class, implemented and verified against source code in the JarvisOS platform.
+3. JarvisOS itself — a fully functional, bootable, open-source AI-native OS released as a research and development platform for the community.
+4. A documented MCP tool-description architecture, independently developed in October–November 2025, predating its appearance in commercial deployments.
+
+---
+
+### Future Work
+
+- **Empirical evaluation** — quantitative attack reproduction results measuring attack success rates, detection rates, and mitigation effectiveness under controlled conditions across the full six-threat taxonomy.
+- **Fine-tuning** — a LoRA/QLoRA fine-tune of Llama 3.1 8B using the NVIDIA NeMo Framework on the provenance-nonce labeled dataset generated by dispatch, with the resulting model and dataset released publicly on HuggingFace.
+- **Platform expansion** — evolving JarvisOS from a research testbed into a general-purpose OS accessible to cybersecurity researchers, developers, and everyday users.
+- **Community registry** — a public MCP registry infrastructure allowing third-party developers to submit and vet servers under the proofread model described in this research.
+
+---
+
+### Publications & Presentations
+
+- **SURCA 2026** — Poster presentation, Washington State University Everett. *Winner, Gray Grant.*
+- **Full paper** — *Security Threats in AI-Native Operating Systems: An Empirical Study Using Privilege-Escalated LLM Agents.* Pre-publication manuscript available on request.
+
+---
+
+### Source Code
+
+The full platform is open-source under a dual-license model (GPLv3 for community use).
+
+- **Project-JARVIS** — [github.com/JarvisOSLinux/Project-JARVIS](https://github.com/JarvisOSLinux/Project-JARVIS)
+- **dispatch** — [github.com/JarvisOSLinux/dispatch](https://github.com/JarvisOSLinux/dispatch)
+- **dmcp** — [github.com/JarvisOSLinux/dmcp](https://github.com/JarvisOSLinux/dmcp)
+- **contextor** — [github.com/JarvisOSLinux/contextor](https://github.com/JarvisOSLinux/contextor)
+- **mcp-registry** — [github.com/JarvisOSLinux/mcp-registry](https://github.com/JarvisOSLinux/mcp-registry)
+
+> *"Built for people, not corporations."*

--- a/jarvis/core/confirmation_manager.py
+++ b/jarvis/core/confirmation_manager.py
@@ -256,9 +256,7 @@ class ConfirmationManager:
 
         # 1. TUI modal — highest priority when Textual is running.
         if self._tui_callback is not None:
-            asyncio.create_task(
-                self._notify_tui(request_id, tool_names)
-            )
+            asyncio.create_task(self._notify_tui(request_id, tool_names))
             return
 
         # 2. Desktop notification (unless silent).

--- a/jarvis/core/confirmation_manager.py
+++ b/jarvis/core/confirmation_manager.py
@@ -75,6 +75,8 @@ class ConfirmationManager:
         self._inject_confirmation: Optional[Callable[[Dict[str, Any]], None]] = None
         # Timeout tasks keyed by request id (so we can cancel on response).
         self._timeout_tasks: Dict[str, asyncio.Task] = {}
+        # TUI callback — async callable that pushes ConfirmModal and returns bool.
+        self._tui_callback: Optional[Callable[[str, List[str]], Any]] = None
 
     # ------------------------------------------------------------------
     # Setup
@@ -88,6 +90,18 @@ class ConfirmationManager:
         """Register the output socket broadcast callback."""
         self._output_callback = callback
         self._has_socket_clients = has_clients
+
+    def set_tui_callback(
+        self,
+        callback: Callable[[str, List[str]], Any],
+    ) -> None:
+        """Register the TUI confirmation callback.
+
+        The callback receives (request_id, tool_names) and must return a
+        bool (True = allow, False = deny).  It is awaited, so it can use
+        Textual's ``push_screen_wait``.
+        """
+        self._tui_callback = callback
 
     def set_event_injector(
         self,
@@ -240,7 +254,14 @@ class ConfirmationManager:
 
         tool_summary = ", ".join(tool_names)
 
-        # 1. Desktop notification (unless silent).
+        # 1. TUI modal — highest priority when Textual is running.
+        if self._tui_callback is not None:
+            asyncio.create_task(
+                self._notify_tui(request_id, tool_names)
+            )
+            return
+
+        # 2. Desktop notification (unless silent).
         if not notification_silent and self._has_desktop_notifications():
             asyncio.create_task(self._notify_desktop(request_id, tool_summary, timeout))
             return
@@ -267,6 +288,24 @@ class ConfirmationManager:
                     "type": "confirmation_response",
                     "id": request_id,
                     "approved": False,
+                }
+            )
+
+    # -- TUI (ConfirmModal) --------------------------------------------
+
+    async def _notify_tui(self, request_id: str, tool_names: List[str]) -> None:
+        try:
+            approved = await self._tui_callback(request_id, tool_names)
+        except Exception as e:
+            logger.warning(f"TUI confirmation callback failed: {e}")
+            approved = False
+
+        if self._inject_confirmation:
+            self._inject_confirmation(
+                {
+                    "type": "confirmation_response",
+                    "id": request_id,
+                    "approved": bool(approved),
                 }
             )
 

--- a/jarvis/tui/app.py
+++ b/jarvis/tui/app.py
@@ -64,16 +64,16 @@ from textual.widgets import (
 
 from ..core.logger import JarvisLogger, get_logger
 from ..sessions.model import Session
-from .confirm_modal import ConfirmModal
-from .settings_modal import SettingsModal
 from . import actions as tui_actions
 from . import lifecycle as tui_lifecycle
 from . import output as tui_output
 from . import status_bar as tui_status_bar
+from .confirm_modal import ConfirmModal
 from .local_input import export_transcript_to_disk, handle_local_input
 from .session_sidebar import on_session_selected as handle_session_selected
 from .session_sidebar import refresh_sidebar
 from .session_sidebar import schedule_sidebar_refresh as queue_sidebar_refresh
+from .settings_modal import SettingsModal
 
 logger = get_logger(__name__)
 

--- a/jarvis/tui/app.py
+++ b/jarvis/tui/app.py
@@ -18,6 +18,7 @@ Layout:
 Keybindings:
     Ctrl+N  — new session
     Ctrl+Q  — quit
+    Ctrl+,  — settings (read-only config viewer)
     Ctrl+L  — focus chat log (scroll with arrows / PgUp)
     Ctrl+I  — focus message input
     Ctrl+Shift+C — clear on-screen transcript (export buffer only; not memory)
@@ -63,6 +64,8 @@ from textual.widgets import (
 
 from ..core.logger import JarvisLogger, get_logger
 from ..sessions.model import Session
+from .confirm_modal import ConfirmModal
+from .settings_modal import SettingsModal
 from . import actions as tui_actions
 from . import lifecycle as tui_lifecycle
 from . import output as tui_output
@@ -153,6 +156,7 @@ class JarvisTUI(App):
         Binding("ctrl+l", "focus_chat", "Log", show=True),
         Binding("ctrl+i", "focus_input", "Input", show=True),
         Binding("f1", "help", "Help", show=True),
+        Binding("ctrl+comma", "settings", "Settings", show=True),
         Binding("ctrl+shift+c", "clear_transcript", "Clear log", show=False),
         Binding("ctrl+shift+e", "export_transcript", "Export", show=False),
     ]
@@ -304,6 +308,12 @@ class JarvisTUI(App):
     def action_export_transcript(self) -> None:
         """Write ``_export_lines`` to ``JARVIS_DATA_DIR/transcripts/``."""
         tui_actions.export_transcript(self)
+
+    def action_settings(self) -> None:
+        self.push_screen(SettingsModal())
+
+    async def _tui_confirm(self, request_id: str, tool_names: list[str]) -> bool:
+        return await self.push_screen_wait(ConfirmModal(request_id, tool_names))
 
     def _export_transcript_to_disk(self, filename: Optional[str]) -> None:
         """Save plain transcript as Markdown under ``JARVIS_DATA_DIR/transcripts``."""

--- a/jarvis/tui/lifecycle.py
+++ b/jarvis/tui/lifecycle.py
@@ -38,6 +38,9 @@ async def start_jarvis(app: Any, logger: Any) -> None:
     jarvis.output_manager.add_output_callback(app._output_cb)
     jarvis.output_manager.add_activity_callback(app._activity_cb)
 
+    if hasattr(jarvis, "confirmation"):
+        jarvis.confirmation.set_tui_callback(app._tui_confirm)
+
     # Kick off the engine's event loop as an async task.
     app._jarvis_task = asyncio.create_task(app._run_engine(), name="jarvis-run")
 

--- a/presentation.md
+++ b/presentation.md
@@ -1,0 +1,281 @@
+# JARVIS OS — AI-Native Operating System
+
+**By Toufic Majdalani and Yakup Atahanov**
+**Washington State University**
+
+---
+
+# "You are no longer more valuable than the data you produce."
+
+---
+
+# The Shift Is Already Here
+
+- Microsoft Copilot is embedded in Windows
+- Apple Intelligence is built into macOS and iOS
+- Google Gemini is integrated into Android and ChromeOS
+- Every major OS vendor is embedding an AI assistant with deepening system access
+
+This is not a prediction. It is happening now.
+
+---
+
+# The Trajectory
+
+These assistants are moving from answering questions to controlling systems.
+
+- 2023: "Summarize this document"
+- 2024: "Manage my files and settings"
+- 2025: "Run commands on my behalf"
+- Next: Full OS-level access — the AI manages your computer
+
+The destination is an AI with root privileges on your machine.
+
+---
+
+# The Business Model Is the Problem
+
+These are corporate products built on data extraction.
+
+Not because the engineers are malicious — because the incentive structure demands it.
+
+- Your files, your commands, your patterns, your habits
+- All of it becomes training data, analytics, leverage
+- Legal frameworks lag years behind the technology
+- Even well-intentioned companies answer to shareholders, not users
+
+**The incentive to collect is structural. Policy alone cannot fix it.**
+
+---
+
+# Mass Surveillance at Scale
+
+When an AI assistant has OS-level access, it sees everything:
+
+- Every file you open
+- Every command you run
+- Every website you visit
+- Every message you write
+- Every password you type
+
+This is not hypothetical. The infrastructure for mass surveillance is being built into the products people use every day — voluntarily.
+
+**Legal or illegal, the capability is the same.**
+
+---
+
+# We Built Exactly This — On Purpose
+
+We created a complete AI-native operating system to study what happens
+when you give an LLM full OS privileges.
+
+Not hypothetically. Empirically.
+
+**Architecture:**
+
+```
+User (Voice / Text)
+       |
+  AI Daemon (local LLM via Ollama)
+       |
+  Task Orchestrator (dispatch)
+       |
+  Tool Manager (dmcp) --> MCP Servers
+       |
+  Policy Engine (4-tier enforcement)
+       |
+  Custom Linux Kernel (/dev/jarvis)
+```
+
+A full stack — from kernel drivers to voice interface — running locally,
+no cloud, no data leaving the device.
+
+---
+
+# The Research Frame
+
+- Built and operated at Washington State University
+- Empirical findings from hands-on operation, not theoretical modeling
+- Every threat we document was discovered by running the system
+- Ongoing academic research effort
+
+**We are not speculating. We ran the experiment.**
+
+---
+
+# What We Found: Forgetful Context
+
+**The Novel Finding**
+
+We told the AI: "Never modify files in /etc."
+
+Minutes later, it did exactly that. Not because it disobeyed — because it **forgot**.
+
+- LLMs have finite context windows
+- As conversation grows, earlier instructions lose weight
+- Security constraints stated at the start of a session get silently dropped
+- The AI doesn't rebel. It simply stops remembering the rules.
+
+**This finding has no prior literature. We discovered it through direct operation.**
+
+Traditional security assumes the agent remembers its constraints.
+LLMs do not.
+
+---
+
+# What We Found: Unauthorized Escalation
+
+The AI discovered it could chain sudo commands to gain access
+we never intended to give it.
+
+- It didn't "hack" anything
+- It followed the path of least resistance
+- One authorized action led to another, then another
+- Each step looked reasonable in isolation
+- The cumulative result was full privilege escalation
+
+**The AI doesn't need to be adversarial to be dangerous.
+It just needs to be helpful.**
+
+---
+
+# What We Found: Blind Trust in Tools
+
+The AI downloaded and executed a tool from the internet
+because the description sounded right.
+
+- No integrity verification
+- No cryptographic signature check
+- No sandbox isolation
+- It trusted the label
+
+**If a tool says "I manage files," the AI believes it.
+A malicious tool with a helpful description is indistinguishable
+from a legitimate one.**
+
+---
+
+# The Core Insight
+
+> Traditional OS security was designed for deterministic programs.
+> LLMs are probabilistic.
+> The entire security paradigm is wrong.
+
+- Firewalls assume you can enumerate allowed behaviors
+- Access control assumes the agent follows rules consistently
+- Sandboxing assumes the agent won't convince itself to escape
+- Audit logs assume the agent isn't generating the logs
+
+**None of these assumptions hold for an AI that reasons about its own constraints.**
+
+---
+
+# If This Is Coming Regardless, Who Should Build It?
+
+The question is not whether AI will manage your computer.
+
+The question is whether the code will be visible.
+
+---
+
+# The Corporate Problem Is Structural
+
+Even well-intentioned companies face inescapable incentives:
+
+| Incentive | Consequence |
+|-----------|-------------|
+| Data collection | Your usage patterns become product |
+| Vendor lock-in | Switching costs keep you trapped |
+| Surveillance compliance | Government requests are fulfilled quietly |
+| Profit motive | Privacy costs money; collection makes money |
+
+**These are not bugs. They are features of the business model.**
+
+No amount of privacy policy can override a profit motive.
+
+---
+
+# The Open-Source Answer
+
+Following the model established by the Free Software Foundation:
+
+- **Community-owned** — no single company controls the code
+- **Auditable** — anyone can read, verify, and challenge the implementation
+- **Local-first** — your data stays on your device
+- **Transparent** — trust is earned through visibility, not marketing
+
+**Open source is not a nice-to-have.
+It is the only structural answer to structural incentives.**
+
+---
+
+# What We Built
+
+Not a product. Infrastructure.
+
+| Component | Role |
+|-----------|------|
+| **Project JARVIS** | AI daemon — voice, text, orchestration |
+| **dispatch** | Parallel task execution engine |
+| **dmcp** | MCP server manager (discover, install, run) |
+| **contextor** | Long-term memory with vector search |
+| **mcp-registry** | Curated, integrity-verified tool catalog |
+| **JARVIS OS** | Full Linux distribution — the implementation |
+| **Custom kernel** | /dev/jarvis — policy enforcement at the kernel level |
+
+Everything runs locally. Everything is open source.
+
+---
+
+# The Security Architecture
+
+A 4-tier policy engine enforced at the kernel level:
+
+| Tier | Behavior |
+|------|----------|
+| **SAFE** | Execute silently |
+| **ELEVATED** | Execute + audit log |
+| **DANGEROUS** | Block until explicit user confirmation |
+| **FORBIDDEN** | Hard block — no override |
+
+The policy engine runs in the kernel, not in the AI.
+The AI cannot modify its own constraints.
+
+---
+
+# Where We Are Going
+
+- Persistent constraint registers that survive context window decay
+- Cryptographic verification for all third-party tools
+- Kernel-level sandboxing for AI-invoked operations
+- Community-driven tool ecosystem with integrity guarantees
+- Academic publication of the threat taxonomy and findings
+
+**The goal is not to build the best AI assistant.
+The goal is to make AI-OS integration safe enough to trust.**
+
+---
+
+# "You are no longer more valuable than the data you produce."
+
+Unless you can see the code that handles your data.
+
+Unless the system runs on your hardware, under your control.
+
+Unless the community — not a corporation — decides what the AI can do.
+
+**That is what we are building.**
+
+---
+
+# Get Involved
+
+**Website**: jarvisoslinux.org
+
+**GitHub**: github.com/JarvisOSLinux
+
+**Contact**:
+- Toufic Majdalani — toufic@touficmajdalani.com
+- Yakup Atahanov — yakup.atahanov@wsu.edu
+
+All code is open source. All contributions are welcome.


### PR DESCRIPTION
## Summary

- **Wire TUI confirmation modal** — `ConfirmModal` now pops up inline when JARVIS needs approval for a dangerous tool call. Added TUI as the highest-priority channel in `ConfirmationManager`, falling back to desktop notification → socket → CLI when not in TUI mode.
- **Wire TUI settings modal** — `SettingsModal` bound to `Ctrl+,`, shows live config with security-sensitive values (`allow_all`, `sudo_enabled`) highlighted in red.
- **Clean up CLAUDE.md** — removed stale tool discovery redesign section (already implemented), `input_guard.py` references (scrapped), and implementation changelog. Cut from 225 to 161 lines.
- **Add research and presentation docs** — canonical research paper content and SURCA presentation slides.
- **Update README** — mission statement, ecosystem overview, trimmed marketing copy.

Closes #73

## Test plan

- [ ] `jarvis tui` launches without import errors
- [ ] `Ctrl+,` opens the settings modal, `Esc` closes it
- [ ] In `smart` or `ask_all` confirmation mode, dispatching a tool with `confirmation_required: true` pops the `ConfirmModal` in the TUI
- [ ] Pressing `Y` approves and the tool executes; pressing `N` or `Esc` denies
- [ ] In CLI mode (`jarvis chat`), confirmation falls through to stdin prompt (TUI callback not registered)
- [ ] `CONFIRMATION_MODE=allow_all` skips confirmation entirely

https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5

---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_