### PR TITLE
feat(tui): provider add/edit modal form

### DIFF
--- a/jarvis/tui/local_input.py
+++ b/jarvis/tui/local_input.py
@@ -18,6 +18,7 @@ from ..core.providers import (
     remove_provider,
 )
 from .help_screen import HelpScreen
+from .provider_modal import ProviderModal
 from .slash_commands_doc import build_help_markdown
 
 
@@ -141,10 +142,26 @@ def _handle_providers(app: Any, text: str) -> None:
         ptype = flags.get("type", "")
         model = flags.get("model", "")
         if not ptype or not model:
-            app._append_log(
-                "[yellow]Usage: /providers add --type <ollama|api> "
-                "--model <model> [--name <n>] [--url <u>] [--key <k>][/yellow]"
-            )
+            # No flags — open the modal form
+            def _on_add(result) -> None:
+                if not result or not result.confirmed:
+                    return
+                try:
+                    pname, position = add_provider(
+                        result.ptype,
+                        result.model,
+                        name=result.name or None,
+                        url=result.url or None,
+                        api_key=result.api_key or None,
+                    )
+                    app._append_log(
+                        f"[green]Added provider '{pname}' ({result.ptype}/{result.model}) "
+                        f"at position {position}[/green]"
+                    )
+                except ValueError as e:
+                    app._append_log(f"[red]Error: {e}[/red]")
+
+            app.push_screen(ProviderModal(mode="add"), _on_add)
             return
         try:
             name, position = add_provider(
@@ -192,16 +209,43 @@ def _handle_providers(app: Any, text: str) -> None:
         if len(tokens) < 2:
             app._append_log(
                 "[yellow]Usage: /providers edit <name> "
-                "--model <m> --url <u> --key <k>[/yellow]"
+                "[--model <m>] [--url <u>] [--key <k>][/yellow]"
             )
             return
         name = tokens[1]
         flags = parse_flags(tokens[2:])
         if not flags:
-            app._append_log(
-                "[yellow]No fields to update. "
-                "Use --model, --url, --key, or --type[/yellow]"
+            # No flags — open pre-filled modal
+            existing = next(
+                (p for p in list_providers() if p.get("name") == name), None
             )
+            if existing is None:
+                app._append_log(f"[red]Error: Provider '{name}' not found[/red]")
+                return
+
+            def _on_edit(result) -> None:
+                if not result or not result.confirmed:
+                    return
+                fields: dict = {}
+                if result.model:
+                    fields["model"] = result.model
+                if result.url:
+                    fields["url"] = result.url
+                if result.api_key:
+                    fields["key"] = result.api_key
+                if result.ptype:
+                    fields["type"] = result.ptype
+                if not fields:
+                    return
+                try:
+                    updated = edit_provider(name, **fields)
+                    app._append_log(
+                        f"[green]Updated provider '{name}': {', '.join(updated)}[/green]"
+                    )
+                except ValueError as e:
+                    app._append_log(f"[red]Error: {e}[/red]")
+
+            app.push_screen(ProviderModal(mode="edit", existing=existing), _on_edit)
             return
         try:
             updated = edit_provider(name, **flags)

--- a/jarvis/tui/provider_modal.py
+++ b/jarvis/tui/provider_modal.py
@@ -1,0 +1,217 @@
+"""Provider add/edit modal — triggered by /providers add (no flags) and /providers edit <name>."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label, Select, Static
+
+
+@dataclass
+class ProviderModalResult:
+    confirmed: bool
+    ptype: str = ""
+    model: str = ""
+    name: str = ""
+    url: str = ""
+    api_key: str = ""
+
+
+_OLLAMA_DEFAULT_URL = "http://localhost:11434"
+
+
+class ProviderModal(ModalScreen[ProviderModalResult]):
+    """Modal form for adding or editing a provider.
+
+    Dismissed with a ProviderModalResult.
+    mode="add"  → all fields blank/defaulted
+    mode="edit" → fields pre-filled from existing provider dict
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=False),
+        Binding("ctrl+s", "confirm", "Save", show=True),
+    ]
+
+    CSS = """
+    ProviderModal {
+        align: center middle;
+    }
+
+    #provider-dialog {
+        width: 60;
+        height: auto;
+        border: round $primary;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #dialog-title {
+        text-style: bold;
+        color: $primary;
+        margin-bottom: 1;
+    }
+
+    .field-label {
+        text-style: bold;
+        margin-top: 1;
+    }
+
+    .field-hint {
+        color: $text-muted;
+        text-style: italic;
+        margin-bottom: 0;
+    }
+
+    #url-field {
+        margin-bottom: 0;
+    }
+
+    #footer {
+        height: 3;
+        align: right middle;
+        margin-top: 1;
+        padding-top: 1;
+        border-top: solid $primary-darken-3;
+    }
+
+    #btn-cancel {
+        margin-right: 2;
+    }
+
+    #type-row {
+        height: 3;
+        margin-bottom: 0;
+    }
+
+    Select {
+        width: 1fr;
+    }
+
+    #error-label {
+        color: $error;
+        margin-top: 1;
+        display: none;
+    }
+
+    #error-label.visible {
+        display: block;
+    }
+    """
+
+    def __init__(
+        self,
+        mode: str = "add",
+        existing: Optional[dict] = None,
+    ) -> None:
+        super().__init__()
+        self._mode = mode
+        self._existing = existing or {}
+        self._ptype = self._existing.get("type", "ollama")
+        self._key_revealed = False
+
+    def compose(self) -> ComposeResult:
+        ex = self._existing
+        title = "Add Provider" if self._mode == "add" else f"Edit Provider: {ex.get('name', '')}"
+        default_url = ex.get("url", _OLLAMA_DEFAULT_URL if self._ptype == "ollama" else "")
+
+        with Vertical(id="provider-dialog"):
+            yield Label(title, id="dialog-title")
+
+            yield Label("Type", classes="field-label")
+            with Horizontal(id="type-row"):
+                yield Select(
+                    [("Ollama (local)", "ollama"), ("API (cloud)", "api")],
+                    value=self._ptype,
+                    id="input-type",
+                    allow_blank=False,
+                )
+
+            yield Label("Model", classes="field-label")
+            yield Input(value=ex.get("model", ""), placeholder="e.g. qwen3:8b or gpt-4o", id="input-model")
+
+            yield Label("Name  (optional — auto-generated if blank)", classes="field-label")
+            yield Input(value=ex.get("name", ""), placeholder="e.g. my-ollama", id="input-name")
+
+            yield Label("URL", classes="field-label")
+            yield Input(value=default_url, placeholder=_OLLAMA_DEFAULT_URL, id="input-url")
+
+            yield Label("API Key", classes="field-label")
+            with Horizontal():
+                yield Input(
+                    value=ex.get("api_key", ""),
+                    placeholder="sk-… (leave blank for Ollama)",
+                    password=True,
+                    id="input-key",
+                )
+                yield Button("show", id="btn-toggle-key", variant="default")
+
+            yield Static("", id="error-label")
+
+            with Horizontal(id="footer"):
+                yield Button("Cancel", id="btn-cancel", variant="default")
+                yield Button(
+                    "Add" if self._mode == "add" else "Save",
+                    id="btn-confirm",
+                    variant="primary",
+                )
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        if event.select.id != "input-type":
+            return
+        self._ptype = str(event.value)
+        url_input = self.query_one("#input-url", Input)
+        if not url_input.value or url_input.value == _OLLAMA_DEFAULT_URL:
+            url_input.value = _OLLAMA_DEFAULT_URL if self._ptype == "ollama" else ""
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-cancel":
+            self.action_cancel()
+        elif event.button.id == "btn-confirm":
+            self.action_confirm()
+        elif event.button.id == "btn-toggle-key":
+            self._key_revealed = not self._key_revealed
+            inp = self.query_one("#input-key", Input)
+            inp.password = not self._key_revealed
+            event.button.label = "hide" if self._key_revealed else "show"
+
+    def on_key(self, event) -> None:
+        if event.key == "enter":
+            self.action_confirm()
+
+    def action_cancel(self) -> None:
+        self.dismiss(ProviderModalResult(confirmed=False))
+
+    def action_confirm(self) -> None:
+        model = self.query_one("#input-model", Input).value.strip()
+        if not model:
+            err = self.query_one("#error-label", Static)
+            err.update("Model is required.")
+            err.add_class("visible")
+            return
+
+        ptype = str(self.query_one("#input-type", Select).value)
+        url = self.query_one("#input-url", Input).value.strip()
+        api_key = self.query_one("#input-key", Input).value.strip()
+
+        if ptype == "api" and not api_key:
+            err = self.query_one("#error-label", Static)
+            err.update("API key is required for cloud providers.")
+            err.add_class("visible")
+            return
+
+        self.dismiss(
+            ProviderModalResult(
+                confirmed=True,
+                ptype=ptype,
+                model=model,
+                name=self.query_one("#input-name", Input).value.strip(),
+                url=url,
+                api_key=api_key,
+            )
+        )

