### PR TITLE
docs(legal): expand Appendix A, add CLA and C-points methodology

### DIFF
--- a/SCCL-v1.md
+++ b/SCCL-v1.md
@@ -256,22 +256,79 @@ The defining feature of this License is **Board-governed commercial access**: th
 
 ## Appendix A — Fee Formula
 
-> *To be completed. The current working formula is:*
->
-> ```
-> Annual Fee = annual_revenue × K₁ × (1 + K₂ × inclusion_index) × inflation_factor
-> ```
->
-> Where:
-> - `annual_revenue` — Licensee's total annual revenue
-> - `K₁` — rate constant (percentage of revenue)
-> - `K₂` — ecosystem lock-in penalty multiplier
-> - `inclusion_index` — 0.0 (fully open) to 1.0 (fully locked-in), assessed by the Board
-> - `inflation_factor` — `(1 + CPI_change + buffer%)`, adjusted annually
->
-> Constants and assessment methodology to be finalized.
->
-> **Current status:** Under development. See project governance discussions.
+### A.1 Formula
+
+```
+Annual Fee = annual_revenue × K₁ × (1 + K₂ × inclusion_index) × inflation_factor
+```
+
+### A.2 Variables
+
+| Variable | Definition |
+|----------|-----------|
+| `annual_revenue` | Licensee's total annual gross revenue for the most recently completed fiscal year, as declared under Article 4.4. |
+| `K₁` | Rate constant — the base percentage of revenue charged as a license fee. |
+| `K₂` | Ecosystem lock-in penalty multiplier — scales the surcharge applied to closed-ecosystem business models. |
+| `inclusion_index` | A score from 0.0 (fully open) to 1.0 (fully locked-in), assessed annually by the Board using the methodology in A.4. |
+| `inflation_factor` | Annual CPI adjustment. Calculated as `1 + CPI_change + buffer`, where `buffer` is a fixed percentage above inflation to account for project growth costs. |
+
+### A.3 Constants and Guidance
+
+#### K₁ — Rate Constant
+
+K₁ represents the percentage of the Licensee's annual revenue paid as a base license fee. The Board sets K₁ at the time of license activation (Article 2.1) and may adjust it with ninety (90) days' written notice (Article 4.2).
+
+**Reasonable range:** 1–5%. Software royalties in comparable open-core and dual-licensing arrangements typically fall in this range. A K₁ of 2% on a $10M revenue company yields a $200,000 annual fee before ecosystem adjustments.
+
+**Board guidance for setting K₁:**
+- Project maturity: early-stage projects may set K₁ at the lower end to encourage commercial adoption.
+- Licensee size: the Board may apply tiered K₁ values by revenue bracket (e.g., lower rate for companies under $1M ARR).
+- Market context: the Board should reference comparable dual-license and open-core arrangements in the software industry when setting K₁.
+
+#### K₂ — Ecosystem Lock-In Penalty Multiplier
+
+K₂ controls how much additional fee a Licensee pays for operating a walled-garden business model that restricts users from switching away. It amplifies the `inclusion_index` score.
+
+**Interpretation:**
+- `K₂ = 0`: No ecosystem penalty — the fee is the base rate regardless of lock-in.
+- `K₂ = 1.0`: A Licensee with `inclusion_index = 1.0` (fully locked-in) pays **double** the base rate.
+- `K₂ = 0.5`: A fully locked-in Licensee pays 1.5× the base rate.
+
+**Reasonable range:** 0.5–1.5. The Board sets K₂ alongside K₁. Higher values create stronger incentives for interoperability and data portability.
+
+#### Inflation Factor
+
+The inflation factor is recalculated annually by the Board and applied to the following year's fee.
+
+```
+inflation_factor = 1 + CPI_change + buffer
+```
+
+- **CPI index**: The Board selects a widely recognized national or regional consumer price index relevant to the jurisdiction where the Organization is incorporated (see Article 8.3). The same index is used consistently year over year; changes require a Charter amendment.
+- **Buffer above CPI**: A fixed percentage above CPI, in the range of **2–5%**, to account for project infrastructure growth, maintainer compensation, and reserve fund requirements. The buffer is set in the Charter (Appendix B) and is subject to the Charter amendment process.
+- **Floor**: `inflation_factor` shall not be less than 1.0 — the fee may not decrease due to deflation.
+
+### A.4 Inclusion Index Assessment Methodology
+
+The Board assesses a Licensee's `inclusion_index` annually using the following scoring criteria. Each criterion is scored 0.0–1.0; the inclusion index is the weighted average.
+
+| Criterion | Weight | 0.0 (fully open) | 1.0 (fully closed) |
+|-----------|--------|-------------------|---------------------|
+| **Data portability** | 25% | Users can export all their data in standard formats at any time. | No export capability; data is locked to the platform. |
+| **API openness** | 20% | Public API with standard protocols; third-party integrations fully supported. | Proprietary APIs; third-party integrations blocked or heavily restricted. |
+| **Interoperability** | 20% | Product interoperates with competing products and open standards. | Product deliberately prevents interoperability with alternatives. |
+| **Switching cost** | 20% | No contractual lock-in; users can migrate to alternatives with minimal friction. | Long-term contracts, migration fees, or technical barriers that prevent switching. |
+| **Platform dependency** | 15% | No dependency on Licensee-controlled infrastructure for core functionality. | Core functionality requires Licensee-controlled proprietary infrastructure. |
+
+**Assessment process:**
+1. The Licensee submits a self-assessment alongside the annual revenue declaration (Article 4.4).
+2. The Board reviews the self-assessment and may request supporting evidence.
+3. The Board issues a final score. Disputes are resolved under Article 7 (Dispute Resolution).
+
+**Example scores:**
+- A fully open-source product with standard APIs and free data export: `inclusion_index ≈ 0.05`
+- A SaaS product with export features but proprietary APIs: `inclusion_index ≈ 0.40`
+- A walled-garden platform with no export, proprietary APIs, and vendor lock-in contracts: `inclusion_index ≈ 0.90`
 
 ---
 
