### PR TITLE
feat(runtime): scope MCP docs to active dispatch chain (#117)

### DIFF
--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -158,11 +158,6 @@ class Config:
     # 0 = unknown (shows raw token count without a denominator).
     LLM_CONTEXT_WINDOW = int(os.getenv("LLM_CONTEXT_WINDOW", "0"))
 
-    # --- MCP Server Buffer ---
-    # Number of recently-used server doc blocks to keep in the system context.
-    # Frequency-based eviction: lowest-use server is dropped when buffer is full.
-    MCP_BUFFER_SIZE = int(os.getenv("MCP_BUFFER_SIZE", "5"))
-
     # --- Semantic Tool Discovery ---
     # Master switch for vector-based tool search via dispatch/dmcp
     ALLOW_EMBEDDING_SEARCH = (

--- a/jarvis/llm/provider_pool.py
+++ b/jarvis/llm/provider_pool.py
@@ -61,6 +61,8 @@ class ProviderPool(BaseLLMProvider):
             try:
                 result = entry.provider.chat(messages)
                 self.model = entry.provider.model
+                self.last_prompt_tokens = entry.provider.last_prompt_tokens
+                self.last_completion_tokens = entry.provider.last_completion_tokens
                 if entry.failure_count > 0:
                     logger.info(f"Provider '{entry.name}' recovered")
                     entry.failure_count = 0

--- a/jarvis/main.py
+++ b/jarvis/main.py
@@ -100,8 +100,8 @@ class Jarvis:
 
         # PIDs from the most recently dispatched task batch (used by wait action).
         self._pending_dispatch_pids: list = []
-        # Session-scoped MCP server doc buffer: {server_id: {"docs": str, "count": int}}
-        self.mcp_buffer: dict = {}
+        # Server docs scoped to the active dispatch chain — cleared on respond.
+        self.mcp_dispatch_docs: dict = {}
         # Set by the TUI layer to open the server config modal before setup runs.
         # Signature: async (server_id, server_name, server_desc, props, saved) -> ConfigModalResult
         self.config_modal_callback: Any = None

--- a/jarvis/runtime/root_actions.py
+++ b/jarvis/runtime/root_actions.py
@@ -90,19 +90,8 @@ async def _handle_get_server_docs(
         server_id, tools, error=tools_error, configurable_props=configurable_props
     )
 
-    # Cache successful server docs in the MCP buffer for future turns.
-    if tools and hasattr(app, "mcp_buffer"):
-        buf = app.mcp_buffer
-        if server_id in buf:
-            buf[server_id]["count"] += 1
-            buf[server_id]["docs"] = docs_block
-        else:
-            max_size = getattr(Config, "MCP_BUFFER_SIZE", 5)
-            if len(buf) >= max_size:
-                # Evict lowest-frequency entry.
-                evict = min(buf, key=lambda k: buf[k]["count"])
-                del buf[evict]
-            buf[server_id] = {"docs": docs_block, "count": 1}
+    if tools and hasattr(app, "mcp_dispatch_docs"):
+        app.mcp_dispatch_docs[server_id] = docs_block
 
     context = build_root_context(app, logger)
     context += "\n" + docs_block
@@ -377,6 +366,8 @@ async def act_on_root_response(
         apply_goal_updates(app, parsed.get("goal_updates", []))
         app.output_manager.handle_response({"output": output})
         persist_assistant_turn(app, output)
+        if hasattr(app, "mcp_dispatch_docs"):
+            app.mcp_dispatch_docs.clear()
         dismissed = app.goals.dismiss_completed()
         if dismissed:
             logger.info(f"JARVIS: Dismissed {len(dismissed)} completed goal(s)")

--- a/jarvis/runtime/root_context.py
+++ b/jarvis/runtime/root_context.py
@@ -82,13 +82,11 @@ def build_root_context(
     if summary:
         parts.append(f"CONVERSATION_SUMMARY: {summary}")
 
-    mcp_buffer = getattr(app, "mcp_buffer", {})
-    if mcp_buffer:
-        buf_parts = [
-            "MCP_BUFFER (recently used servers — call dispatch directly, skip get_server_docs):"
-        ]
-        for _sid, entry in mcp_buffer.items():
-            buf_parts.append(entry["docs"])
+    dispatch_docs = getattr(app, "mcp_dispatch_docs", {})
+    if dispatch_docs:
+        buf_parts = ["ACTIVE_SERVER_DOCS (dispatch directly, skip get_server_docs):"]
+        for _sid, docs_block in dispatch_docs.items():
+            buf_parts.append(docs_block)
         parts.append("\n".join(buf_parts))
 
     if new_input:

--- a/jarvis/runtime/session_commands.py
+++ b/jarvis/runtime/session_commands.py
@@ -119,11 +119,11 @@ def handle_slash_command(app: Any, text: str) -> bool:
             if window > 0:
                 pct = int(prompt_toks / window * 100)
                 lines.append(f"  Context window:    {window} ({pct}% used)")
-        buf = getattr(jarvis, "mcp_buffer", {})
-        if buf:
-            lines.append(f"  MCP buffer:        {len(buf)} server(s) cached")
-            for sid, entry in buf.items():
-                lines.append(f"    {sid}  (used {entry['count']}x)")
+        dispatch_docs = getattr(jarvis, "mcp_dispatch_docs", {})
+        if dispatch_docs:
+            lines.append(f"  Active server docs: {len(dispatch_docs)} server(s)")
+            for sid in dispatch_docs:
+                lines.append(f"    {sid}")
         session_reply(app, "\n".join(lines))
         return True
 

--- a/jarvis/tui/config_modal.py
+++ b/jarvis/tui/config_modal.py
@@ -60,13 +60,6 @@ _SETTINGS: List[_SettingDef] = [
         hint="Auto-deny after this many seconds",
     ),
     _SettingDef(
-        "MCP_BUFFER_SIZE",
-        "MCP buffer size",
-        "Memory",
-        "int",
-        hint="Recently-used server docs kept in context",
-    ),
-    _SettingDef(
         "RAG_TOP_K",
         "RAG top-k",
         "Memory",

--- a/jarvis/tui/local_input.py
+++ b/jarvis/tui/local_input.py
@@ -304,7 +304,6 @@ def _apply_in_memory(key: str, value: str) -> None:
 
     bool_keys = {"RESET_HISTORY_AFTER_RESPONSE"}
     int_keys = {
-        "MCP_BUFFER_SIZE",
         "RAG_TOP_K",
         "MAX_GOALS_IN_CONTEXT",
         "CONFIRMATION_TIMEOUT",


### PR DESCRIPTION
## Summary

- Replace the global session-scoped `mcp_buffer` with `mcp_dispatch_docs` — server docs are only in context while a dispatch chain is active
- `get_server_docs` populates `mcp_dispatch_docs[server_id]`; `respond` action clears it entirely
- Normal conversation turns now carry **zero MCP doc overhead** (previously up to ~2,750 tokens of cached server docs on every turn)
- Remove `MCP_BUFFER_SIZE` config, LFU eviction machinery, and settings UI entry — no longer needed
- Net -24 lines

Also includes a fix for `ProviderPool` not propagating `last_prompt_tokens` / `last_completion_tokens` up from the active provider (TUI status bar always showed 0).

## Test plan

- [ ] Send a message that triggers `search_tools` → `get_server_docs` → `dispatch` — verify the chain works as before
- [ ] After the LLM responds to the user, send a plain conversational message — verify no `ACTIVE_SERVER_DOCS` section in the root context (check debug logs)
- [ ] Run `/status` during an active dispatch chain — verify "Active server docs: N server(s)" appears
- [ ] Run `/status` during normal conversation — verify no server docs listed
- [ ] Verify TUI status bar shows token counts after each LLM response (was always 0 before)

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5

---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_