### PR TITLE
Add TUI slash commands and extract shared provider CRUD

### DIFF
--- a/jarvis/cli.py
+++ b/jarvis/cli.py
@@ -21,6 +21,14 @@ from pathlib import Path
 
 from .config import Config
 from .core.logger import JarvisLogger, get_logger
+from .core.providers import (
+    add_provider,
+    edit_provider,
+    list_providers,
+    move_provider,
+    parse_flags,
+    remove_provider,
+)
 
 # Initialise logging from config before any get_logger() call so that the
 # file handler (LOG_FILE) and level (LOG_LEVEL) are applied from the start.
@@ -283,61 +291,10 @@ def _check_capabilities() -> dict:
     return capabilities
 
 
-def _load_providers_file() -> dict:
-    """Load providers.json, returning empty structure if absent."""
-    providers_file = Config.PROVIDERS_FILE
-    if os.path.isfile(providers_file):
-        import json
-
-        with open(providers_file) as f:
-            return json.load(f)
-    return {"providers": []}
-
-
-def _save_providers_file(data: dict) -> None:
-    """Write providers.json, creating parent dirs if needed."""
-    import json
-
-    providers_file = Config.PROVIDERS_FILE
-    os.makedirs(os.path.dirname(providers_file), exist_ok=True)
-    with open(providers_file, "w") as f:
-        json.dump(data, f, indent=2)
-        f.write("\n")
-
-
-def _parse_provider_flags(args: list) -> dict:
-    """Parse --flag value pairs from an argument list."""
-    flags: dict = {}
-    i = 0
-    while i < len(args):
-        if args[i].startswith("--") and i + 1 < len(args):
-            key = args[i][2:]
-            flags[key] = args[i + 1]
-            i += 2
-        else:
-            i += 1
-    return flags
-
-
-def _generate_provider_name(ptype: str, model: str, existing: list) -> str:
-    """Auto-generate a unique provider name from type and model."""
-    import re
-
-    base = f"{ptype}-{re.sub(r'[^a-zA-Z0-9]', '-', model)}"
-    base = re.sub(r"-+", "-", base).strip("-").lower()
-    if base not in existing:
-        return base
-    n = 2
-    while f"{base}-{n}" in existing:
-        n += 1
-    return f"{base}-{n}"
-
-
 def _cmd_providers() -> None:
     """Manage the provider failover pool."""
     if len(sys.argv) == 2:
-        data = _load_providers_file()
-        providers = data.get("providers", [])
+        providers = list_providers()
         if not providers:
             print("No providers configured in providers.json.")
             print(f"  Using legacy config: {Config.LLM_PROVIDER} / {Config.LLM_MODEL}")
@@ -371,137 +328,69 @@ def _cmd_providers() -> None:
     subcmd = sys.argv[2]
 
     if subcmd == "add":
-        flags = _parse_provider_flags(sys.argv[3:])
-        ptype = flags.get("type", "").lower()
+        flags = parse_flags(sys.argv[3:])
+        ptype = flags.get("type", "")
         model = flags.get("model", "")
-
         if not ptype or not model:
             print("Usage: jarvis providers add --type <ollama|api> --model <model>")
             print("  Optional: --name <label> --url <url> --key <api_key>")
             sys.exit(1)
-
-        if ptype not in ("ollama", "api"):
-            print(f"Error: Unknown provider type '{ptype}'. Use 'ollama' or 'api'.")
+        try:
+            name, position = add_provider(
+                ptype,
+                model,
+                name=flags.get("name"),
+                url=flags.get("url"),
+                api_key=flags.get("key"),
+            )
+            print(f"Added provider '{name}' ({ptype}/{model}) at position {position}")
+        except ValueError as e:
+            print(f"Error: {e}")
             sys.exit(1)
