### PR TITLE
fix: /rename spaces, Ollama retry hang, add CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,55 @@
+# Code of Conduct
+
+**Version 1.0 — 2026-06-15**
+
+This Code of Conduct applies to all project spaces operated by the JarvisOSLinux Organization: GitHub issues, pull requests, discussions, chat, and any other official communication channels.
+
+---
+
+## Our Standards
+
+We expect all participants to:
+
+- Be respectful and constructive in all interactions
+- Assume good intent when others are unclear
+- Offer and accept feedback gracefully
+- Focus disagreements on ideas, not people
+- Acknowledge mistakes and course-correct
+
+We do not tolerate:
+
+- Harassment, intimidation, or personal attacks of any kind
+- Discriminatory language or behavior based on age, body size, disability, ethnicity, gender identity, nationality, religion, sexual orientation, or experience level
+- Publishing private information about others without consent
+- Sustained disruption of discussions
+- Threats or incitement to violence
+
+---
+
+## Enforcement
+
+Violations can be reported to the project maintainers at **myclaude.exception057@slmails.com**. All reports are treated as confidential.
+
+The Governing Board (or designated maintainers until the Board is constituted) handles enforcement. Responses may include:
+
+1. **Warning** — private message with explanation of the violation
+2. **Temporary ban** — removal from project spaces for a defined period
+3. **Permanent ban** — for severe or repeated violations
+
+Decisions are final at the discretion of the enforcing maintainer. Appeals may be submitted in writing to the Governing Board.
+
+---
+
+## Scope
+
+This Code of Conduct applies within all project spaces and when an individual is representing the project in public (e.g., using an official email, posting on social media as a project representative, or speaking at an event on the project's behalf).
+
+---
+
+## Updates
+
+The Organization may update this Code of Conduct with thirty (30) days' written notice to active contributors, per SCCL v1 Article 3.1. The version date at the top of this file tracks all revisions.
+
+---
+
+*Based on the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).*

--- a/jarvis/llm/chat.py
+++ b/jarvis/llm/chat.py
@@ -189,8 +189,12 @@ class LLM:
         try:
             response_text = self.provider.chat(messages)
         except Exception as e:
+            # Provider-level failure (timeout, network, Ollama down). Don't
+            # burn through all JSON retries waiting — each retry would hit
+            # the same dead endpoint and waste LLM_TIMEOUT seconds per attempt.
             logger.error(f"LLM [{self._mode}] provider error: {e}")
-            response_text = ""
+            self.chat_history.pop()
+            return self._fallback_response()
 
         logger.debug(
             f"LLM [{self._mode}] attempt={attempt} responded "

--- a/jarvis/runtime/session_commands.py
+++ b/jarvis/runtime/session_commands.py
@@ -19,6 +19,9 @@ def handle_slash_command(app: Any, text: str) -> bool:
     parts = text.strip().split(maxsplit=1)
     cmd = parts[0].lower()
     arg = parts[1].strip() if len(parts) > 1 else ""
+    # Strip surrounding quote pairs so `/rename 'Hello World'` works naturally.
+    if len(arg) >= 2 and arg[0] == arg[-1] and arg[0] in ('"', "'"):
+        arg = arg[1:-1]
 
     if cmd == "/new":
         if not app.sessions.available:

--- a/jarvis/sessions/manager.py
+++ b/jarvis/sessions/manager.py
@@ -149,7 +149,12 @@ class SessionManager:
 
         # Refresh cached current session if that's what we renamed.
         if self._current and self._current.id == sid:
-            self._current = Session.from_dict(result["session"])
+            session_data = result.get("session", {})
+            if session_data.get("id"):
+                self._current = Session.from_dict(session_data)
+            else:
+                # Contextor didn't echo back the full session; patch locally.
+                self._current.title = title
         return True
 
     def delete(self, session_id: str, delete_entries: bool = True) -> bool:


### PR DESCRIPTION
## Summary

- **`jarvis/llm/chat.py`** — Provider exceptions (timeout, Ollama unreachable) no longer trigger `MAX_JSON_RETRIES` (10) retry loop. Previously: up to 11 × 60 s = 11 min hang. Now: immediate fallback. Fixes JarvisOSLinux/Project-JARVIS#93
- **`jarvis/runtime/session_commands.py`** — Strip surrounding quote pairs from `/rename` arg. `/rename 'Hello World'` → title `Hello World`. Fixes JarvisOSLinux/Project-JARVIS#92
- **`jarvis/sessions/manager.py`** — Guard against empty session dict when contextor doesn't echo back full session after update; patch title locally as fallback.
- **`CODE_OF_CONDUCT.md`** — Add v1.0 based on Contributor Covenant; versioned per SCCL Article 3.1. Fixes JarvisOSLinux/Project-JARVIS#85
- **`deps/rust/contextor`** — Bump submodule to contextor PR #7: `cmd_update_session` now returns the updated session object.

## Test plan

- [ ] `/rename 'Hello World'` renames session correctly
- [ ] Kill Ollama, send a message → JARVIS fails fast (no 11-min hang)
- [ ] `CODE_OF_CONDUCT.md` renders correctly on GitHub
- [ ] `cargo test` passes in contextor submodule

🤖 Generated with [Claude Code](https://claude.com/claude-code)