### PR TITLE
Fix cloud provider auth and model check for provider pool

### DIFF
--- a/jarvis/core/component_factory.py
+++ b/jarvis/core/component_factory.py
@@ -54,6 +54,11 @@ class ComponentFactory:
                         getattr(Config, "LLM_TEMPERATURE", 0.7),
                     )
                     kwargs["strict_json"] = spec.get("strict_json", False)
+                    llm_think = getattr(Config, "LLM_THINK", None)
+                    if spec.get("think") is not None:
+                        kwargs["think"] = spec["think"]
+                    elif llm_think is not None:
+                        kwargs["think"] = llm_think
                 elif ptype == "api":
                     kwargs["api_url"] = spec.get("url", "")
                     kwargs["api_key"] = spec.get("api_key", "")

--- a/jarvis/llm/providers/ollama.py
+++ b/jarvis/llm/providers/ollama.py
@@ -163,9 +163,13 @@ class OllamaProvider(BaseLLMProvider):
             return content
         return ""
 
+    @property
+    def _is_remote(self) -> bool:
+        return self.base_url != "http://localhost:11434"
+
     def is_available(self) -> bool:
         try:
-            self._ollama.list()
+            self._client.list()
             return True
         except Exception as e:
             logger.debug(f"Ollama not available: {e}")
@@ -174,9 +178,16 @@ class OllamaProvider(BaseLLMProvider):
     # -- Ollama-specific -----------------------------------------------------
 
     def ensure_model(self) -> bool:
-        """Ensure the model exists locally, pulling it if necessary."""
+        """Ensure the model exists, pulling it if necessary."""
         if self._model_exists():
             logger.debug(f"Model '{self.model}' is already available")
+            return True
+
+        if self._is_remote:
+            logger.info(
+                f"Model '{self.model}' not in remote list at {self.base_url} "
+                "— proceeding anyway (cloud models may not appear in list)"
+            )
             return True
 
         logger.warning(f"Model '{self.model}' is not installed locally")
@@ -207,7 +218,7 @@ class OllamaProvider(BaseLLMProvider):
 
     def _model_exists(self) -> bool:
         try:
-            models_response = self._ollama.list()
+            models_response = self._client.list()
             if hasattr(models_response, "models"):
                 models = models_response.models
                 model_names = [m.model for m in models if hasattr(m, "model")]

--- a/jarvis/llm/providers/ollama.py
+++ b/jarvis/llm/providers/ollama.py
@@ -40,7 +40,10 @@ class OllamaProvider(BaseLLMProvider):
         try:
             from ollama import Client
 
-            self._client = Client(host=self.base_url, timeout=LLM_TIMEOUT)
+            client_kwargs = {"timeout": LLM_TIMEOUT}
+            if api_key:
+                client_kwargs["headers"] = {"Authorization": f"Bearer {api_key}"}
+            self._client = Client(host=self.base_url, **client_kwargs)
             import ollama as _ollama
 
             self._ollama = _ollama
@@ -74,8 +77,6 @@ class OllamaProvider(BaseLLMProvider):
         log_kwargs = {k: v for k, v in kwargs.items() if k != "messages"}
         log_kwargs["num_messages"] = len(kwargs.get("messages", []))
         logger.debug(f"Ollama chat request: {log_kwargs}")
-
-        self._apply_api_key()
 
         try:
             response = self._client.chat(**kwargs)
@@ -167,17 +168,8 @@ class OllamaProvider(BaseLLMProvider):
     def _is_remote(self) -> bool:
         return self.base_url != "http://localhost:11434"
 
-    def _apply_api_key(self) -> None:
-        import os
-
-        if self._api_key:
-            os.environ["OLLAMA_API_KEY"] = self._api_key
-        elif "OLLAMA_API_KEY" in os.environ:
-            del os.environ["OLLAMA_API_KEY"]
-
     def is_available(self) -> bool:
         try:
-            self._apply_api_key()
             self._client.list()
             return True
         except Exception as e:
@@ -227,7 +219,6 @@ class OllamaProvider(BaseLLMProvider):
 
     def _model_exists(self) -> bool:
         try:
-            self._apply_api_key()
             models_response = self._client.list()
             if hasattr(models_response, "models"):
                 models = models_response.models

--- a/jarvis/llm/providers/ollama.py
+++ b/jarvis/llm/providers/ollama.py
@@ -90,22 +90,18 @@ class OllamaProvider(BaseLLMProvider):
             if "model" in error_str and (
                 "not found" in error_str or "does not exist" in error_str
             ):
