### PR TITLE
fix: allow TUI to launch without a configured LLM provider

### DIFF
--- a/jarvis/cli.py
+++ b/jarvis/cli.py
@@ -458,10 +458,6 @@ def main() -> None:
             sys.exit(1)
 
     elif command == "tui":
-        if not _has_llm_configured():
-            print("Error: No LLM configured.")
-            print("  Quick start: jarvis providers add --type ollama --model qwen3:4b")
-            sys.exit(1)
         try:
             from .tui import run_tui
         except ImportError as e:

--- a/jarvis/core/component_factory.py
+++ b/jarvis/core/component_factory.py
@@ -77,19 +77,21 @@ class ComponentFactory:
             if entries:
                 return ProviderPool(entries)
 
-        raise RuntimeError(
-            "No LLM providers configured.\n"
-            "  Add one with: jarvis providers add --type ollama --model qwen3:4b\n"
-            "  Or in the TUI: /providers add"
-        )
+        return None
 
     @staticmethod
-    def create_llm() -> LLM:
-        """Create LLM with provider pool (failover-capable)."""
+    def create_llm() -> Optional[LLM]:
+        """Create LLM with provider pool (failover-capable).
+
+        Returns None if no providers are configured.
+        """
         logger.info("Getting system information...")
         system_info = SystemInfo.get_system_info()
 
         pool = ComponentFactory._build_provider_pool()
+        if pool is None:
+            logger.warning("No LLM providers configured — running without LLM")
+            return None
         logger.info(
             f"Provider pool ready: {len(pool.entries)} provider(s), "
             f"active: {pool.active_provider_name}"
@@ -399,7 +401,7 @@ class ComponentFactory:
 
         # Report active LLM provider to kernel sysfs
         kernel_client = components["kernel_client"]
-        if kernel_client.available:
+        if kernel_client.available and components["llm"] is not None:
             pool = components["llm"].provider
             pname = pool.active_provider_name or "unknown"
             model = getattr(pool, "model", "") or ""

--- a/jarvis/runtime/root_handlers.py
+++ b/jarvis/runtime/root_handlers.py
@@ -11,6 +11,11 @@ from .output_hooks import emit_activity
 from .root_context import build_root_context, compact_payload_for_llm
 from .session_commands import handle_slash_command
 
+_NO_LLM_MSG = (
+    "No LLM provider configured. "
+    "Add one with `/providers add` or through settings, then restart."
+)
+
 
 async def on_user_input(app: Any, logger: Logger, text: str) -> None:
     logger.info(f"JARVIS: User input: '{text}'")
@@ -19,6 +24,10 @@ async def on_user_input(app: Any, logger: Logger, text: str) -> None:
         handled = handle_slash_command(app, text)
         if handled:
             return
+
+    if app.llm is None:
+        app.output_manager.display({"output": _NO_LLM_MSG})
+        return
 
     app.sessions.ensure_session()
     app.goals.add_goal(text)
@@ -52,6 +61,10 @@ async def on_dispatch_signal(app: Any, logger: Logger, signal: dict[str, Any]) -
         emit_activity(
             app, f"Dispatch signal: {sig_type} (pid {sig_pid})", kind="dispatch"
         )
+
+    if app.llm is None:
+        logger.warning("Dispatch signal received but no LLM configured — ignoring")
+        return
 
     app.goals.update_from_signal(signal)
     app.llm.switch_mode("root")
@@ -102,6 +115,10 @@ async def on_confirmation_response(
         f"approved={len(pending.approved_tasks)}, "
         f"denied={len(pending.denied_tools)}"
     )
+
+    if app.llm is None:
+        logger.warning("Confirmation resolved but no LLM configured — ignoring")
+        return
 
     if pending.denied_tools and not pending.approved_tasks:
         denied_list = ", ".join(pending.denied_tools)

--- a/jarvis/tui/lifecycle.py
+++ b/jarvis/tui/lifecycle.py
@@ -49,7 +49,18 @@ async def start_jarvis(app: Any, logger: Any) -> None:
     await asyncio.sleep(0.1)
     await app._refresh_sidebar()
     app._update_status()
-    app._append_log("[green]Ready.[/green] Type below or use Ctrl+N for a new chat.")
+
+    if jarvis.llm is None:
+        app._append_log(
+            "[yellow]No LLM provider configured.[/yellow]\n"
+            "  Use [bold]/providers add[/bold] or open "
+            "[bold]Settings (F2)[/bold] to get started.\n"
+            "  After adding a provider, restart the TUI."
+        )
+    else:
+        app._append_log(
+            "[green]Ready.[/green] Type below or use Ctrl+N for a new chat."
+        )
     app.query_one("#input", Input).focus()
 
 


### PR DESCRIPTION
## Summary

- `_build_provider_pool()` returns `None` instead of raising `RuntimeError` when no providers exist
- `create_llm()` returns `None` when pool is empty, so `Jarvis` constructs with `self.llm = None`
- Removed the `_has_llm_configured()` gate from the `tui` CLI command (kept for `run`, `chat`)
- All three root event handlers (`on_user_input`, `on_dispatch_signal`, `on_confirmation_response`) guard against `app.llm is None` — user input shows a friendly "add a provider" message, signals/confirmations log and return early
- Slash commands (`/providers add`, `/help`, etc.) still work since they're dispatched before the LLM check
- TUI lifecycle shows a yellow setup prompt instead of "Ready." when no LLM is available

## Test plan

- [x] 110/111 tests pass (1 pre-existing failure)
- [ ] `jarvis tui` launches and shows setup prompt when no `providers.json` exists
- [ ] `/providers add` works from within the degraded TUI
- [ ] After adding a provider and restarting, TUI works normally

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5

---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_