-
-        if ptype == "api" and (not flags.get("url") or not flags.get("key")):
-            print("Error: API providers require --url and --key")
-            sys.exit(1)
-
-        data = _load_providers_file()
-        existing_names = [p.get("name") for p in data.get("providers", [])]
-
-        name = flags.get("name") or _generate_provider_name(
-            ptype, model, existing_names
-        )
-        if name in existing_names:
-            print(f"Error: Provider '{name}' already exists. Remove it first.")
-            sys.exit(1)
-
-        entry: dict = {"name": name, "type": ptype, "model": model}
-        if flags.get("url"):
-            entry["url"] = flags["url"]
-        if flags.get("key"):
-            entry["api_key"] = flags["key"]
-
-        data.setdefault("providers", []).append(entry)
-        _save_providers_file(data)
-        position = len(data["providers"])
-        print(f"Added provider '{name}' ({ptype}/{model}) at position {position}")
 
     elif subcmd == "remove":
         if len(sys.argv) < 4:
             print("Usage: jarvis providers remove <name>")
             sys.exit(1)
-
-        name = sys.argv[3]
-        data = _load_providers_file()
-        providers = data.get("providers", [])
-        before = len(providers)
-        data["providers"] = [p for p in providers if p.get("name") != name]
-
-        if len(data["providers"]) == before:
-            print(f"Error: Provider '{name}' not found.")
+        try:
+            remove_provider(sys.argv[3])
+            print(f"Removed provider '{sys.argv[3]}'")
+        except ValueError as e:
+            print(f"Error: {e}")
             sys.exit(1)
-
-        _save_providers_file(data)
-        print(f"Removed provider '{name}'")
 
     elif subcmd == "move":
         if len(sys.argv) < 5:
             print("Usage: jarvis providers move <name> <position>")
             print("  Position is 1-based (1 = highest priority)")
             sys.exit(1)
-
-        name = sys.argv[3]
         try:
             target_pos = int(sys.argv[4])
         except ValueError:
             print(f"Error: Position must be a number, got '{sys.argv[4]}'")
             sys.exit(1)
-
-        data = _load_providers_file()
-        providers = data.get("providers", [])
-
-        idx = None
-        for i, p in enumerate(providers):
-            if p.get("name") == name:
-                idx = i
-                break
-
-        if idx is None:
-            print(f"Error: Provider '{name}' not found.")
+        try:
+            move_provider(sys.argv[3], target_pos)
+            print(f"Moved provider '{sys.argv[3]}' to position {target_pos}")
+        except ValueError as e:
+            print(f"Error: {e}")
             sys.exit(1)
-
-        if target_pos < 1 or target_pos > len(providers):
-            print(f"Error: Position must be between 1 and {len(providers)}")
-            sys.exit(1)
-
-        entry = providers.pop(idx)
-        providers.insert(target_pos - 1, entry)
-        data["providers"] = providers
-        _save_providers_file(data)
-        print(f"Moved provider '{name}' to position {target_pos}")
 
     elif subcmd == "edit":
         if len(sys.argv) < 4:
             print("Usage: jarvis providers edit <name> --field <value>")
             print("  Fields: --model, --url, --key, --type")
             sys.exit(1)
-
-        name = sys.argv[3]
-        flags = _parse_provider_flags(sys.argv[4:])
-
+        flags = parse_flags(sys.argv[4:])
         if not flags:
             print("Error: No fields to update. Use --model, --url, --key, or --type")
             sys.exit(1)
-
-        data = _load_providers_file()
-        providers = data.get("providers", [])
-
-        target = None
-        for p in providers:
-            if p.get("name") == name:
-                target = p
-                break
-
-        if target is None:
-            print(f"Error: Provider '{name}' not found.")
+        try:
+            updated = edit_provider(sys.argv[3], **flags)
+            print(f"Updated provider '{sys.argv[3]}': {', '.join(updated)}")
+        except ValueError as e:
+            print(f"Error: {e}")
             sys.exit(1)
-
-        field_map = {"model": "model", "url": "url", "key": "api_key", "type": "type"}
-        updated = []
-        for flag_key, json_key in field_map.items():
-            if flag_key in flags:
-                target[json_key] = flags[flag_key]
-                updated.append(flag_key)
-
-        if not updated:
-            print("Error: No recognized fields. Use --model, --url, --key, or --type")
-            sys.exit(1)
-
-        _save_providers_file(data)
-        print(f"Updated provider '{name}': {', '.join(updated)}")
 
     else:
         print(f"Error: Unknown subcommand '{subcmd}'")

