### PR TITLE
chore: derive package version from git tags (setuptools-scm)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Auto-generated version file (setuptools-scm)
+jarvis/_version.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -5,7 +5,10 @@ Copyright (C) 2025 YakupAtahanov
 License: GPL-3.0
 """
 
-__version__ = "1.0.0"
+try:
+    from ._version import version as __version__
+except ImportError:
+    __version__ = "0.0.0"
 __author__ = "YakupAtahanov"
 __email__ = "yakup.atahanow.b@gmail.com"
 __license__ = "GPL-3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=61.0", "setuptools-scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "project-jarvis"
-version = "1.1.1"
+dynamic = ["version"]
 description = "AI-Native Voice Assistant with Concurrent Task Dispatch"
 readme = "README.md"
 license = "GPL-3.0-only"
@@ -169,3 +169,8 @@ markers = [
     "integration: marks tests as integration tests",
     "unit: marks tests as unit tests",
 ]
+
+[tool.setuptools_scm]
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"
+write_to = "jarvis/_version.py"


### PR DESCRIPTION
## Summary

- Replaces hardcoded `version = "1.1.1"` in `pyproject.toml` with `dynamic = ["version"]` powered by `setuptools-scm`
- Version is now derived from git tags automatically — tag `v1.2.0` → package version `1.2.0`
- `jarvis/__init__.py` reads `__version__` from the auto-generated `_version.py` instead of a hardcoded string
- Publish workflow fetches full git history (`fetch-depth: 0`) so tags are visible to the build
- `jarvis/_version.py` added to `.gitignore` (auto-generated at build time)

### New release flow

1. Create a GitHub release with tag `vX.Y.Z`
2. Done — the build reads the version from the tag and publishes to PyPI

No more editing `pyproject.toml`, no more version mismatch failures.

## Test plan

- [x] `python -m setuptools_scm` detects version from tags
- [x] 110/111 tests pass (1 pre-existing failure)
- [ ] Create a test release and verify the correct version appears on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5

---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_