### PR TITLE
fix: GUI socket, Ollama embedding auto-start/pull, Windows compatibility

### DIFF
--- a/jarvis/contextor/embeddings.py
+++ b/jarvis/contextor/embeddings.py
@@ -119,7 +119,7 @@ class OllamaEmbeddings:
         return results
 
     def ensure_model(self) -> bool:
-        """Check if the embedding model is available; auto-start Ollama if needed."""
+        """Check if the embedding model is available; auto-start Ollama and pull if needed."""
         try:
             self.embed_single("test")
             return True
@@ -127,26 +127,19 @@ class OllamaEmbeddings:
             error_str = str(e).lower()
 
             if any(kw in error_str for kw in _CONNECT_KEYWORDS):
-                # Ollama server not running — try to start it and retry once.
                 logger.info("Embeddings: Ollama not reachable — attempting auto-start")
-                if _try_start_ollama(self.base_url):
-                    try:
-                        self.embed_single("test")
-                        return True
-                    except Exception as retry_err:
-                        logger.error(
-                            f"Embeddings: Still unavailable after Ollama start: {retry_err}"
-                        )
-                return False
+                if not _try_start_ollama(self.base_url):
+                    return False
+                # Ollama is now up — re-check; may still need to pull the model.
+                return self.ensure_model()
 
             if "not found" in error_str or "does not exist" in error_str:
