### PR TITLE
feat: MCP buffer, token tracking, docstring description fallback

### DIFF
--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -152,6 +152,16 @@ class Config:
     # Minimum cosine similarity for RAG results (0.0-1.0)
     RAG_MIN_SCORE = float(os.getenv("RAG_MIN_SCORE", "0.3"))
 
+    # --- Token Tracking ---
+    # Model context window size (tokens). Used for ctx: X/Y display in the TUI.
+    # 0 = unknown (shows raw token count without a denominator).
+    LLM_CONTEXT_WINDOW = int(os.getenv("LLM_CONTEXT_WINDOW", "0"))
+
+    # --- MCP Server Buffer ---
+    # Number of recently-used server doc blocks to keep in the system context.
+    # Frequency-based eviction: lowest-use server is dropped when buffer is full.
+    MCP_BUFFER_SIZE = int(os.getenv("MCP_BUFFER_SIZE", "5"))
+
     # --- Semantic Tool Discovery ---
     # Master switch for vector-based tool search via dispatch/dmcp
     ALLOW_EMBEDDING_SEARCH = (

--- a/jarvis/dispatch/dmcp_registry.py
+++ b/jarvis/dispatch/dmcp_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import json
 import os
@@ -181,6 +182,96 @@ async def uninstall_server(logger: Logger, server_id: str) -> Dict[str, Any]:
     return {"uninstalled": server_id, "output": raw.strip()}
 
 
+def _extract_mcp_docstrings(source_file: Path) -> Dict[str, str]:
+    """Return {tool_name: first_docstring_line} for @mcp.tool-decorated fns."""
+    try:
+        tree = ast.parse(source_file.read_text(encoding="utf-8", errors="replace"))
+    except Exception:
+        return {}
+
+    result: Dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+
+        is_tool = False
+        explicit_name: Optional[str] = None
+        for dec in node.decorator_list:
+            # @tool, @mcp.tool, @server.tool, @app.tool
+            bare = None
+            call_func = None
+            call_kwargs: Dict[str, Any] = {}
+            if isinstance(dec, ast.Attribute) and dec.attr == "tool":
+                is_tool = True
+                bare = dec.attr
+            elif isinstance(dec, ast.Name) and dec.id == "tool":
+                is_tool = True
+                bare = dec.id
+            elif isinstance(dec, ast.Call):
+                f = dec.func
+                if (isinstance(f, ast.Attribute) and f.attr == "tool") or (
+                    isinstance(f, ast.Name) and f.id == "tool"
+                ):
+                    is_tool = True
+                    # Look for name= kwarg
+                    for kw in dec.keywords:
+                        if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                            explicit_name = str(kw.value.value)
+
+        if not is_tool:
+            continue
+
+        docstring = ast.get_docstring(node)
+        if not docstring:
+            continue
+
+        first_line = docstring.split("\n")[0].strip()
+        name = explicit_name or node.name
+        result[name] = first_line
+
+    return result
+
+
+def _find_python_source(manifest: Dict[str, Any]) -> Optional[Path]:
+    """Locate the main Python source file referenced by a server manifest."""
+    transports = manifest.get("transports") or []
+    if not transports:
+        return None
+
+    primary = transports[0]
+    if primary.get("type") != "stdio":
+        return None
+
+    install_dir = manifest.get("installDir") or manifest.get("install_dir")
+    if not install_dir:
+        return None
+    base = Path(install_dir)
+    if not base.is_dir():
+        return None
+
+    # Try each arg for a .py file
+    for arg in primary.get("args") or []:
+        p = Path(arg)
+        if p.suffix != ".py":
+            continue
+        candidate = base / p if not p.is_absolute() else p
+        if candidate.exists():
+            return candidate
+
+    # Fallback: well-known entry-point names
+    for name in ("server.py", "main.py", "app.py", "__main__.py"):
+        f = base / name
+        if f.exists():
+            return f
+
+    # Last resort: single .py file in install dir
+    py_files = list(base.glob("*.py"))
+    if len(py_files) == 1:
+        return py_files[0]
+
+    return None
+
+
 async def list_server_tools(logger: Logger, server_id: str) -> Dict[str, Any]:
     """List tools available on an installed MCP server."""
     logger.info(f"Dispatch: Listing tools for server '{server_id}'")
@@ -220,6 +311,32 @@ async def list_server_tools(logger: Logger, server_id: str) -> Dict[str, Any]:
         tools = []
 
     logger.info(f"Dispatch: Server '{server_id}' has {len(tools)} tool(s)")
+
+    # Docstring fallback: if any tools lack descriptions, parse Python source.
+    if any(not t.get("description") for t in tools if isinstance(t, dict)):
+        base = _dmcp_base_dir()
+        manifest_path = base / "installed" / server_id / "manifest.json"
+        if manifest_path.exists():
+            try:
+                manifest = json.loads(manifest_path.read_text())
+                src = _find_python_source(manifest)
+                if src:
+                    docstrings = _extract_mcp_docstrings(src)
+                    if docstrings:
+                        for tool in tools:
+                            if not isinstance(tool, dict):
+                                continue
+                            if not tool.get("description"):
+                                name = tool.get("name", "")
+                                if name in docstrings:
+                                    tool["description"] = docstrings[name]
+                        logger.debug(
+                            f"Dispatch: applied docstring fallback for {server_id}"
+                            f" ({len(docstrings)} found)"
+                        )
+            except Exception as e:
+                logger.debug(f"Dispatch: docstring fallback error for {server_id}: {e}")
+
     return {"server": server_id, "tools": tools}
 
 

--- a/jarvis/llm/base.py
+++ b/jarvis/llm/base.py
@@ -14,6 +14,8 @@ class BaseLLMProvider(ABC):
 
     def __init__(self, model: str):
         self.model = model
+        self.last_prompt_tokens: int = 0
+        self.last_completion_tokens: int = 0
 
     @abstractmethod
     def chat(self, messages: List[Dict[str, str]]) -> str:

--- a/jarvis/llm/providers/api.py
+++ b/jarvis/llm/providers/api.py
@@ -67,6 +67,9 @@ class APIProvider(BaseLLMProvider):
                 result = response.json()
 
                 if "choices" in result and len(result["choices"]) > 0:
+                    usage = result.get("usage", {})
+                    self.last_prompt_tokens = usage.get("prompt_tokens", 0) or 0
+                    self.last_completion_tokens = usage.get("completion_tokens", 0) or 0
                     return result["choices"][0]["message"]["content"]
                 raise ValueError(f"Unexpected API response format: {result}")
 

--- a/jarvis/llm/providers/ollama.py
+++ b/jarvis/llm/providers/ollama.py
@@ -74,7 +74,10 @@ class OllamaProvider(BaseLLMProvider):
 
         try:
             response = self._client.chat(**kwargs)
-            return self._extract_content(response)
+            text = self._extract_content(response)
+            self.last_prompt_tokens = getattr(response, "prompt_eval_count", 0) or 0
+            self.last_completion_tokens = getattr(response, "eval_count", 0) or 0
+            return text
         except Exception as e:
             error_str = str(e).lower()
             if "model" in error_str and (
@@ -86,7 +89,10 @@ class OllamaProvider(BaseLLMProvider):
                 if self.ensure_model():
                     try:
                         response = self._client.chat(**kwargs)
-                        return self._extract_content(response)
+                        text = self._extract_content(response)
+                        self.last_prompt_tokens = getattr(response, "prompt_eval_count", 0) or 0
+                        self.last_completion_tokens = getattr(response, "eval_count", 0) or 0
+                        return text
                     except Exception as retry_error:
                         logger.error(
                             f"Ollama chat error after model pull: {retry_error}"

--- a/jarvis/main.py
+++ b/jarvis/main.py
@@ -100,6 +100,8 @@ class Jarvis:
 
         # PIDs from the most recently dispatched task batch (used by wait action).
         self._pending_dispatch_pids: list = []
+        # Session-scoped MCP server doc buffer: {server_id: {"docs": str, "count": int}}
+        self.mcp_buffer: dict = {}
         # Set by the TUI layer to open the server config modal before setup runs.
         # Signature: async (server_id, server_name, server_desc, props, saved) -> ConfigModalResult
         self.config_modal_callback: Any = None

--- a/jarvis/runtime/root_actions.py
+++ b/jarvis/runtime/root_actions.py
@@ -86,10 +86,26 @@ async def _handle_get_server_docs(
         manifest = await app.dispatch.get_server_manifest(server_id)
         configurable_props = manifest.get("configurableProperties") or None
 
-    context = build_root_context(app, logger)
-    context += "\n" + format_server_docs(
+    docs_block = format_server_docs(
         server_id, tools, error=tools_error, configurable_props=configurable_props
     )
+
+    # Cache successful server docs in the MCP buffer for future turns.
+    if tools and hasattr(app, "mcp_buffer"):
+        buf = app.mcp_buffer
+        if server_id in buf:
+            buf[server_id]["count"] += 1
+            buf[server_id]["docs"] = docs_block
+        else:
+            max_size = getattr(Config, "MCP_BUFFER_SIZE", 5)
+            if len(buf) >= max_size:
+                # Evict lowest-frequency entry.
+                evict = min(buf, key=lambda k: buf[k]["count"])
+                del buf[evict]
+            buf[server_id] = {"docs": docs_block, "count": 1}
+
+    context = build_root_context(app, logger)
+    context += "\n" + docs_block
     response = await ask_llm(app, logger, context, tag="root-get-server-docs")
     await app._act_on_root_response(response, depth + 1)
 

--- a/jarvis/runtime/root_context.py
+++ b/jarvis/runtime/root_context.py
@@ -82,6 +82,15 @@ def build_root_context(
     if summary:
         parts.append(f"CONVERSATION_SUMMARY: {summary}")
 
+    mcp_buffer = getattr(app, "mcp_buffer", {})
+    if mcp_buffer:
+        buf_parts = [
+            "MCP_BUFFER (recently used servers — call dispatch directly, skip get_server_docs):"
+        ]
+        for _sid, entry in mcp_buffer.items():
+            buf_parts.append(entry["docs"])
+        parts.append("\n".join(buf_parts))
+
     if new_input:
         parts.append(f"NEW INPUT: {new_input}")
 

--- a/jarvis/runtime/session_commands.py
+++ b/jarvis/runtime/session_commands.py
@@ -1,8 +1,10 @@
-"""Session management slash-commands (/new, /sessions, /switch, /rename, /delete)."""
+"""Session management slash-commands (/new, /sessions, /switch, /rename, /delete, /context)."""
 
 from __future__ import annotations
 
 from typing import Any
+
+from ..config import Config
 
 
 def session_reply(app: Any, message: str) -> None:
@@ -97,6 +99,32 @@ def handle_slash_command(app: Any, text: str) -> bool:
             session_reply(app, f"Deleted session {matches[0].short_id()}.")
         else:
             session_reply(app, "Delete failed.")
+        return True
+
+    if cmd == "/context":
+        lines = ["Context usage (last LLM call):"]
+        jarvis = getattr(app, "jarvis", app)
+        raw_provider = None
+        if hasattr(jarvis, "llm"):
+            raw_provider = getattr(jarvis.llm, "provider", None)
+        prompt_toks = getattr(raw_provider, "last_prompt_tokens", 0) or 0
+        completion_toks = getattr(raw_provider, "last_completion_tokens", 0) or 0
+        if prompt_toks == 0 and completion_toks == 0:
+            lines.append("  No LLM calls made yet in this session.")
+        else:
+            window = getattr(Config, "LLM_CONTEXT_WINDOW", 0)
+            lines.append(f"  Prompt tokens:     {prompt_toks}")
+            lines.append(f"  Completion tokens: {completion_toks}")
+            lines.append(f"  Total:             {prompt_toks + completion_toks}")
+            if window > 0:
+                pct = int(prompt_toks / window * 100)
+                lines.append(f"  Context window:    {window} ({pct}% used)")
+        buf = getattr(jarvis, "mcp_buffer", {})
+        if buf:
+            lines.append(f"  MCP buffer:        {len(buf)} server(s) cached")
+            for sid, entry in buf.items():
+                lines.append(f"    {sid}  (used {entry['count']}x)")
+        session_reply(app, "\n".join(lines))
         return True
 
     # Unknown slash-command — let it through to the LLM so the user

--- a/jarvis/tui/status_bar.py
+++ b/jarvis/tui/status_bar.py
@@ -27,6 +27,18 @@ def update_status(app: Any) -> None:
 
     parts.append(f"model: {model}")
     parts.append(f"provider: {provider}")
+
+    if app.jarvis is not None and hasattr(app.jarvis, "llm"):
+        raw_provider = getattr(app.jarvis.llm, "provider", None)
+        prompt_toks = getattr(raw_provider, "last_prompt_tokens", 0) or 0
+        if prompt_toks > 0:
+            window = getattr(Config, "LLM_CONTEXT_WINDOW", 0)
+            if window > 0:
+                pct = int(prompt_toks / window * 100)
+                parts.append(f"ctx: {prompt_toks}/{window} ({pct}%)")
+            else:
+                parts.append(f"ctx: {prompt_toks}tk")
+
     parts.append(
         "Ctrl+N new · Ctrl+D delete · Ctrl+Q quit · Ctrl+L log · Ctrl+I input · F1 help · "
         "Ctrl+Shift+C clear · Ctrl+Shift+E export"


### PR DESCRIPTION
## Summary

- **MCP server buffer (#89)**: After `get_server_docs`, tool docs are cached in the session-scoped `mcp_buffer` dict. On subsequent turns, `build_root_context()` injects the buffer so the LLM can dispatch directly without re-fetching. Frequency-based eviction (lowest-use entry dropped when full). Size controlled by `MCP_BUFFER_SIZE` env (default 5).

- **Token tracking (#79)**: `OllamaProvider` captures `prompt_eval_count` and `eval_count` from each response; `APIProvider` captures `usage.prompt_tokens` / `usage.completion_tokens`. Both stored as `last_prompt_tokens` / `last_completion_tokens` on the provider base class. Status bar shows `ctx: X/Y (Z%)` when `LLM_CONTEXT_WINDOW` is configured, or `ctx: Xtk` otherwise. New `/context` slash command shows full breakdown including MCP buffer state.

- **Docstring fallback (dispatch#5)**: `list_server_tools()` in `dmcp_registry.py` now checks if any returned tools lack descriptions. If so, it locates the server's Python source file from the manifest's stdio transport args, parses it with `ast`, and fills in first-line docstrings from `@mcp.tool`-decorated functions. Handles `@tool`, `@mcp.tool`, `@server.tool`, and `name=` kwargs.

## Test plan

- [ ] Start JARVIS, call a tool — verify `ctx:` appears in status bar after first LLM call
- [ ] Run `/context` — verify token counts and MCP buffer listed
- [ ] Call `get_server_docs` on a server, then dispatch again — verify `MCP_BUFFER` appears in LLM context (check logs)
- [ ] Install a Python MCP server with empty descriptions — verify `list_server_tools` patches descriptions from docstrings
- [ ] Set `LLM_CONTEXT_WINDOW=8192` — verify status bar shows `ctx: X/8192 (Y%)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)