-                logger.warning(
-                    "Model not found during chat, attempting to ensure model is available..."
-                )
-                if self.ensure_model():
-                    try:
-                        response = self._client.chat(**kwargs)
-                        return self._extract_content(response)
-                    except Exception as retry_error:
-                        logger.error(
-                            f"Ollama chat error after model pull: {retry_error}"
-                        )
-                        raise
-                else:
-                    raise RuntimeError(
-                        f"Model '{self.model}' is not available and could not be pulled"
-                    )
+                if self.auto_pull and not self._is_remote:
+                    logger.warning("Model not found, auto-pulling...")
+                    if self._pull_model():
+                        try:
+                            response = self._client.chat(**kwargs)
+                            return self._extract_content(response)
+                        except Exception as retry_error:
+                            logger.error(
+                                f"Ollama chat error after model pull: {retry_error}"
+                            )
+                            raise
+                raise RuntimeError(f"model '{self.model}' not found (status code: 404)")
             logger.error(f"Ollama chat error: {e}")
             raise
 
@@ -126,13 +122,17 @@ class OllamaProvider(BaseLLMProvider):
 
         msg = response["message"]
         content = msg.get("content") or ""
+        thinking = msg.get("thinking") or ""
 
-        msg_keys = list(msg.keys()) if hasattr(msg, "keys") else dir(msg)
-        logger.debug(
-            f"Ollama raw response: content={repr(content[:200])}, "
-            f"thinking={repr((msg.get('thinking') or '')[:200])}, "
-            f"keys={msg_keys}"
-        )
+        if not content and not thinking:
+            eval_count = None
+            if hasattr(response, "get"):
+                eval_count = response.get("eval_count")
+            if eval_count and eval_count > 0:
+                logger.warning(
+                    f"Ollama: model generated {eval_count} tokens but returned "
+                    "empty content — possible cloud proxy issue"
+                )
 
         if content:
             cleaned = re.sub(r"<\|[^|>]+\|>", "", content).strip()
@@ -148,7 +148,6 @@ class OllamaProvider(BaseLLMProvider):
                 "Ollama: content was non-empty but stripping removed all text, "
                 "falling through to thinking field / raw content"
             )