-                logger.warning(
-                    f"Embedding model '{self.model}' not found. "
-                    f"Pull it with: ollama pull {self.model}"
+                # nomic-embed-text is infrastructure, not a user LLM choice —
+                # always pull it automatically when Ollama is reachable.
+                logger.info(
+                    f"Embeddings: Model '{self.model}' not pulled yet — pulling now"
                 )
-                if getattr(Config, "LLM_AUTO_PULL", False):
-                    return self._pull_model()
-                return False
+                return self._pull_model()
 
             logger.error(f"Embeddings: Availability check failed: {e}")
             return False

--- a/jarvis/contextor/embeddings.py
+++ b/jarvis/contextor/embeddings.py
@@ -11,7 +11,9 @@ Why Ollama embeddings?
 - nomic-embed-text is small (~270MB) and produces 768-dim vectors
 """
 
-from typing import List, Optional
+import subprocess
+import time
+from typing import List
 
 from ..config import Config
 from ..core.logger import get_logger
@@ -19,6 +21,49 @@ from ..core.logger import get_logger
 logger = get_logger(__name__)
 
 DEFAULT_EMBED_MODEL = "nomic-embed-text"
+
+_CONNECT_KEYWORDS = ("connect", "connection", "refused", "unreachable", "timeout")
+
+
+def _is_ollama_up(base_url: str) -> bool:
+    import urllib.request
+
+    try:
+        urllib.request.urlopen(f"{base_url}/api/tags", timeout=2)
+        return True
+    except Exception:
+        return False
+
+
+def _try_start_ollama(base_url: str) -> bool:
+    """Start Ollama via platform service manager or direct spawn."""
+    from ..platform import current as platform
+
+    if platform.try_start_service("ollama", base_url):
+        logger.info("Embeddings: Ollama started via system service manager")
+        return True
+
+    try:
+        subprocess.Popen(
+            ["ollama", "serve"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        logger.warning("Embeddings: ollama binary not found; cannot auto-start")
+        return False
+    except Exception as exc:
+        logger.warning(f"Embeddings: Failed to spawn ollama serve: {exc}")
+        return False
+
+    for _ in range(5):
+        time.sleep(1)
+        if _is_ollama_up(base_url):
+            logger.info("Embeddings: Ollama started via direct spawn")
+            return True
+
+    logger.warning("Embeddings: Ollama auto-start attempted but did not become ready")
+    return False
 
 
 class OllamaEmbeddings:
@@ -63,28 +108,37 @@ class OllamaEmbeddings:
 
     def embed_batch(self, texts: List[str]) -> List[List[float]]:
         """Embed a batch of texts. Falls back to sequential calls."""
-        # Ollama doesn't natively support batch embeddings in all versions,
-        # so we call sequentially. For typical JARVIS workloads (storing a
-        # few memories per interaction) this is fine.
         results = []
         for text in texts:
             try:
                 results.append(self.embed_single(text))
             except Exception as e:
                 logger.warning(f"Embeddings: Failed to embed text: {e}")
-                # Return zero vector as fallback so indexing stays consistent
                 dim = self._dim or 768
                 results.append([0.0] * dim)
         return results
 
     def ensure_model(self) -> bool:
-        """Check if the embedding model is available, pull if configured."""
+        """Check if the embedding model is available; auto-start Ollama if needed."""
         try:
-            # Quick probe — if this works, the model is available
             self.embed_single("test")
             return True
         except Exception as e:
             error_str = str(e).lower()
+
+            if any(kw in error_str for kw in _CONNECT_KEYWORDS):
+                # Ollama server not running — try to start it and retry once.
+                logger.info("Embeddings: Ollama not reachable — attempting auto-start")
+                if _try_start_ollama(self.base_url):
+                    try:
+                        self.embed_single("test")
+                        return True
+                    except Exception as retry_err:
+                        logger.error(
+                            f"Embeddings: Still unavailable after Ollama start: {retry_err}"
+                        )
+                return False
+
             if "not found" in error_str or "does not exist" in error_str:
                 logger.warning(
                     f"Embedding model '{self.model}' not found. "
@@ -92,8 +146,9 @@ class OllamaEmbeddings:
                 )
                 if getattr(Config, "LLM_AUTO_PULL", False):
                     return self._pull_model()
-            else:
-                logger.error(f"Embeddings: Availability check failed: {e}")
+                return False
+
+            logger.error(f"Embeddings: Availability check failed: {e}")
             return False
 
     def _pull_model(self) -> bool:

--- a/jarvis/core/component_factory.py
+++ b/jarvis/core/component_factory.py
@@ -330,13 +330,8 @@ class ComponentFactory:
         # Kernel integration client (started first — LLM providers may use keyring)
         components["kernel_client"] = ComponentFactory.create_kernel_client()
 
-        # LLM — created before embeddings so that Ollama auto-start fires here,
-        # ensuring the server is up before the embedding availability check runs.
-        components["llm"] = ComponentFactory.create_llm()
-
         # Shared embeddings instance — used by both contextor (memory)
         # and dispatch (semantic tool discovery). Created once, shared.
-        # Ollama is already running at this point (warmed by LLM preload above).
         embeddings = None
         if Config.RAG_ENABLED or Config.ALLOW_EMBEDDING_SEARCH:
             try:
@@ -375,6 +370,9 @@ class ComponentFactory:
                 components["contextor"] = None
         else:
             components["contextor"] = None
+
+        # LLM — no longer needs contextor (RAG is handled in main.py)
+        components["llm"] = ComponentFactory.create_llm()
 
         components["dispatch_adapter"] = ComponentFactory.create_dispatch_adapter()
         components["goal_manager"] = ComponentFactory.create_goal_manager()

--- a/jarvis/core/component_factory.py
+++ b/jarvis/core/component_factory.py
@@ -330,8 +330,13 @@ class ComponentFactory:
         # Kernel integration client (started first — LLM providers may use keyring)
         components["kernel_client"] = ComponentFactory.create_kernel_client()
 
+        # LLM — created before embeddings so that Ollama auto-start fires here,
+        # ensuring the server is up before the embedding availability check runs.
+        components["llm"] = ComponentFactory.create_llm()
+
         # Shared embeddings instance — used by both contextor (memory)
         # and dispatch (semantic tool discovery). Created once, shared.
+        # Ollama is already running at this point (warmed by LLM preload above).
         embeddings = None
         if Config.RAG_ENABLED or Config.ALLOW_EMBEDDING_SEARCH:
             try:
@@ -370,9 +375,6 @@ class ComponentFactory:
                 components["contextor"] = None
         else:
             components["contextor"] = None
-
-        # LLM — no longer needs contextor (RAG is handled in main.py)
-        components["llm"] = ComponentFactory.create_llm()
 
         components["dispatch_adapter"] = ComponentFactory.create_dispatch_adapter()
         components["goal_manager"] = ComponentFactory.create_goal_manager()


### PR DESCRIPTION
## Summary

- **GUI socket (`jarvis.sock`)**: Added a unified bidirectional IPC socket for desktop GUI clients. Daemon sends `state`, streaming `response`, `wake_word_detected`, `confirmation_request`, and `ping` messages; clients send `message`, `start_listening`, `stop_listening`, `stop_stream`, `confirmation_response`, and `ping`. State is broadcast on connect and after every response. 60-second keepalive ping loop prevents stale connections.

- **Ollama embedding auto-start**: `OllamaEmbeddings.ensure_model()` now detects connection failures, attempts to start Ollama via the platform service manager or direct spawn, then re-checks. Works regardless of which LLM provider is configured (Claude API, OpenAI, local Ollama, etc.).

- **Embedding model auto-pull**: After Ollama starts, if `nomic-embed-text` is not yet pulled, it is pulled automatically. The model is infrastructure (not a user LLM choice) so no config flag gates it.

- **Startup ordering fix (reverted workaround)**: An intermediate commit moved `create_llm()` before the embedding check as a workaround; this was reverted in favor of fixing the root cause in `OllamaEmbeddings` directly.

## Commits

- `7c484a3` Add unified bidirectional GUI socket (jarvis.sock)
- `0b5f595` fix: auto-start Ollama in OllamaEmbeddings when server is not running
- `bde2eb9` fix: auto-pull embedding model and correctly handle errors after Ollama start


---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_