### PR TITLE
feat(providers): per-provider temperature setting

### DIFF
--- a/jarvis/cli.py
+++ b/jarvis/cli.py
@@ -321,6 +321,8 @@ def _cmd_providers() -> None:
                 print(f"      url: {url}")
             if ptype == "api":
                 print(f"      api_key: {'set' if p.get('api_key') else '(not set)'}")
+            if p.get("temperature") is not None:
+                print(f"      temperature: {p['temperature']}")
             print()
         print(f"  File: {Config.PROVIDERS_FILE}")
         return
@@ -333,8 +335,19 @@ def _cmd_providers() -> None:
         model = flags.get("model", "")
         if not ptype or not model:
             print("Usage: jarvis providers add --type <ollama|api> --model <model>")
-            print("  Optional: --name <label> --url <url> --key <api_key>")
+            print(
+                "  Optional: --name <label> --url <url> --key <api_key> --temperature <0.0-2.0>"
+            )
             sys.exit(1)
+        temp = None
+        if flags.get("temperature"):
+            try:
+                temp = float(flags["temperature"])
+            except ValueError:
+                print(
+                    f"Error: Temperature must be a number, got '{flags['temperature']}'"
+                )
+                sys.exit(1)
         try:
             name, position = add_provider(
                 ptype,
@@ -342,6 +355,7 @@ def _cmd_providers() -> None:
                 name=flags.get("name"),
                 url=flags.get("url"),
                 api_key=flags.get("key"),
+                temperature=temp,
             )
             print(f"Added provider '{name}' ({ptype}/{model}) at position {position}")
         except ValueError as e:

--- a/jarvis/core/providers.py
+++ b/jarvis/core/providers.py
@@ -51,6 +51,7 @@ def add_provider(
     name: Optional[str] = None,
     url: Optional[str] = None,
     api_key: Optional[str] = None,
+    temperature: Optional[float] = None,
 ) -> Tuple[str, int]:
     """Add a provider. Returns (name, position) or raises ValueError."""
     ptype = ptype.lower()
@@ -72,6 +73,8 @@ def add_provider(
         entry["url"] = url
     if api_key:
         entry["api_key"] = api_key
+    if temperature is not None:
+        entry["temperature"] = temperature
 
     data.setdefault("providers", []).append(entry)
     save_providers(data)
@@ -114,9 +117,15 @@ def move_provider(name: str, position: int) -> None:
     save_providers(data)
 
 
-def edit_provider(name: str, **fields: str) -> List[str]:
+def edit_provider(name: str, **fields) -> List[str]:
     """Update fields on an existing provider. Returns list of updated field names."""
-    field_map = {"model": "model", "url": "url", "key": "api_key", "type": "type"}
+    field_map = {
+        "model": "model",
+        "url": "url",
+        "key": "api_key",
+        "type": "type",
+        "temperature": "temperature",
+    }
 
     data = load_providers()
     target = None
@@ -135,7 +144,9 @@ def edit_provider(name: str, **fields: str) -> List[str]:
             updated.append(flag_key)
 
     if not updated:
-        raise ValueError("No recognized fields. Use model, url, key, or type.")
+        raise ValueError(
+            "No recognized fields. Use model, url, key, temperature, or type."
+        )
 
     save_providers(data)
     return updated

--- a/jarvis/tui/local_input.py
+++ b/jarvis/tui/local_input.py
@@ -121,7 +121,9 @@ def _show_providers(app: Any) -> None:
             elif s == "error":
                 status_str = " [red]error[/red]"
 
-        lines.append(f"  [{i + 1}] {name} — {ptype}/{model}{status_str}")
+        temp = p.get("temperature")
+        temp_str = f" (temp={temp})" if temp is not None else ""
+        lines.append(f"  [{i + 1}] {name} — {ptype}/{model}{temp_str}{status_str}")
 
     app._append_log("\n".join(lines))
 
@@ -153,6 +155,7 @@ def _handle_providers(app: Any, text: str) -> None:
                         name=result.name or None,
                         url=result.url or None,
                         api_key=result.api_key or None,
+                        temperature=result.temperature,
                     )
                     app._append_log(
                         f"[green]Added provider '{pname}' ({result.ptype}/{result.model}) "
@@ -235,6 +238,8 @@ def _handle_providers(app: Any, text: str) -> None:
                     fields["key"] = result.api_key
                 if result.ptype:
                     fields["type"] = result.ptype
+                if result.temperature is not None:
+                    fields["temperature"] = result.temperature
                 if not fields:
                     return
                 try:

--- a/jarvis/tui/provider_modal.py
+++ b/jarvis/tui/provider_modal.py
@@ -20,6 +20,7 @@ class ProviderModalResult:
     name: str = ""
     url: str = ""
     api_key: str = ""
+    temperature: Optional[float] = None
 
 
 _OLLAMA_DEFAULT_URL = "http://localhost:11434"
@@ -117,8 +118,14 @@ class ProviderModal(ModalScreen[ProviderModalResult]):
 
     def compose(self) -> ComposeResult:
         ex = self._existing
-        title = "Add Provider" if self._mode == "add" else f"Edit Provider: {ex.get('name', '')}"
-        default_url = ex.get("url", _OLLAMA_DEFAULT_URL if self._ptype == "ollama" else "")
+        title = (
+            "Add Provider"
+            if self._mode == "add"
+            else f"Edit Provider: {ex.get('name', '')}"
+        )
+        default_url = ex.get(
+            "url", _OLLAMA_DEFAULT_URL if self._ptype == "ollama" else ""
+        )
 
         with Vertical(id="provider-dialog"):
             yield Label(title, id="dialog-title")
@@ -133,13 +140,36 @@ class ProviderModal(ModalScreen[ProviderModalResult]):
                 )
 
             yield Label("Model", classes="field-label")