--- a/jarvis/tui/slash_commands_doc.py
+++ b/jarvis/tui/slash_commands_doc.py
@@ -37,10 +37,12 @@ TUI_LOCAL_SLASH_HELP: tuple[tuple[str, str], ...] = (
     ("/quit, /exit", "Exit the TUI."),
     ("/status", "Show current provider, model, and session."),
     ("/providers", "List configured providers with live pool status."),
-    ("/providers add --type ... --model ...", "Add a provider to the pool."),
+    ("/providers add", "Open guided modal to add a provider."),
+    ("/providers add --type ... --model ...", "Add a provider directly (power-user flags)."),
     ("/providers remove <name>", "Remove a provider by name."),
     ("/providers move <name> <pos>", "Reorder provider priority (1 = highest)."),
-    ("/providers edit <name> --field <val>", "Update a field on a provider."),
+    ("/providers edit <name>", "Open pre-filled modal to edit a provider."),
+    ("/providers edit <name> --field <val>", "Update a provider field directly (power-user flags)."),
     ("/model [name]", "Show or switch the current LLM model."),
 )
 


### PR DESCRIPTION
## Summary

- Adds `jarvis/tui/provider_modal.py` — a Textual `ModalScreen` with Name, Type (ollama/api Select), Model, URL, and Key (masked) fields
- Modifies `jarvis/tui/local_input.py` — `/providers add` and `/providers edit <name>` with no flags now open the modal; flag-based syntax unchanged for power users
- Updates `jarvis/tui/slash_commands_doc.py` — documents both modal and flag-based variants

**UX:**
```
┌─ Add Provider ──────────────────────────────┐
│ Type:  [Ollama (local)                    ] │
│ Model: [                                  ] │
│ Name:  (optional — auto-generated if blank) │
│ URL:   [http://localhost:11434            ] │
│ Key:   [•••••••••••••••••••••••••] [show]   │
│                          [Cancel]  [Add]    │
└─────────────────────────────────────────────┘
```

## Test plan

- [ ] `/providers add` → modal opens with Ollama defaults
- [ ] `/providers add --type api --model gpt-4o` → bypasses modal, direct add
- [ ] `/providers edit <name>` → modal opens pre-filled
- [ ] `/providers edit <name> --model qwen3:4b` → bypasses modal, direct edit
- [ ] API type selected → URL clears, Key is required
- [ ] Esc / Cancel → no provider added
- [ ] Ctrl+S or Enter → saves

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)