--- a/jarvis/core/providers.py
+++ b/jarvis/core/providers.py
@@ -1,0 +1,155 @@
+"""Shared provider pool CRUD — used by both CLI and TUI."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import List, Optional, Tuple
+
+from ..config import Config
+
+
+def load_providers() -> dict:
+    """Load providers.json, returning empty structure if absent."""
+    providers_file = Config.PROVIDERS_FILE
+    if os.path.isfile(providers_file):
+        with open(providers_file) as f:
+            return json.load(f)
+    return {"providers": []}
+
+
+def save_providers(data: dict) -> None:
+    """Write providers.json, creating parent dirs if needed."""
+    providers_file = Config.PROVIDERS_FILE
+    os.makedirs(os.path.dirname(providers_file), exist_ok=True)
+    with open(providers_file, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+
+def generate_name(ptype: str, model: str, existing: List[str]) -> str:
+    """Auto-generate a unique provider name from type and model."""
+    base = f"{ptype}-{re.sub(r'[^a-zA-Z0-9]', '-', model)}"
+    base = re.sub(r"-+", "-", base).strip("-").lower()
+    if base not in existing:
+        return base
+    n = 2
+    while f"{base}-{n}" in existing:
+        n += 1
+    return f"{base}-{n}"
+
+
+def list_providers() -> List[dict]:
+    """Return the list of configured providers."""
+    return load_providers().get("providers", [])
+
+
+def add_provider(
+    ptype: str,
+    model: str,
+    name: Optional[str] = None,
+    url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Tuple[str, int]:
+    """Add a provider. Returns (name, position) or raises ValueError."""
+    ptype = ptype.lower()
+    if ptype not in ("ollama", "api"):
+        raise ValueError(f"Unknown provider type '{ptype}'. Use 'ollama' or 'api'.")
+
+    if ptype == "api" and (not url or not api_key):
+        raise ValueError("API providers require url and api_key.")
+
+    data = load_providers()
+    existing_names = [p.get("name") for p in data.get("providers", [])]
+
+    resolved_name = name or generate_name(ptype, model, existing_names)
+    if resolved_name in existing_names:
+        raise ValueError(f"Provider '{resolved_name}' already exists.")
+
+    entry: dict = {"name": resolved_name, "type": ptype, "model": model}
+    if url:
+        entry["url"] = url
+    if api_key:
+        entry["api_key"] = api_key
+
+    data.setdefault("providers", []).append(entry)
+    save_providers(data)
+    return resolved_name, len(data["providers"])
+
+
+def remove_provider(name: str) -> None:
+    """Remove a provider by name. Raises ValueError if not found."""
+    data = load_providers()
+    providers = data.get("providers", [])
+    before = len(providers)
+    data["providers"] = [p for p in providers if p.get("name") != name]
+
+    if len(data["providers"]) == before:
+        raise ValueError(f"Provider '{name}' not found.")
+
+    save_providers(data)
+
+
+def move_provider(name: str, position: int) -> None:
+    """Move a provider to a 1-based position. Raises ValueError on errors."""
+    data = load_providers()
+    providers = data.get("providers", [])
+
+    idx = None
+    for i, p in enumerate(providers):
+        if p.get("name") == name:
+            idx = i
+            break
+
+    if idx is None:
+        raise ValueError(f"Provider '{name}' not found.")
+
+    if position < 1 or position > len(providers):
+        raise ValueError(f"Position must be between 1 and {len(providers)}.")
+
+    entry = providers.pop(idx)
+    providers.insert(position - 1, entry)
+    data["providers"] = providers
+    save_providers(data)
+
+
+def edit_provider(name: str, **fields: str) -> List[str]:
+    """Update fields on an existing provider. Returns list of updated field names."""
+    field_map = {"model": "model", "url": "url", "key": "api_key", "type": "type"}
+
+    data = load_providers()
+    target = None
+    for p in data.get("providers", []):
+        if p.get("name") == name:
+            target = p
+            break
+
+    if target is None:
+        raise ValueError(f"Provider '{name}' not found.")
+
+    updated = []
+    for flag_key, json_key in field_map.items():
+        if flag_key in fields and fields[flag_key] is not None:
+            target[json_key] = fields[flag_key]
+            updated.append(flag_key)
+
+    if not updated:
+        raise ValueError("No recognized fields. Use model, url, key, or type.")
+
+    save_providers(data)
+    return updated
+
+
+def parse_flags(args: list) -> dict:
+    """Parse --flag value pairs from an argument list."""
+    flags: dict = {}
+    i = 0
+    while i < len(args):
+        if args[i].startswith("--") and i + 1 < len(args):
+            key = args[i][2:]
+            flags[key] = args[i + 1]
+            i += 2
+        else:
+            i += 1
+    return flags

--- a/jarvis/tui/local_input.py
+++ b/jarvis/tui/local_input.py
@@ -1,4 +1,4 @@
-"""TUI-local input handlers (/help, /export) and transcript export helper."""
+"""TUI-local input handlers and transcript export helper."""
 
 from __future__ import annotations
 
@@ -9,13 +9,14 @@ from pathlib import Path
 from typing import Any, Optional
 
 from ..config import Config
+from ..core.providers import list_providers
 from .help_screen import HelpScreen
 from .slash_commands_doc import build_help_markdown
 
 
 def handle_local_input(app: Any, text: str, bindings: Any) -> bool:
     """Handle TUI-only slash commands. Return True when handled."""
-    low = text.lower()
+    low = text.lower().strip()
     if low in ("/help", "/?"):
         app.push_screen(HelpScreen(build_help_markdown(bindings)))
         return True
@@ -26,7 +27,91 @@ def handle_local_input(app: Any, text: str, bindings: Any) -> bool:
         export_transcript_to_disk(app, name_arg)
         return True
 
+    if low == "/clear":
+        from .actions import clear_transcript
+
+        clear_transcript(app)
+        return True
+
+    if low in ("/quit", "/exit"):
+        app.exit()
+        return True
+
+    if low == "/status":
+        _show_status(app)
+        return True
+
+    if low == "/providers":
+        _show_providers(app)
+        return True
+
     return False
+
+
+def _show_status(app: Any) -> None:
+    """Display current provider, model, and session info."""
+    model = getattr(Config, "LLM_MODEL", None) or "(unset)"
+    provider_name = getattr(Config, "LLM_PROVIDER", "?")
+
+    pool = None
+    if app.jarvis is not None and hasattr(app.jarvis, "llm"):
+        pool = getattr(app.jarvis.llm, "provider", None)
+
+    if pool is not None and hasattr(pool, "active_provider_name"):
+        provider_name = pool.active_provider_name or provider_name
+        model = getattr(pool, "model", model)
+
+    session_id = "(none)"
+    if app.jarvis is not None and app.jarvis.sessions.current:
+        session_id = app.jarvis.sessions.current.short_id()
+
+    lines = [
+        "[bold cyan]Status[/bold cyan]",
+        f"  provider: {provider_name}",
+        f"  model: {model}",
+        f"  session: {session_id}",
+    ]
+    app._append_log("\n".join(lines))
+
+
+def _show_providers(app: Any) -> None:
+    """Display configured providers with live pool status if available."""
+    pool_status = {}
+    if app.jarvis is not None and hasattr(app.jarvis, "llm"):
+        pool = getattr(app.jarvis.llm, "provider", None)
+        if pool is not None and hasattr(pool, "get_status"):
+            for info in pool.get_status():
+                pool_status[info["name"]] = info
+
+    providers = list_providers()
+    if not providers:
+        app._append_log(
+            "[dim]No providers configured. "
+            f"Using legacy: {Config.LLM_PROVIDER} / {Config.LLM_MODEL}[/dim]"
+        )
+        return
+
+    lines = [f"[bold cyan]Provider pool[/bold cyan] ({len(providers)} providers)"]
+    for i, p in enumerate(providers):
+        name = p.get("name", f"provider-{i}")
+        ptype = p.get("type", "?")
+        model = p.get("model", "?")
+
+        status_str = ""
+        live = pool_status.get(name)
+        if live:
+            s = live["status"]
+            if s == "active":
+                status_str = " [green]active[/green]"
+            elif s in ("cooldown", "exhausted"):
+                remaining = live.get("cooldown_remaining", "?")
+                status_str = f" [yellow]{s} ({remaining}s)[/yellow]"
+            elif s == "error":
+                status_str = " [red]error[/red]"
+
+        lines.append(f"  [{i + 1}] {name} — {ptype}/{model}{status_str}")
+
+    app._append_log("\n".join(lines))
 
 
 def export_transcript_to_disk(app: Any, filename: Optional[str]) -> None:

--- a/jarvis/tui/slash_commands_doc.py
+++ b/jarvis/tui/slash_commands_doc.py
@@ -31,8 +31,12 @@ TUI_LOCAL_SLASH_HELP: tuple[tuple[str, str], ...] = (
     ("/help, /?", "Open help (TUI only; not sent to the LLM)."),
     (
         "/export [file]",
-        "Save plain transcript (Markdown) under `transcripts/`; optional basename only (TUI only).",
+        "Save plain transcript (Markdown) under `transcripts/`; optional basename only.",
     ),
+    ("/clear", "Clear the chat view (on-screen only; session memory unchanged)."),
+    ("/quit, /exit", "Exit the TUI."),
+    ("/status", "Show current provider, model, and session."),
+    ("/providers", "List configured providers with live pool status."),
 )
 
 # Keys that are not represented as App BINDINGS but belong in the cheat sheet.

--- a/jarvis/tui/status_bar.py
+++ b/jarvis/tui/status_bar.py
@@ -18,6 +18,13 @@ def update_status(app: Any) -> None:
 
     model = getattr(Config, "LLM_MODEL", None) or "(unset)"
     provider = getattr(Config, "LLM_PROVIDER", "?")
+
+    if app.jarvis is not None and hasattr(app.jarvis, "llm"):
+        pool = getattr(app.jarvis.llm, "provider", None)
+        if pool is not None and hasattr(pool, "active_provider_name"):
+            provider = pool.active_provider_name or provider
+            model = getattr(pool, "model", model)
+
     parts.append(f"model: {model}")
     parts.append(f"provider: {provider}")
     parts.append(


### PR DESCRIPTION
## Summary

- **`jarvis/core/providers.py`** (new) — shared provider pool CRUD logic, importable by both CLI and TUI. Functions: `load_providers`, `save_providers`, `list_providers`, `add_provider`, `remove_provider`, `move_provider`, `edit_provider`, `parse_flags`, `generate_name`.
- **`jarvis/cli.py`** — refactored to delegate provider operations to `core.providers` instead of inline private functions.
- **TUI slash commands** — added `/clear`, `/quit`, `/exit`, `/status`, `/providers` to `local_input.py`. All handled TUI-side, never reach the LLM.
  - `/status` shows live provider name, model, and session from the running `ProviderPool`
  - `/providers` lists all configured providers with live pool status (active/cooldown/error)
- **Status bar** — reads live provider name and model from `ProviderPool` instead of static `Config` values.
- **Help docs** — `slash_commands_doc.py` updated with new command entries.

Partial progress on #79 (Phase 1 — TUI-specific commands).

## Test plan

- [ ] `/clear` clears the chat view without touching session memory
- [ ] `/quit` and `/exit` close the TUI
- [ ] `/status` shows current provider, model, and session
- [ ] `/providers` lists providers with live status from pool
- [ ] `/help` shows updated command table including new commands
- [ ] Status bar reflects live provider name from pool
- [ ] CLI `jarvis providers` commands still work after refactor to shared module

https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5

---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_