-            yield Input(value=ex.get("model", ""), placeholder="e.g. qwen3:8b or gpt-4o", id="input-model")
+            yield Input(
+                value=ex.get("model", ""),
+                placeholder="e.g. qwen3:8b or gpt-4o",
+                id="input-model",
+            )
 
-            yield Label("Name  (optional — auto-generated if blank)", classes="field-label")
-            yield Input(value=ex.get("name", ""), placeholder="e.g. my-ollama", id="input-name")
+            yield Label(
+                "Name  (optional — auto-generated if blank)", classes="field-label"
+            )
+            yield Input(
+                value=ex.get("name", ""), placeholder="e.g. my-ollama", id="input-name"
+            )
 
             yield Label("URL", classes="field-label")
-            yield Input(value=default_url, placeholder=_OLLAMA_DEFAULT_URL, id="input-url")
+            yield Input(
+                value=default_url, placeholder=_OLLAMA_DEFAULT_URL, id="input-url"
+            )
+
+            yield Label(
+                "Temperature  (0.0–2.0, blank = global default)", classes="field-label"
+            )
+            yield Input(
+                value=(
+                    str(ex.get("temperature", ""))
+                    if ex.get("temperature") is not None
+                    else ""
+                ),
+                placeholder="0.7",
+                id="input-temperature",
+            )
 
             yield Label("API Key", classes="field-label")
             with Horizontal():
@@ -205,6 +235,22 @@ class ProviderModal(ModalScreen[ProviderModalResult]):
             err.add_class("visible")
             return
 
+        temperature: Optional[float] = None
+        temp_str = self.query_one("#input-temperature", Input).value.strip()
+        if temp_str:
+            try:
+                temperature = float(temp_str)
+                if temperature < 0.0 or temperature > 2.0:
+                    err = self.query_one("#error-label", Static)
+                    err.update("Temperature must be between 0.0 and 2.0.")
+                    err.add_class("visible")
+                    return
+            except ValueError:
+                err = self.query_one("#error-label", Static)
+                err.update("Temperature must be a number (e.g. 0.7).")
+                err.add_class("visible")
+                return
+
         self.dismiss(
             ProviderModalResult(
                 confirmed=True,
@@ -213,5 +259,6 @@ class ProviderModal(ModalScreen[ProviderModalResult]):
                 name=self.query_one("#input-name", Input).value.strip(),
                 url=url,
                 api_key=api_key,
+                temperature=temperature,
             )
         )

--- a/jarvis/tui/slash_commands_doc.py
+++ b/jarvis/tui/slash_commands_doc.py
@@ -38,11 +38,17 @@ TUI_LOCAL_SLASH_HELP: tuple[tuple[str, str], ...] = (
     ("/status", "Show current provider, model, and session."),
     ("/providers", "List configured providers with live pool status."),
     ("/providers add", "Open guided modal to add a provider."),
-    ("/providers add --type ... --model ...", "Add a provider directly (power-user flags)."),
+    (
+        "/providers add --type ... --model ...",
+        "Add a provider directly (power-user flags).",
+    ),
     ("/providers remove <name>", "Remove a provider by name."),
     ("/providers move <name> <pos>", "Reorder provider priority (1 = highest)."),
     ("/providers edit <name>", "Open pre-filled modal to edit a provider."),
-    ("/providers edit <name> --field <val>", "Update a provider field directly (power-user flags)."),
+    (
+        "/providers edit <name> --field <val>",
+        "Update a provider field directly (power-user flags).",
+    ),
     ("/model [name]", "Show or switch the current LLM model."),
 )
 


### PR DESCRIPTION
## Summary

- Add temperature field to the provider add/edit modal (TUI) with 0.0–2.0 validation
- Add `--temperature` flag to CLI `jarvis providers add/edit`
- Wire temperature through the CRUD layer (`providers.py`) into `providers.json`
- Display per-provider temperature in both TUI `/providers` listing and CLI listing

No changes needed in `component_factory.py` — it already reads `spec.get("temperature")` from `providers.json` and passes it to the provider constructor.

Closes #109

## Test plan

- [ ] `/providers add` in TUI — verify temperature field appears between URL and API Key
- [ ] Enter invalid temperature (e.g. "abc", "3.0") — verify error message
- [ ] Leave temperature blank — verify it uses global `LLM_TEMPERATURE` default
- [ ] `/providers edit <name>` — verify temperature pre-fills from existing value
- [ ] `jarvis providers add --type ollama --model qwen3:4b --temperature 0.3` — verify CLI works
- [ ] `jarvis providers` — verify temperature shows in listing when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5

---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_