@@ -294,11 +351,23 @@ The defining feature of this License is **Board-governed commercial access**: th
 
 ## Appendix C — Contributor Agreement Reference
 
-> *Commercial licensees contributing back under Article 5 must sign the Project's Contributor License Agreement (CLA). Community contributors may use the Developer Certificate of Origin (DCO) — a `Signed-off-by` line in each commit.*
->
-> **Current CLA:** [TO BE PUBLISHED]
->
-> **DCO reference:** [developercertificate.org](https://developercertificate.org/)
+Commercial licensees contributing back under Article 5 must sign the Project's **Contributor License Agreement (CLA)**. Community contributors use the **Developer Certificate of Origin (DCO)** — a `Signed-off-by` line in each commit.
+
+**CLA document:** [`legal/cla.md`](legal/cla.md)
+
+**DCO reference:** [developercertificate.org](https://developercertificate.org/)
+
+The CLA covers IP license grant, scope of Article 5 contributions, representations and warranties, and the per-entity signing process. See `legal/cla.md` for the full text.
+
+---
+
+## Appendix D — Contribution Points (C-points) Methodology
+
+C-points are the weighted composite score used to rank contributors for **Governance Pool** membership (top 1000 contributors). The Governance Pool determines voting rights and eligibility for the contributor compensation pool.
+
+**Methodology document:** [`legal/c-points.md`](legal/c-points.md)
+
+The methodology covers: variables and weights (merge volume, code scope, review labor, security work, maintenance, docs, mentorship, leadership), calculation mechanics (rolling 24-month window, daily recalculation, normalization), anti-gaming measures, and tooling requirements.
 
 ---
 

--- a/legal/c-points.md
+++ b/legal/c-points.md
@@ -1,0 +1,130 @@
+# Project JARVIS — Contribution Points (C-points) Methodology
+
+**Version:** 1.0-draft
+**Effective date:** To be set upon Organization formation (see SCCL-v1.md Article 2.1)
+
+> **Note:** This document is a working draft requiring Board ratification before becoming operative. See issue #83.
+
+---
+
+## Overview
+
+C-points are a weighted composite score that ranks contributors for eligibility in the **Governance Pool** (top 1000 contributors by C-point score, as defined in the Organization Charter, Appendix B §B.2.5). C-points replace raw merged commit count as the ranking factor, acknowledging that not all contributions carry equal weight.
+
+C-points are **not currency** and carry no direct monetary value. They determine Governance Pool membership, which in turn determines eligibility for the contributor compensation pool described in the Charter.
+
+---
+
+## 1. Variables and Weights
+
+The C-point score for a contributor over a rolling 24-month window is calculated as:
+
+```
+C = Σ (dimension_score × weight)
+```
+
+| # | Dimension | Weight | Description |
+|---|-----------|--------|-------------|
+| 1 | Merged contribution volume | 20% | Number of merged pull requests, normalized by repository activity level. |
+| 2 | Code scope | 20% | Complexity-adjusted lines of code changed, measured by cyclomatic complexity of modified functions. Pure formatting/whitespace changes score zero. |
+| 3 | Review labor | 15% | Pull requests reviewed, weighted by review thoroughness (comment depth, identified issues resolved). |
+| 4 | Security-critical work | 15% | Security patches, vulnerability fixes, security audit participation, threat-model contributions. Weighted higher due to specialized skill and project risk reduction. |
+| 5 | Maintenance burden | 10% | Long-term module ownership, triage work (issue triage, milestone tracking), on-call/incident response. |
+| 6 | Documentation contributions | 10% | User-facing documentation, API docs, guides, examples — excluding auto-generated docs. |
+| 7 | Mentorship and community | 5% | Onboarding new contributors, answering questions in issues/discussions, reviewing contributor-submitted drafts. |
+| 8 | Community leadership | 5% | Organizing, moderating, representing the project at external venues (conferences, publications). |
+
+### Weight adjustment
+
+Weights are set by the Board at license activation and may be adjusted via the Charter amendment process (Charter §B.4.5). Individual weights may be changed by up to ±5 percentage points per amendment cycle without triggering a full Charter revision; larger changes require the standard amendment quorum.
+
+---
+
+## 2. Calculation Mechanics
+
+### 2.1 Time window
+
+C-points are calculated over a **rolling 24-month window**, matching the Active Contributor definition. Contributions older than 24 months fall out of the window on a daily rolling basis.
+
+Rationale: a rolling window keeps the Governance Pool populated by currently active contributors rather than rewarding historical work that may no longer reflect project involvement.
+
+### 2.2 Recalculation frequency
+
+C-point scores are recalculated **daily** via automated tooling (see §5). The Governance Pool membership list (top 1000) is published monthly as a snapshot.
+
+### 2.3 Normalization
+
+Each dimension score is normalized to a 0–100 scale before weighting, using the 95th-percentile contributor in that dimension as the normalization ceiling. This prevents any single prolific contributor from dominating the composite score through volume alone.
+
+### 2.4 Multi-category contributions
+
+A contribution may span multiple categories (e.g., a security fix that also includes documentation). Each category's score is credited independently; there is no double-counting penalty.
+
+### 2.5 Reverted contributions
+
+If a merged contribution is subsequently reverted, the C-points credited for that contribution are removed retroactively from the contributor's score at the time of revert.
+
+---
+
+## 3. Anti-Gaming Measures
+
+### 3.1 Minimum quality threshold
+
+A pull request must meet the project's code quality bar (CI passing, review approval from a maintainer) to generate any C-points. Merged-but-reverted PRs, trivial changes (e.g., single-character fixes, whitespace normalization), and automated/bot submissions are excluded.
+
+### 3.2 Volume floor
+
+A single contributor's **merged contribution volume** dimension (dimension 1) is capped at the 95th-percentile normalization ceiling. Submitting more than the ceiling amount of PRs in the window does not increase the score beyond the ceiling for that dimension.
+
+### 3.3 Review credit requires engagement
+
+Review labor (dimension 3) credit requires reviews with substantive content (minimum comment threshold set by the Board). Rubber-stamp approvals with no comments do not generate review credits.
+
+### 3.4 Bot and automated contributions excluded
+
+Contributions authored by automated systems, bots, or CI pipelines are ineligible for C-points regardless of merge status. Contributions must be attributed to a human contributor identity.
+
+### 3.5 Board audit rights
+
+The Board may audit any contributor's C-point breakdown and disqualify contributions that appear to be the result of gaming or coordinated inflation. Disputes are resolved under the Charter dispute resolution process.
+
+---
+
+## 4. Edge Cases
+
+| Scenario | Treatment |
+|----------|-----------|
+| Contributor leaves and contributions are reverted en masse | C-points removed retroactively for reverted work; remaining valid work retains credits. |
+| Co-authored contribution (two contributors) | C-points split equally between co-authors unless otherwise noted in the PR. |
+| Contribution submitted under CLA (commercial) | C-points not awarded for contributions made under the CLA (commercial obligation). Only voluntary community contributions earn C-points. |
+| Contributor changes GitHub identity | Tooling must map old → new identity; historical C-points transfer. Contributor must notify the Organization to trigger identity merge. |
+
+---
+
+## 5. Tooling
+
+As required by Charter §D.3, contributors must be able to view their C-point score and per-dimension breakdown.
+
+**Planned interfaces:**
+- **Web dashboard** — available at a URL published in the Organization's public registry. Shows total score, 24-month trend, and per-dimension breakdown.
+- **CLI command** — `jarvis contrib score [--contributor <github-handle>]` returns the score for the caller or a named contributor.
+- **GitHub Action** — runs on PR merge to update the contributor's score in the registry.
+
+The canonical score is stored in the Organization's registry (not derived from GitHub stats alone), to allow for Board adjustments, identity merges, and audit overrides.
+
+---
+
+## 6. Governance Pool Membership
+
+The **Governance Pool** consists of the top 1000 contributors by C-point score in the rolling 24-month window. Membership is recalculated monthly.
+
+Governance Pool members receive:
+- A weighted vote on Charter amendments and major project decisions (Charter §B.3).
+- Eligibility for the contributor compensation pool distribution (Charter §B.5).
+- Recognition in the public contributor registry.
+
+A contributor who leaves the top 1000 loses Governance Pool membership at the next monthly recalculation. There is no grandfather provision.
+
+---
+
+*This methodology document is maintained by the Organization Board. Amendment proposals should be submitted as pull requests to this file with a corresponding Charter amendment reference.*

--- a/legal/cla.md
+++ b/legal/cla.md
@@ -1,0 +1,113 @@
+# Project JARVIS — Contributor License Agreement (CLA)
+
+**Version:** 1.0-draft
+**Effective date:** To be set upon Organization formation (see SCCL-v1.md Article 2.1)
+
+> **Note:** This document is a working draft. It requires legal review before becoming binding. See issue #83 for the finalization milestone.
+
+---
+
+## Scope and Purpose
+
+This Contributor License Agreement ("Agreement") applies to **commercial licensees** contributing modifications or derivative works to the Project JARVIS codebase under the obligations of the Sustainable Commercial Contributor License (SCCL), Article 5.
+
+Community contributors (individuals) do not sign this Agreement. They use the **Developer Certificate of Origin (DCO)** — a `Signed-off-by` line in each commit — as documented in `CONTRIBUTING.md`.
+
+This Agreement governs:
+1. Contributions made to satisfy the mandatory contribution-back obligation under SCCL Article 5 (modifications to the Software deployed in a commercial product, due within 90 days of deployment).
+2. Voluntary contributions from commercial licensees beyond their Article 5 obligations.
+
+---
+
+## Article 1 — Definitions
+
+**"Contributor"** means the legal entity (company, organization, or person acting on behalf of their employer) that executes this Agreement.
+
+**"Contribution"** means any original work of authorship, including modifications, additions, or derivative works, submitted to the Project JARVIS repository by the Contributor.
+
+**"Organization"** means the governing body of Project JARVIS as defined in the Organization Charter (SCCL Appendix B).
+
+**"Project"** means the Project JARVIS software repository and all associated tooling, documentation, and infrastructure managed by the Organization.
+
+**"SCCL"** means the Sustainable Commercial Contributor License, Version 1, governing the Contributor's commercial use of the Project.
+
+---
+
+## Article 2 — License Grant
+
+### 2.1 Copyright License
+
+Subject to the terms and conditions of this Agreement, the Contributor hereby grants to the Organization and to all recipients of software distributed by the Organization a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license** to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute the Contribution and such derivative works.
+
+### 2.2 Patent License
+
+Subject to the terms and conditions of this Agreement, the Contributor hereby grants to the Organization and to all recipients of software distributed by the Organization a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license** to make, have made, use, offer to sell, sell, import, and otherwise transfer the Contribution, where such license applies only to those patent claims licensable by the Contributor that are necessarily infringed by the Contribution alone or by the combination of the Contribution with the Project to which the Contribution was submitted.
+
+### 2.3 Retained Rights
+
+The Contributor retains all rights, title, and interest in and to the Contribution not expressly granted above. This Agreement is a **license grant, not a copyright assignment**. The Contributor may continue to use, license, and distribute the Contribution independently.
+
+### 2.4 No Governance Rights
+
+A license grant under this Agreement does not confer Governance Pool membership or C-point credits on the contributing entity. Commercial contributions under SCCL Article 5 are an obligation of the SCCL, not a voluntary community contribution. Governance rights are addressed separately in the Charter (SCCL Appendix B).
+
+---
+
+## Article 3 — Representations and Warranties
+
+The Contributor represents and warrants that:
+
+1. **Authority.** The Contributor has the legal authority to enter into this Agreement and to grant the licenses set out in Article 2. If the Contributor is a company or organization, the individual executing this Agreement is duly authorized to bind the Contributor.
+
+2. **Originality.** Each Contribution is the Contributor's original work, or the Contributor has sufficient rights to grant the licenses described in Article 2.
+
+3. **No third-party IP conflicts.** The Contribution does not, to the Contributor's knowledge, infringe or misappropriate any third party's intellectual property rights, including patents, copyrights, trademarks, or trade secrets.
+
+4. **Employer authorization.** If the Contribution was created in the course of the Contributor's employment, the Contributor's employer has authorized this Agreement and the grant of rights herein, or the employer has waived all rights in the Contribution.
+
+5. **Notification of third-party elements.** If any portion of a Contribution is not the Contributor's original work and includes third-party intellectual property, the Contributor will identify such third-party elements at the time of submission with as much detail as reasonably practicable (e.g., license type, source).
+
+---
+
+## Article 4 — Process
+
+### 4.1 Signing
+
+This Agreement is signed **per legal entity** (not per individual developer). One signed Agreement covers all Contributions made by employees or contractors of the Contributor.
+
+Signing process:
+1. The authorized representative of the Contributor submits a signed copy of this Agreement to the Organization via the contact method published in the Project's `SECURITY.md` or the Organization's official contact channel.
+2. The Organization maintains a registry of signed CLAs. Upon signing, the Contributor is added to `legal/cla-signatories.md`.
+3. A signed Agreement remains in effect indefinitely unless terminated by either party with 30 days' written notice.
+
+### 4.2 Submission
+
+Contributions subject to this Agreement are submitted via pull request to the Project JARVIS GitHub repository. Each pull request must:
+- Reference the SCCL Article 5 obligation (if applicable) or state that it is a voluntary contribution.
+- Include a commit footer: `Contributed-under: Project JARVIS CLA v1.0`
+
+### 4.3 Relationship to SCCL Article 5
+
+This Agreement satisfies the legal framework for the contribution-back obligation in SCCL Article 5. A Contributor that has not signed this Agreement is not in compliance with Article 5 until a signed Agreement is on file with the Organization.
+
+---
+
+## Article 5 — Disclaimer
+
+THE CONTRIBUTION IS PROVIDED "AS IS". THE CONTRIBUTOR MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT.
+
+---
+
+## Article 6 — Governing Law
+
+This Agreement is governed by the laws of the jurisdiction specified in the Organization Charter (SCCL Article 8.3), without regard to conflict-of-law principles.
+
+---
+
+## Article 7 — Entire Agreement
+
+This Agreement, together with the SCCL and the Organization Charter, constitutes the entire agreement between the parties with respect to the subject matter hereof and supersedes all prior or contemporaneous understandings regarding such subject matter.
+
+---
+
+*By submitting a Contribution or by executing this Agreement, the Contributor agrees to be bound by the terms herein.*


### PR DESCRIPTION
## Summary

Addresses #96, #97, and #98 — the three legal documentation issues under the #83 sustainability umbrella.

**Appendix A (SCCL-v1.md `Appendix A — Fee Formula`)**
- Full explanatory text for K₁ (1–5% range, Board guidance on maturity and licensee size)
- Full explanatory text for K₂ (0.5–1.5 range, lock-in penalty interpretation)
- Inflation factor: CPI index selection rationale, 2–5% buffer, floor = 1.0
- Inclusion index: 5-criterion scoring rubric (data portability 25%, API openness 20%, interoperability 20%, switching cost 20%, platform dependency 15%) with worked examples
- Appendix D placeholder updated to reference new `legal/c-points.md`

**`legal/cla.md`** — Full draft CLA for commercial contributors (SCCL Article 5)
- Copyright + patent license grant (not copyright assignment)
- No governance rights from commercial contributions
- Representations and warranties (authority, originality, no IP conflicts, employer authorization)
- Per-entity signing process, PR footer: `Contributed-under: Project JARVIS CLA v1.0`

**`legal/c-points.md`** — C-points methodology for Governance Pool ranking
- 8 dimensions with weights summing to 100%
- Rolling 24-month window, daily recalculation, 95th-percentile normalization
- Anti-gaming: quality threshold, volume cap, review engagement, bot exclusion, Board audit
- Tooling: web dashboard + `jarvis contrib score` CLI + GitHub Action

> These are drafts requiring legal review before becoming binding. See #83.

## Test plan

- [ ] SCCL-v1.md renders correctly in GitHub markdown
- [ ] `legal/cla.md` links work
- [ ] `legal/c-points.md` links work
- [ ] Appendix A formula examples are mathematically consistent

Closes #96
Closes #97
Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)