### PR TITLE
feat(llm): on-demand Ollama auto-start (#106)

### DIFF
--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -43,6 +43,7 @@ class Config:
 
     # Ollama-specific
     LLM_AUTO_PULL = os.getenv("LLM_AUTO_PULL", "false").lower() == "true"
+    OLLAMA_AUTO_START = os.getenv("OLLAMA_AUTO_START", "true").lower() == "true"
 
     # Sampling temperature for LLM responses (0.0 = deterministic, 1.0+ = creative)
     # Default 0.7 gives a balance of consistency and variety.

--- a/jarvis/core/component_factory.py
+++ b/jarvis/core/component_factory.py
@@ -71,6 +71,8 @@ class ComponentFactory:
                     )
                     entries.append(ProviderEntry(provider=provider, name=name))
                     logger.info(f"  [{len(entries)}] {name}: {ptype}/{model}")
+                    if ptype == "ollama":
+                        provider.is_available()  # proactive auto-start at startup
                 except Exception as e:
                     logger.warning(f"Failed to create provider '{name}': {e}")
 

--- a/jarvis/core/component_factory.py
+++ b/jarvis/core/component_factory.py
@@ -71,8 +71,6 @@ class ComponentFactory:
                     )
                     entries.append(ProviderEntry(provider=provider, name=name))
                     logger.info(f"  [{len(entries)}] {name}: {ptype}/{model}")
-                    if ptype == "ollama":
-                        provider.is_available()  # proactive auto-start at startup
                 except Exception as e:
                     logger.warning(f"Failed to create provider '{name}': {e}")
 

--- a/jarvis/llm/providers/ollama.py
+++ b/jarvis/llm/providers/ollama.py
@@ -3,7 +3,7 @@
 import subprocess
 import sys
 import time
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
 from ...core.logger import get_logger
 from ..base import BaseLLMProvider
@@ -13,7 +13,8 @@ logger = get_logger(__name__)
 LLM_TIMEOUT = 60  # seconds — prevents indefinite hangs on cloud API
 
 _shared_clients: Dict[tuple, Any] = {}
-_autostart_attempted: Set[str] = set()  # hosts where we've already tried auto-start
+_last_autostart: Dict[str, float] = {}  # host -> epoch of last auto-start attempt
+AUTOSTART_COOLDOWN = 60.0  # minimum seconds between auto-start attempts per host
 
 
 def _is_ollama_up(base_url: str) -> bool:
@@ -265,19 +266,23 @@ class OllamaProvider(BaseLLMProvider):
         return self.base_url != "http://localhost:11434"
 
     def _maybe_autostart(self) -> bool:
-        """Try to start Ollama if this is a localhost provider and we haven't yet.
+        """Try to start Ollama if this is a localhost provider and the cooldown has elapsed.
 
-        Returns True if Ollama is now reachable.  Respects OLLAMA_AUTO_START.
+        Returns True if Ollama is now reachable.  Respects OLLAMA_AUTO_START and
+        AUTOSTART_COOLDOWN to avoid hammering the system on repeated failures.
         """
+        import time as _time
+
         from ...config import Config
 
         if self._is_remote:
             return False
         if not Config.OLLAMA_AUTO_START:
             return False
-        if self.base_url in _autostart_attempted:
+        now = _time.monotonic()
+        if now - _last_autostart.get(self.base_url, 0) < AUTOSTART_COOLDOWN:
             return False
-        _autostart_attempted.add(self.base_url)
+        _last_autostart[self.base_url] = now
         return _try_start_ollama(self.base_url)
 
     def is_available(self) -> bool:

--- a/jarvis/llm/providers/ollama.py
+++ b/jarvis/llm/providers/ollama.py
@@ -3,7 +3,7 @@
 import subprocess
 import sys
 import time
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
 from ...core.logger import get_logger
 from ..base import BaseLLMProvider
@@ -13,7 +13,8 @@ logger = get_logger(__name__)
 LLM_TIMEOUT = 60  # seconds — prevents indefinite hangs on cloud API
 
 _shared_clients: Dict[tuple, Any] = {}
-_autostart_attempted: Set[str] = set()  # hosts where we've already tried auto-start
+_last_autostart: Dict[str, float] = {}
+AUTOSTART_COOLDOWN = 60.0
 
 
 def _is_ollama_up(base_url: str) -> bool:
@@ -130,6 +131,7 @@ class OllamaProvider(BaseLLMProvider):
     # -- BaseLLMProvider interface -------------------------------------------
 
     def chat(self, messages: List[Dict[str, str]]) -> str:
+        self._maybe_autostart()
         self._ensure_client()
 
         options = {}
@@ -180,27 +182,6 @@ class OllamaProvider(BaseLLMProvider):
                             )
                             raise
                 raise RuntimeError(f"model '{self.model}' not found (status code: 404)")
-
-            # Connection error to localhost — try auto-start once then retry
-            is_conn_err = any(
-                k in error_str
-                for k in ("connect", "refused", "unreachable", "network", "timeout")
-            )
-            if is_conn_err and not self._is_remote and self._maybe_autostart():
-                try:
-                    response = self._client.chat(**kwargs)
-                    text = self._extract_content(response)
-                    self.last_prompt_tokens = (
-                        getattr(response, "prompt_eval_count", 0) or 0
-                    )
-                    self.last_completion_tokens = (
-                        getattr(response, "eval_count", 0) or 0
-                    )
-                    return text
-                except Exception as retry_error:
-                    logger.error(f"Ollama chat error after auto-start: {retry_error}")
-                    raise
-
             logger.error(f"Ollama chat error: {e}")
             raise
 
@@ -264,25 +245,29 @@ class OllamaProvider(BaseLLMProvider):
     def _is_remote(self) -> bool:
         return self.base_url != "http://localhost:11434"
 
-    def _maybe_autostart(self) -> bool:
-        """Try to start Ollama if this is a localhost provider and we haven't yet.
+    def _maybe_autostart(self) -> None:
+        """Start Ollama if this is a localhost provider and it isn't running.
 
-        Returns True if Ollama is now reachable.  Respects OLLAMA_AUTO_START.
+        Rate-limited to one attempt per AUTOSTART_COOLDOWN seconds per host.
+        Controlled by OLLAMA_AUTO_START config (default true).
         """
