### PR TITLE
v1.0.0 release preparation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,17 +27,17 @@ jarvisos-app                — Desktop GUI (Rust + CXX-Qt + Qt6/QML)
 jarvisos                    — AI-native Linux distro (Arch base + custom kernel)
 ```
 
-### Two-Dispatch Clarification
+### Dispatch: Python wrapper vs Rust engine
 
-`jarvis/dispatch/` (Python) is the **interface layer** — wraps the Rust
-`dispatch` binary, manages subprocess lifecycle, translates Python calls into
-MCP JSON-RPC, surfaces signals back to the event loop.
+Two things share the name "dispatch":
 
-The standalone `dispatch` repo (Rust/Tokio) is the **execution engine** — spawns
-MCP tool calls in parallel, tracks PIDs, fires INIT/EXIT/REMIND/WAIT/KILL
-signals, only wakes the LLM when there is something to reason about.
+| Layer | Location | Language | Role |
+|-------|----------|----------|------|
+| Interface | `jarvis/dispatch/` | Python | Wraps the Rust binary, translates Python calls to MCP JSON-RPC, surfaces signals to the event loop |
+| Engine | `deps/rust/dispatch` (submodule) | Rust/Tokio | Spawns MCP tool calls in parallel, tracks PIDs, fires INIT/EXIT/REMIND/WAIT/KILL signals |
 
-Python dispatch wraps Rust dispatch.
+One-liner: **Python dispatch wraps Rust dispatch.** The Python package
+docstring (`jarvis/dispatch/__init__.py`) documents this boundary.
 
 ---
 

--- a/docs/SECURITY-ARCHITECTURE.md
+++ b/docs/SECURITY-ARCHITECTURE.md
@@ -103,8 +103,8 @@ Slack tokens, and months of complete chat histories.
 - Chat history lives in `~/.jarvis/` (local, not served).
 - Output socket broadcasts only to processes that explicitly connect.
 
-- Status: ✅ No default cloud exposure · ⚠️ Users choosing `LLM_PROVIDER=api`
-  must protect their own `.env`
+- Status: ✅ No default cloud exposure · ⚠️ Users adding API providers
+  must protect their `providers.json` (API keys stored there)
 
 ### Root / Privileged Execution
 
@@ -209,7 +209,7 @@ into future LLM contexts through RAG retrieval.
 |---|---|---|
 | `CONFIRMATION_MODE` | `smart` | `allow_all` disables all tool confirmation |
 | `JARVIS_SUDO_ENABLED` | `false` | `true` grants shell access to privileged commands |
-| `LLM_PROVIDER` | `ollama` | `api` requires protecting API keys in `.env` |
+| `providers.json` | (empty) | API providers store keys in this file |
 | `NOTIFICATION_SILENT` | `false` | `true` suppresses desktop confirmation UI |
 | `DATA_CONSENT` | `true` | Controls proactive vs explicit memory only |
 

--- a/jarvis/.env.example
+++ b/jarvis/.env.example
@@ -21,48 +21,15 @@
 VOSK_MODEL_PATH=models/vosk/vosk-model-small-en-us-0.15
 
 # ===========================================
-# Large Language Model Configuration
+# LLM Provider Configuration
 # ===========================================
-# LLM Provider: Choose between "ollama" (local) or "api" (remote API-based)
-# Default: "ollama"
-LLM_PROVIDER=ollama
-
-# Model identifier (required for both providers)
-# Examples for Ollama:
-# - codegemma:7b-instruct-q5_K_M (good for coding)
-# - llama3:8b (general purpose)
-# - mistral:7b (balanced performance)
-# - codellama:7b-instruct-q3_K_M (coding focused)
+# Providers are configured via `providers.json` (not .env).
+# Use the CLI or TUI to manage them:
+#   jarvis providers add --type ollama --model qwen3:4b
+#   jarvis providers add --type api --model gpt-4 --url https://api.example.com --key sk-xxx
+#   jarvis providers          # list configured providers
 #
-# Examples for API providers (OpenAI, Claude, OpenRouter, etc.):
-# - gpt-4, gpt-3.5-turbo (OpenAI)
-# - claude-3-opus-20240229 (Anthropic)
-# - deepseek/deepseek-chat (OpenRouter)
-# - Custom model identifier for your API
-LLM_MODEL=qwen3:4b
-
-# ===========================================
-# LLM Connection Settings (all providers)
-# ===========================================
-# Base URL for LLM endpoint (default: http://localhost:11434)
-# Examples:
-# - Ollama local:   http://localhost:11434
-# - OpenAI:         https://api.openai.com
-# - Anthropic:      https://api.anthropic.com
-# - OpenRouter:     https://openrouter.ai/api
-# - Custom server:  https://your-llm-server.com
-# NOTE: This is only for the chat LLM. Embeddings use EMBED_URL (see below).
-# LLM_URL=http://localhost:11434
-
-# API key for authentication (required for cloud/API providers)
-# - Not needed for local Ollama
-# - For Ollama cloud: get key at https://ollama.com/settings/keys
-# - For other providers: get key from their website
-# LLM_API_KEY=sk-...
-
-# Optional: Custom headers as JSON string
-# Most providers use Bearer token authentication via Authorization header (auto-set)
-# LLM_API_HEADERS={"X-Custom-Header": "value"}
+# Config file location: ~/.config/jarvis/providers.json
 
 # Auto-pull missing Ollama models (true/false)
 # - true: Automatically pull missing models without prompting

--- a/jarvis/cli.py
+++ b/jarvis/cli.py
@@ -160,74 +160,13 @@ def get_sudo_status() -> None:
         print("  Run 'jarvis sudo enable' or 'jarvis sudo disable' to sync")
 
 
-def set_llm_provider(provider: str) -> None:
-    """Set LLM provider (ollama or api)."""
-    provider = provider.lower().strip()
-    if provider not in ["ollama", "api"]:
-        print(f"Error: Invalid provider '{provider}'. Must be 'ollama' or 'api'")
-        sys.exit(1)
-
-    _update_env_setting("LLM_PROVIDER", provider)
-    print(f"LLM provider set to: {provider}")
-
-    if provider == "api":
-        print("  Note: Set URL and key with 'jarvis llm-url' and 'jarvis api-key'")
-
-
-def set_llm_model(model_name: str) -> None:
-    """
-    Update LLM_MODEL in .env file.
-
-    Args:
-        model_name: Model name (e.g., 'qwen2.5:7b', 'gpt-4')
-    """
-    if not model_name or not model_name.strip():
-        print("Error: Model name cannot be empty")
-        sys.exit(1)
-
-    model_name = model_name.strip()
-    _update_env_setting("LLM_MODEL", model_name)
-    print(f"LLM model set to: {model_name}")
-
-
-def get_llm_model() -> str:
-    """Get current LLM model from config."""
-    return Config.LLM_MODEL or "(not set)"
-
-
-def set_llm_url(url: str) -> None:
-    """Set LLM base URL (used by all providers)."""
-    if not url or not url.strip():
-        print("Error: URL cannot be empty")
-        sys.exit(1)
-
-    _update_env_setting("LLM_URL", url.strip())
-    print(f"LLM URL set to: {url.strip()}")
-
-
-def set_api_key(key: str) -> None:
-    """Set API key (used by all providers that require authentication)."""
-    if not key or not key.strip():
-        print("Error: API key cannot be empty")
-        sys.exit(1)
-
-    _update_env_setting("LLM_API_KEY", key.strip())
-    print(f"API key set (length: {len(key.strip())} chars)")
-
-
-def show_llm_config() -> None:
-    """Show current LLM configuration."""
-    print("LLM Configuration:")
-    print(f"  Provider: {Config.LLM_PROVIDER}")
-    print(f"  Model: {Config.LLM_MODEL or '(not set)'}")
-    print(f"  URL: {Config.LLM_URL}")
-    print(f"  API Key: {'set' if Config.LLM_API_KEY else '(not set)'}")
-
-    if Config.LLM_PROVIDER == "ollama":
-        print(f"  Auto-pull: {'enabled' if Config.LLM_AUTO_PULL else 'disabled'}")
-
-    print(f"  Dispatch binary: {Config.DISPATCH_BINARY}")
-    print(f"  Dispatch timeout: {Config.DISPATCH_TIMEOUT}s")
+def _legacy_redirect(old_cmd: str) -> None:
+    """Print a migration hint for removed legacy commands."""
+    print(f"'{old_cmd}' has been removed. Use the provider pool instead:")
+    print("  jarvis providers                                    # List providers")
+    print("  jarvis providers add --type ollama --model <model>  # Add provider")
+    print("  jarvis providers edit <name> --model <model>        # Update a field")
+    sys.exit(1)
 
 
 def _update_env_setting(key: str, value: str) -> None:
@@ -296,8 +235,7 @@ def _cmd_providers() -> None:
     if len(sys.argv) == 2:
         providers = list_providers()
         if not providers:
-            print("No providers configured in providers.json.")
-            print(f"  Using legacy config: {Config.LLM_PROVIDER} / {Config.LLM_MODEL}")
+            print("No providers configured.")
             print()
             print("Add one with:")
             print("  jarvis providers add --type ollama --model qwen3:4b")
@@ -447,21 +385,13 @@ def show_usage() -> None:
     print("  jarvis providers remove <name>                      # Remove provider")
     print("  jarvis providers move <name> <position>             # Reorder priority")
     print("  jarvis providers edit <name> --model <model>        # Update a field")
-    print()
-    print("LLM Configuration (legacy — prefer 'jarvis providers'):")
-    print("  jarvis provider <ollama|api>  # Set LLM provider")
-    print("  jarvis model                  # Show current LLM model")
-    print("  jarvis model <model_name>     # Set LLM model")
-    print("  jarvis llm-url <url>          # Set LLM base URL")
-    print("  jarvis api-key <key>          # Set API key")
-    print("  jarvis auto-pull on/off       # Enable/disable auto-pull missing models")
-    print("  jarvis llm-config             # Show current LLM configuration")
+    print(
+        "  jarvis auto-pull on/off                             # Auto-pull missing models"
+    )
 
 
 def _has_llm_configured() -> bool:
-    """True if at least one LLM source is configured (pool or legacy)."""
-    if Config.LLM_MODEL and str(Config.LLM_MODEL).strip():
-        return True
+    """True if at least one provider is configured."""
     return bool(list_providers())
 
 
@@ -592,21 +522,7 @@ def main() -> None:
             sys.exit(1)
 
     elif command == "model":
-        if len(sys.argv) == 2:
-            model = get_llm_model()
-            print(f"Current LLM model: {model}")
-        elif len(sys.argv) == 3:
-            if sys.argv[2] in ["-n", "--name", "set"]:
-                print("Error: Model name required")
-                print("Usage: jarvis model <model_name>")
-                sys.exit(1)
-            else:
-                set_llm_model(sys.argv[2])
-        elif len(sys.argv) == 4 and sys.argv[2] in ["-n", "--name", "set"]:
-            set_llm_model(sys.argv[3])
-        else:
-            print("Usage: jarvis model [<model_name>]")
-            sys.exit(1)
+        _legacy_redirect("jarvis model")
 
     elif command == "ask":
         if len(sys.argv) < 3:
@@ -618,27 +534,8 @@ def main() -> None:
         jarvis = Jarvis(text_mode=True)
         jarvis.ask(message)
 
-    elif command == "provider":
-        if len(sys.argv) < 3:
-            print(f"Current provider: {Config.LLM_PROVIDER}")
-            print("Usage: jarvis provider <ollama|api>")
-            sys.exit(1)
-        set_llm_provider(sys.argv[2])
-
-    elif command == "llm-url":
-        if len(sys.argv) < 3:
-            print(f"Current LLM URL: {Config.LLM_URL}")
-            sys.exit(1)
-        set_llm_url(sys.argv[2])
-
-    elif command == "api-key":
-        if len(sys.argv) < 3:
-            print(f"API key: {'set' if Config.LLM_API_KEY else '(not set)'}")
-            sys.exit(1)
-        set_api_key(sys.argv[2])
-
-    elif command == "llm-config":
-        show_llm_config()
+    elif command in ("provider", "llm-url", "api-key", "llm-config"):
+        _legacy_redirect(f"jarvis {command}")
 
     elif command == "providers":
         _cmd_providers()

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -32,15 +32,6 @@ class Config:
         os.path.join(MODELS_DIR, "vosk", "vosk-model-small-en-us-0.15"),
     )
 
-    # LLM Configuration
-    LLM_PROVIDER = os.getenv("LLM_PROVIDER", "ollama")  # "ollama" or "api"
-    LLM_MODEL = os.getenv("LLM_MODEL")
-
-    # Unified LLM connection settings (used by all providers)
-    LLM_URL = os.getenv("LLM_URL", "http://localhost:11434")
-    LLM_API_KEY = os.getenv("LLM_API_KEY")
-    LLM_API_HEADERS = os.getenv("LLM_API_HEADERS")
-
     # Ollama-specific
     LLM_AUTO_PULL = os.getenv("LLM_AUTO_PULL", "false").lower() == "true"
     OLLAMA_AUTO_START = os.getenv("OLLAMA_AUTO_START", "true").lower() == "true"

--- a/jarvis/core/component_factory.py
+++ b/jarvis/core/component_factory.py
@@ -76,50 +76,12 @@ class ComponentFactory:
 
             if entries:
                 return ProviderPool(entries)
-            logger.warning("No valid providers in providers.json, falling back to env")
 
-        provider_type = Config.LLM_PROVIDER.lower()
-        kwargs = {}
-        if provider_type == "ollama":
-            kwargs["base_url"] = Config.LLM_URL
-            kwargs["api_key"] = Config.LLM_API_KEY
-            kwargs["auto_pull"] = getattr(Config, "LLM_AUTO_PULL", False)
-            kwargs["temperature"] = getattr(Config, "LLM_TEMPERATURE", 0.7)
-            kwargs["strict_json"] = getattr(Config, "LLM_STRICT_JSON", False)
-            llm_think = getattr(Config, "LLM_THINK", None)
-            if llm_think is not None:
-                kwargs["think"] = llm_think
-        elif provider_type == "api":
-            if not Config.LLM_URL:
-                raise ValueError("LLM_URL must be set when using API provider")
-            if not Config.LLM_API_KEY:
-                raise ValueError("LLM_API_KEY must be set when using API provider")
-            kwargs["api_url"] = Config.LLM_URL
-            kwargs["api_key"] = Config.LLM_API_KEY
-            if Config.LLM_API_HEADERS:
-                try:
-                    kwargs["headers"] = json.loads(Config.LLM_API_HEADERS)
-                except json.JSONDecodeError:
-                    logger.warning("Invalid LLM_API_HEADERS JSON, ignoring")
-
-        provider = create_llm_provider(
-            provider=provider_type,
-            model=Config.LLM_MODEL,
-            **kwargs,
+        raise RuntimeError(
+            "No LLM providers configured.\n"
+            "  Add one with: jarvis providers add --type ollama --model qwen3:4b\n"
+            "  Or in the TUI: /providers add"
         )
-
-        if provider_type == "ollama":
-            if not provider.is_available():
-                logger.warning("Ollama provider configured but not available.")
-            else:
-                logger.info(f"Checking if model '{Config.LLM_MODEL}' is available...")
-                if not provider.ensure_model():
-                    raise RuntimeError(
-                        f"Model '{Config.LLM_MODEL}' is not available. "
-                        "Please install it or enable auto-pull."
-                    )
-
-        return ProviderPool([ProviderEntry(provider=provider, name=provider_type)])
 
     @staticmethod
     def create_llm() -> LLM:
@@ -438,8 +400,11 @@ class ComponentFactory:
         # Report active LLM provider to kernel sysfs
         kernel_client = components["kernel_client"]
         if kernel_client.available:
-            k_provider = provider_from_config(Config.LLM_PROVIDER)
-            kernel_client.report_provider(k_provider, Config.LLM_MODEL)
+            pool = components["llm"].provider
+            pname = pool.active_provider_name or "unknown"
+            model = getattr(pool, "model", "") or ""
+            k_provider = provider_from_config(pname)
+            kernel_client.report_provider(k_provider, model)
 
         logger.info("Initiations Complete!")
         return components

--- a/jarvis/dispatch/__init__.py
+++ b/jarvis/dispatch/__init__.py
@@ -1,9 +1,18 @@
 """
-Dispatch subsystem for JARVIS.
+Dispatch subsystem — Python interface layer for the Rust dispatch engine.
 
-Handles concurrent task execution through the dispatch binary,
-goal tracking for user requests, and async event merging for
-dual-input (user messages + dispatch signals).
+This package is NOT the orchestrator itself. The Rust ``dispatch`` binary
+(a separate repo/crate) is the execution engine that spawns MCP tool calls
+in parallel, tracks PIDs, and fires signals (INIT/EXIT/REMIND/WAIT/KILL).
+
+This Python package wraps that binary:
+
+- ``adapter.py``       — subprocess lifecycle, MCP JSON-RPC over stdio
+- ``discovery.py``     — semantic + keyword tool search via dmcp
+- ``dmcp_registry.py`` — dmcp CLI wrappers (install, tools, config)
+- ``goal_manager.py``  — tracks user goals and links them to dispatch PIDs
+- ``event_merger.py``  — merges voice/CLI/socket/dispatch events
+- ``transport.py``     — MCP transport type resolution
 """
 
 from .adapter import DispatchAdapter

--- a/jarvis/kernel_client.py
+++ b/jarvis/kernel_client.py
@@ -501,7 +501,7 @@ class KernelClient:
 
 def provider_from_config(provider_name: str) -> int:
     """
-    Convert a JARVIS Config.LLM_PROVIDER string to a JARVIS_PROVIDER_* int.
+    Convert a provider type name to a JARVIS_PROVIDER_* int.
     """
     mapping = {
         "ollama": PROVIDER_OLLAMA,

--- a/jarvis/llm/chat.py
+++ b/jarvis/llm/chat.py
@@ -207,7 +207,7 @@ class LLM:
                     "LLM: Cannot reach Ollama — is it running?\n"
                     f"  Expected at: {getattr(self.provider, 'base_url', 'http://localhost:11434')}\n"
                     "  Start Ollama with: ollama serve\n"
-                    "  Or set LLM_URL in ~/.config/jarvis/jarvis.conf"
+                    "  Or check your provider config: jarvis providers"
                 )
             else:
                 logger.error(f"LLM [{self._mode}] provider error: {e}")

--- a/jarvis/main.py
+++ b/jarvis/main.py
@@ -98,8 +98,6 @@ class Jarvis:
         self.voice_manager = self.components.get("voice_manager")
         self._output_clients: List[asyncio.StreamWriter] = []
 
-        # PIDs from the most recently dispatched task batch (used by wait action).
-        self._pending_dispatch_pids: list = []
         # Server docs scoped to the active dispatch chain — cleared on respond.
         self.mcp_dispatch_docs: dict = {}
         # Set by the TUI layer to open the server config modal before setup runs.

--- a/jarvis/runtime/dispatch_flow.py
+++ b/jarvis/runtime/dispatch_flow.py
@@ -649,6 +649,12 @@ async def dispatch_execute_tasks(
         )
         return
 
+    pids = _extract_pids_from_result(result)
+    if pids:
+        active = app.goals.get_active_goals()
+        if active:
+            app.goals.link_tasks(active[-1].id, pids)
+
     app.llm.switch_mode("root")
     context = build_root_context(app, logger)
     if isinstance(result, dict) and "error" in result:

--- a/jarvis/tui/local_input.py
+++ b/jarvis/tui/local_input.py
@@ -66,8 +66,8 @@ def handle_local_input(app: Any, text: str, bindings: Any) -> bool:
 
 def _show_status(app: Any) -> None:
     """Display current provider, model, and session info."""
-    model = getattr(Config, "LLM_MODEL", None) or "(unset)"
-    provider_name = getattr(Config, "LLM_PROVIDER", "?")
+    model = "(unset)"
+    provider_name = "(none)"
 
     pool = None
     if app.jarvis is not None and hasattr(app.jarvis, "llm"):
@@ -103,7 +103,7 @@ def _show_providers(app: Any) -> None:
     if not providers:
         app._append_log(
             "[dim]No providers configured. "
-            f"Using legacy: {Config.LLM_PROVIDER} / {Config.LLM_MODEL}[/dim]"
+            "Use /providers add or: jarvis providers add --type ollama --model qwen3:4b[/dim]"
         )
         return
 
@@ -275,7 +275,7 @@ def _handle_model(app: Any, text: str) -> None:
     """Show or switch the current model."""
     parts = text.strip().split(maxsplit=1)
     if len(parts) == 1:
-        model = getattr(Config, "LLM_MODEL", None) or "(unset)"
+        model = "(unset)"
         pool = None
         if app.jarvis is not None and hasattr(app.jarvis, "llm"):
             pool = getattr(app.jarvis.llm, "provider", None)
@@ -284,18 +284,9 @@ def _handle_model(app: Any, text: str) -> None:
         app._append_log(f"[bold cyan]Model:[/bold cyan] {model}")
         return
 
-    new_model = parts[1].strip()
-    from .status_bar import update_status
-
-    try:
-        from ..cli import _update_env_setting
-
-        _update_env_setting("LLM_MODEL", new_model)
-        app._append_log(f"[green]Model set to: {new_model}[/green]")
-        app._append_log("[dim]Note: takes effect on next LLM request or restart.[/dim]")
-        update_status(app)
-    except Exception as e:
-        app._append_log(f"[red]Error setting model: {e}[/red]")
+    app._append_log(
+        "[yellow]Use /providers edit <name> --model <model> to change a provider's model.[/yellow]"
+    )
 
 
 def _apply_in_memory(key: str, value: str) -> None:
@@ -352,7 +343,11 @@ def export_transcript_to_disk(app: Any, filename: Optional[str]) -> None:
         return
 
     sid2 = "none"
-    model = getattr(Config, "LLM_MODEL", None) or "(unset)"
+    model = "(unset)"
+    if app.jarvis is not None and hasattr(app.jarvis, "llm"):
+        pool = getattr(app.jarvis.llm, "provider", None)
+        if pool is not None:
+            model = getattr(pool, "model", model)
     if app.jarvis is not None and app.jarvis.sessions.current:
         sid2 = app.jarvis.sessions.current.id
 

--- a/jarvis/tui/status_bar.py
+++ b/jarvis/tui/status_bar.py
@@ -16,8 +16,8 @@ def update_status(app: Any) -> None:
     else:
         parts.append("session: (none)")
 
-    model = getattr(Config, "LLM_MODEL", None) or "(unset)"
-    provider = getattr(Config, "LLM_PROVIDER", "?")
+    model = "(unset)"
+    provider = "(none)"
 
     if app.jarvis is not None and hasattr(app.jarvis, "llm"):
         pool = getattr(app.jarvis.llm, "provider", None)

--- a/packaging/jarvis-daemon
+++ b/packaging/jarvis-daemon
@@ -69,11 +69,6 @@ class JarvisDaemon:
             # Setup environment
             self.setup_environment()
 
-            # Check LLM model is configured (required)
-            if not Config.LLM_MODEL or not str(Config.LLM_MODEL).strip():
-                self.logger.error("LLM_MODEL not configured. Configure model before starting.")
-                return 1
-
             # Initialize JARVIS
             self.logger.info("Initializing JARVIS...")
             self.jarvis = Jarvis()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,7 @@ import pytest
 def temp_env_file():
     """Create a temporary .env file for testing"""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".env", delete=False) as f:
-        f.write("""LLM_MODEL=test-model
-LLM_PROVIDER=ollama
-DISPATCH_TIMEOUT=30
+        f.write("""DISPATCH_TIMEOUT=30
 OUTPUT_MODE=text
 """)
         f.flush()
@@ -28,8 +26,6 @@ OUTPUT_MODE=text
 def mock_config():
     """Mock configuration for testing"""
     return {
-        "LLM_MODEL": "test-model",
-        "LLM_PROVIDER": "ollama",
         "DISPATCH_TIMEOUT": 60,
         "OUTPUT_MODE": "text",
         "LOG_LEVEL": "INFO",

--- a/tests/test_config_direct.py
+++ b/tests/test_config_direct.py
@@ -21,7 +21,6 @@ class TestConfigDirect:
     @patch.dict(
         os.environ,
         {
-            "LLM_MODEL": "test-model",
             "TTS_MODEL_ONNX": "test.onnx",
             "TTS_MODEL_JSON": "test.json",
             "DISPATCH_TIMEOUT": "60",
@@ -36,7 +35,6 @@ class TestConfigDirect:
         importlib.reload(jarvis.config)
         Config = jarvis.config.Config
 
-        assert Config.LLM_MODEL == "test-model"
         assert Config.TTS_MODEL_ONNX == "test.onnx"
         assert Config.TTS_MODEL_JSON == "test.json"
         assert Config.DISPATCH_TIMEOUT == 60
@@ -83,7 +81,6 @@ class TestConfigDirect:
         """Test default values when environment variables are not set"""
         from jarvis.config import Config
 
-        assert hasattr(Config, "LLM_MODEL")
         assert hasattr(Config, "TTS_MODEL_ONNX")
         assert hasattr(Config, "TTS_MODEL_JSON")
         assert hasattr(Config, "DISPATCH_BINARY")

--- a/tests/test_health_checks.py
+++ b/tests/test_health_checks.py
@@ -184,8 +184,6 @@ class TestConfig:
     def test_config_has_expected_attributes(self):
         from jarvis.config import Config
 
-        assert hasattr(Config, "LLM_PROVIDER")
-        assert hasattr(Config, "LLM_MODEL")
         assert hasattr(Config, "OUTPUT_MODE")
         assert hasattr(Config, "LOG_LEVEL")
         assert hasattr(Config, "DISPATCH_TIMEOUT")

--- a/tests/test_integration_components.py
+++ b/tests/test_integration_components.py
@@ -118,8 +118,7 @@ class TestComponentFactoryIntegration:
 
             components = ComponentFactory.create_all_components(text_mode=True)
 
-            # Output manager gets TTS instance
-            mock_om.assert_called_once_with(tts_instance)
+            mock_om.assert_called_once_with(tts_instance, suppress_stdout=False)
 
 
 @pytest.mark.integration

--- a/tests/test_integration_config.py
+++ b/tests/test_integration_config.py
@@ -33,14 +33,12 @@ class TestConfigurationLoading:
         with patch.dict(
             os.environ,
             {
-                "LLM_MODEL": "test-model",
                 "DISPATCH_TIMEOUT": "45",
                 "OUTPUT_MODE": "voice",
                 "LOG_LEVEL": "DEBUG",
             },
         ):
             Config = _reload_config()
-            assert Config.LLM_MODEL == "test-model"
             assert Config.DISPATCH_TIMEOUT == 45
             assert Config.OUTPUT_MODE == "voice"
             assert Config.LOG_LEVEL == "DEBUG"
@@ -49,7 +47,6 @@ class TestConfigurationLoading:
         """Test configuration uses defaults when environment variables not set."""
         from jarvis.config import Config
 
-        assert hasattr(Config, "LLM_PROVIDER")
         assert hasattr(Config, "OUTPUT_MODE")
         assert hasattr(Config, "LOG_LEVEL")
         assert hasattr(Config, "DISPATCH_BINARY")
@@ -62,13 +59,11 @@ class TestConfigurationLoading:
         with patch.dict(
             os.environ,
             {
-                "LLM_MODEL": "override-model",
                 "OUTPUT_MODE": "text",
                 "DISPATCH_TIMEOUT": "120",
             },
         ):
             Config = _reload_config()
-            assert Config.LLM_MODEL == "override-model"
             assert Config.OUTPUT_MODE == "text"
             assert Config.DISPATCH_TIMEOUT == 120
 
@@ -206,7 +201,6 @@ class TestConfigurationValidation:
         """Test handling when required configuration is missing."""
         from jarvis.config import Config
 
-        assert hasattr(Config, "LLM_MODEL")
         assert hasattr(Config, "DISPATCH_BINARY")
         assert Config.DISPATCH_TIMEOUT > 0
 
@@ -312,10 +306,8 @@ class TestConfigurationPersistence:
         with patch.dict(
             os.environ,
             {
-                "LLM_MODEL": "persistence-test",
                 "DISPATCH_TIMEOUT": "123",
             },
         ):
             Config = _reload_config()
-            assert Config.LLM_MODEL == "persistence-test"
             assert Config.DISPATCH_TIMEOUT == 123


### PR DESCRIPTION
## Summary

Pre-release cleanup for the first tagged v1.0.0 release. Resolves the three outstanding issues blocking the milestone:

- **#119** — Remove dead `_pending_dispatch_pids` field from `Jarvis` and add PID→goal linking in ROOT-mode dispatch so EXIT signals resolve to the correct goal context
- **#114** — Remove legacy single-provider `.env` config (`LLM_PROVIDER`, `LLM_MODEL`, `LLM_URL`, `LLM_API_KEY`, `LLM_API_HEADERS`) from Config, component factory, CLI, TUI, daemon, tests, and docs. All provider configuration now goes through `providers.json` managed via `jarvis providers` CLI or TUI `/providers` command
- **#120** — Clarify the two-dispatch naming boundary with a table in CLAUDE.md and a detailed module docstring in `jarvis/dispatch/__init__.py`. Document why `dispatch/` and `dmcp/` submodules appear twice in the jarvisos repo

### Additional fixes included
- Remove ghost `jarvis/SuperMCP` submodule from git index
- Fix `pyproject.toml` license to SPDX format, OS classifier to `POSIX :: Linux`
- Add GitHub Actions publish workflow for releases
- Fix author email in `jarvis/__init__.py`
- Fix pre-existing test assertion for `create_output_manager` kwargs

## Test plan
- [x] All 59 config/component tests pass
- [x] `pip install -e ".[all]"` works end-to-end in clean venv
- [x] `jarvis providers add` / `jarvis providers` CLI works
- [x] Legacy CLI commands (`jarvis model`, `jarvis provider`, etc.) print migration hint and exit
- [ ] Manual: `jarvis tui` launches and `/status`, `/providers`, `/model` work
- [ ] Manual: tag `v1.0.0` on merge commit after review

Closes #119, closes #114, closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5

---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_