-        thinking = msg.get("thinking") or ""
         if thinking:
             logger.debug(
                 "Ollama: content empty, falling back to thinking field "

--- a/jarvis/llm/providers/ollama.py
+++ b/jarvis/llm/providers/ollama.py
@@ -74,6 +74,12 @@ class OllamaProvider(BaseLLMProvider):
 
         try:
             response = self._client.chat(**kwargs)
+            logger.debug(
+                f"Ollama chat raw: type={type(response).__name__}, "
+                f"model={response.get('model', '?') if hasattr(response, 'get') else '?'}, "
+                f"done={response.get('done', '?') if hasattr(response, 'get') else '?'}, "
+                f"done_reason={response.get('done_reason', '?') if hasattr(response, 'get') else '?'}"
+            )
             return self._extract_content(response)
         except Exception as e:
             error_str = str(e).lower()
@@ -116,6 +122,14 @@ class OllamaProvider(BaseLLMProvider):
 
         msg = response["message"]
         content = msg.get("content") or ""
+
+        msg_keys = list(msg.keys()) if hasattr(msg, "keys") else dir(msg)
+        logger.debug(
+            f"Ollama raw response: content={repr(content[:200])}, "
+            f"thinking={repr((msg.get('thinking') or '')[:200])}, "
+            f"keys={msg_keys}"
+        )
+
         if content:
             cleaned = re.sub(r"<\|[^|>]+\|>", "", content).strip()
             if cleaned != content:

--- a/jarvis/llm/providers/ollama.py
+++ b/jarvis/llm/providers/ollama.py
@@ -117,15 +117,19 @@ class OllamaProvider(BaseLLMProvider):
         msg = response["message"]
         content = msg.get("content") or ""
         if content:
-            # Strip chat-template channel tokens that some thinking models
-            # emit in-band: <|start|>, <|channel|>..., <|message|>, <|end|>
             cleaned = re.sub(r"<\|[^|>]+\|>", "", content).strip()
             if cleaned != content:
                 logger.debug(
                     f"Ollama: stripped special tokens from content "
                     f"({len(content)} → {len(cleaned)} chars)"
                 )
-            return cleaned
+            if cleaned:
+                return cleaned
+            # Stripping removed everything — fall through to thinking/raw
+            logger.warning(
+                "Ollama: content was non-empty but stripping removed all text, "
+                "falling through to thinking field / raw content"
+            )
         thinking = msg.get("thinking") or ""
         if thinking:
             logger.debug(
@@ -133,7 +137,13 @@ class OllamaProvider(BaseLLMProvider):
                 f"({len(thinking)} chars)"
             )
             return thinking
-        return content
+        if content:
+            logger.warning(
+                "Ollama: returning raw content (before stripping) as last resort "
+                f"({len(content)} chars)"
+            )
+            return content
+        return ""
 
     def is_available(self) -> bool:
         try:

--- a/jarvis/llm/providers/ollama.py
+++ b/jarvis/llm/providers/ollama.py
@@ -72,6 +72,10 @@ class OllamaProvider(BaseLLMProvider):
             # by models that don't support the option.
             kwargs["think"] = self.think
 
+        log_kwargs = {k: v for k, v in kwargs.items() if k != "messages"}
+        log_kwargs["num_messages"] = len(kwargs.get("messages", []))
+        logger.debug(f"Ollama chat request: {log_kwargs}")
+
         try:
             response = self._client.chat(**kwargs)
             logger.debug(

--- a/jarvis/llm/providers/ollama.py
+++ b/jarvis/llm/providers/ollama.py
@@ -30,13 +30,12 @@ class OllamaProvider(BaseLLMProvider):
         self.temperature = temperature
         self.strict_json = strict_json
         self.think = think
+        self._api_key = api_key
 
         import os
 
         if base_url and base_url != "http://localhost:11434":
             os.environ["OLLAMA_HOST"] = base_url
-        if api_key:
-            os.environ["OLLAMA_API_KEY"] = api_key
 
         try:
             from ollama import Client
@@ -75,6 +74,8 @@ class OllamaProvider(BaseLLMProvider):
         log_kwargs = {k: v for k, v in kwargs.items() if k != "messages"}
         log_kwargs["num_messages"] = len(kwargs.get("messages", []))
         logger.debug(f"Ollama chat request: {log_kwargs}")
+
+        self._apply_api_key()
 
         try:
             response = self._client.chat(**kwargs)
@@ -166,8 +167,17 @@ class OllamaProvider(BaseLLMProvider):
     def _is_remote(self) -> bool:
         return self.base_url != "http://localhost:11434"
 
+    def _apply_api_key(self) -> None:
+        import os
+
+        if self._api_key:
+            os.environ["OLLAMA_API_KEY"] = self._api_key
+        elif "OLLAMA_API_KEY" in os.environ:
+            del os.environ["OLLAMA_API_KEY"]
+
     def is_available(self) -> bool:
         try:
+            self._apply_api_key()
             self._client.list()
             return True
         except Exception as e:
@@ -217,6 +227,7 @@ class OllamaProvider(BaseLLMProvider):
 
     def _model_exists(self) -> bool:
         try:
+            self._apply_api_key()
             models_response = self._client.list()
             if hasattr(models_response, "models"):
                 models = models_response.models


### PR DESCRIPTION
## Summary

Fixes several bugs discovered during live testing of the provider pool with Ollama cloud models.

- **API key collision**: Each `OllamaProvider` now bakes its key directly into its `Client` instance as `Authorization: Bearer <key>` at construction time. Previously all providers wrote to `os.environ["OLLAMA_API_KEY"]` — the last provider's key overwrote all previous ones, causing every earlier provider to authenticate with the wrong key.
- **Remote model check**: `_model_exists()` now uses `self._client.list()` (queries the correct host) instead of `self._ollama.list()` (always queried localhost). Cloud models not appearing in the list are now passed through rather than triggering a pull prompt.
- **Interactive pull prompt removed from chat retry**: 404 "model not found" during `chat()` now fails fast so the `ProviderPool` can do clean failover, instead of blocking on a stdin prompt mid-session.
- **`LLM_THINK` propagated to pool path**: Was only applied in the legacy `.env` path, not when loading from `providers.json`.
- **Cloud proxy empty response warning**: When `eval_count > 0` but content is empty (Ollama cloud bug), a targeted warning is logged instead of silently retrying 11 times.

## Test plan

- [ ] `jarvis providers` lists providers with correct names/models
- [ ] `jarvis providers add --type ollama --model <m> --key <k> --name <n>` adds provider
- [ ] Multiple cloud providers each authenticate with their own key (no cross-contamination)
- [ ] Provider pool failover works: bad provider goes to cooldown, next is tried
- [ ] `/providers` and all subcommands work in TUI
- [ ] `/status` shows active provider name from pool
- [ ] Preload succeeds on first attempt with valid cloud providers

## Related

- Related to #78 — provider failover pool (fixes bugs in the pool implementation)
- Related to #79 — TUI provider commands (fixes the underlying auth so they work end-to-end)
- Follow-up to #88, #90, #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5