+        import time as _time
+
         from ...config import Config
 
         if self._is_remote:
-            return False
+            return
         if not Config.OLLAMA_AUTO_START:
-            return False
-        if self.base_url in _autostart_attempted:
-            return False
-        _autostart_attempted.add(self.base_url)
-        return _try_start_ollama(self.base_url)
+            return
+        if _is_ollama_up(self.base_url):
+            return
+        now = _time.monotonic()
+        if now - _last_autostart.get(self.base_url, 0) < AUTOSTART_COOLDOWN:
+            return
+        _last_autostart[self.base_url] = now
+        _try_start_ollama(self.base_url)
 
     def is_available(self) -> bool:
-        if not self._is_remote and not _is_ollama_up(self.base_url):
-            self._maybe_autostart()
         self._ensure_client()
         try:
             self._client.list()

--- a/jarvis/llm/providers/ollama.py
+++ b/jarvis/llm/providers/ollama.py
@@ -1,7 +1,9 @@
 """Ollama LLM provider."""
 
+import subprocess
 import sys
-from typing import Any, Dict, List, Optional
+import time
+from typing import Any, Dict, List, Optional, Set
 
 from ...core.logger import get_logger
 from ..base import BaseLLMProvider
@@ -11,6 +13,61 @@ logger = get_logger(__name__)
 LLM_TIMEOUT = 60  # seconds — prevents indefinite hangs on cloud API
 
 _shared_clients: Dict[tuple, Any] = {}
+_autostart_attempted: Set[str] = set()  # hosts where we've already tried auto-start
+
+
+def _is_ollama_up(base_url: str) -> bool:
+    """Return True if Ollama responds on base_url/api/tags within 2 s."""
+    import urllib.request
+
+    try:
+        urllib.request.urlopen(f"{base_url}/api/tags", timeout=2)
+        return True
+    except Exception:
+        return False
+
+
+def _try_start_ollama(base_url: str) -> bool:
+    """Start Ollama via systemd or direct spawn. Return True if it comes up."""
+    logger.info("Ollama not reachable — attempting auto-start")
+
+    # systemd --user first (most common for desktop installs), then system-wide
+    for cmd in (
+        ["systemctl", "--user", "start", "ollama"],
+        ["systemctl", "start", "ollama"],
+    ):
+        try:
+            subprocess.run(cmd, timeout=5, capture_output=True)
+        except Exception:
+            continue
+        for _ in range(3):
+            time.sleep(1)
+            if _is_ollama_up(base_url):
+                logger.info(f"Ollama started via: {' '.join(cmd)}")
+                return True
+
+    # Fall back to direct spawn
+    try:
+        subprocess.Popen(
+            ["ollama", "serve"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        logger.warning("ollama binary not found; cannot auto-start")
+        return False
+    except Exception as exc:
+        logger.warning(f"Failed to spawn ollama serve: {exc}")
+        return False
+
+    for _ in range(5):
+        time.sleep(1)
+        if _is_ollama_up(base_url):
+            logger.info("Ollama started via direct spawn")
+            return True
+
+    logger.warning("Ollama auto-start attempted but did not become ready in time")
+    return False
 
 
 def _get_shared_client(host: str, api_key: Optional[str]) -> Any:
@@ -123,6 +180,27 @@ class OllamaProvider(BaseLLMProvider):
                             )
                             raise
                 raise RuntimeError(f"model '{self.model}' not found (status code: 404)")
+
+            # Connection error to localhost — try auto-start once then retry
+            is_conn_err = any(
+                k in error_str
+                for k in ("connect", "refused", "unreachable", "network", "timeout")
+            )
+            if is_conn_err and not self._is_remote and self._maybe_autostart():
+                try:
+                    response = self._client.chat(**kwargs)
+                    text = self._extract_content(response)
+                    self.last_prompt_tokens = (
+                        getattr(response, "prompt_eval_count", 0) or 0
+                    )
+                    self.last_completion_tokens = (
+                        getattr(response, "eval_count", 0) or 0
+                    )
+                    return text
+                except Exception as retry_error:
+                    logger.error(f"Ollama chat error after auto-start: {retry_error}")
+                    raise
+
             logger.error(f"Ollama chat error: {e}")
             raise
 
@@ -186,7 +264,25 @@ class OllamaProvider(BaseLLMProvider):
     def _is_remote(self) -> bool:
         return self.base_url != "http://localhost:11434"
 
+    def _maybe_autostart(self) -> bool:
+        """Try to start Ollama if this is a localhost provider and we haven't yet.
+
+        Returns True if Ollama is now reachable.  Respects OLLAMA_AUTO_START.
+        """
+        from ...config import Config
+
+        if self._is_remote:
+            return False
+        if not Config.OLLAMA_AUTO_START:
+            return False
+        if self.base_url in _autostart_attempted:
+            return False
+        _autostart_attempted.add(self.base_url)
+        return _try_start_ollama(self.base_url)
+
     def is_available(self) -> bool:
+        if not self._is_remote and not _is_ollama_up(self.base_url):
+            self._maybe_autostart()
         self._ensure_client()
         try:
             self._client.list()

--- a/jarvis/llm/providers/ollama.py
+++ b/jarvis/llm/providers/ollama.py
@@ -3,7 +3,7 @@
 import subprocess
 import sys
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from ...core.logger import get_logger
 from ..base import BaseLLMProvider
@@ -13,8 +13,7 @@ logger = get_logger(__name__)
 LLM_TIMEOUT = 60  # seconds — prevents indefinite hangs on cloud API
 
 _shared_clients: Dict[tuple, Any] = {}
-_last_autostart: Dict[str, float] = {}  # host -> epoch of last auto-start attempt
-AUTOSTART_COOLDOWN = 60.0  # minimum seconds between auto-start attempts per host
+_autostart_attempted: Set[str] = set()  # hosts where we've already tried auto-start
 
 
 def _is_ollama_up(base_url: str) -> bool:
@@ -266,23 +265,19 @@ class OllamaProvider(BaseLLMProvider):
         return self.base_url != "http://localhost:11434"
 
     def _maybe_autostart(self) -> bool:
-        """Try to start Ollama if this is a localhost provider and the cooldown has elapsed.
+        """Try to start Ollama if this is a localhost provider and we haven't yet.
 
-        Returns True if Ollama is now reachable.  Respects OLLAMA_AUTO_START and
-        AUTOSTART_COOLDOWN to avoid hammering the system on repeated failures.
+        Returns True if Ollama is now reachable.  Respects OLLAMA_AUTO_START.
         """
-        import time as _time
-
         from ...config import Config
 
         if self._is_remote:
             return False
         if not Config.OLLAMA_AUTO_START:
             return False
-        now = _time.monotonic()
-        if now - _last_autostart.get(self.base_url, 0) < AUTOSTART_COOLDOWN:
+        if self.base_url in _autostart_attempted:
             return False
-        _last_autostart[self.base_url] = now
+        _autostart_attempted.add(self.base_url)
         return _try_start_ollama(self.base_url)
 
     def is_available(self) -> bool:


### PR DESCRIPTION
## Summary

- Ollama is started **on demand** — only when the pool selects a local Ollama provider for a `chat()` call
- Keeps Ollama off when cloud providers are active, avoiding idle VRAM/RAM consumption
- Falls back gracefully: `systemctl --user start ollama` → `systemctl start ollama` → `ollama serve` background spawn
- 60 s cooldown per host prevents retry storms if Ollama fails to come up
- `is_available()` remains a passive health check (no side effects)
- Opt-out via `OLLAMA_AUTO_START=false`

## How it works

```
pool.chat() → entry.provider.chat()
                └── _maybe_autostart()   ← new: checks localhost + not running + cooldown
                      └── _try_start_ollama()  ← systemd or spawn
                └── _ensure_client()
                └── self._client.chat(...)
```

## Test plan

- [ ] Start JARVIS with a local Ollama provider configured but Ollama not running — first message should trigger auto-start and succeed
- [ ] Verify Ollama is NOT started at JARVIS startup (no `ollama serve` process until first message)
- [ ] With a mixed pool (local + cloud): cloud handles requests while Ollama is down; when local is next in priority and Ollama is off, auto-start fires
- [ ] Set `OLLAMA_AUTO_START=false` — confirm Ollama is NOT auto-started, error is surfaced normally
- [ ] Ollama crashes mid-session: next request to local provider triggers auto-start after 60 s cooldown

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5

---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_