### PR TITLE
Expose session CRUD over the GUI socket protocol

### DIFF
--- a/jarvis/runtime/io.py
+++ b/jarvis/runtime/io.py
@@ -253,11 +253,131 @@ async def _process_gui_message(
         )
         await set_gui_state(app, "idle")
 
+    elif msg_type == "list_sessions":
+        await _gui_write(writer, _handle_list_sessions(app, msg))
+
+    elif msg_type == "create_session":
+        await _reply_or_broadcast(app, writer, _handle_create_session(app, msg))
+
+    elif msg_type == "switch_session":
+        await _reply_or_broadcast(app, writer, _handle_switch_session(app, msg))
+
+    elif msg_type == "rename_session":
+        await _reply_or_broadcast(app, writer, _handle_rename_session(app, msg))
+
+    elif msg_type == "delete_session":
+        await _reply_or_broadcast(app, writer, _handle_delete_session(app, msg))
+
     elif msg_type == "ping":
         try:
             await _gui_write(writer, {"type": "pong"})
         except Exception:
             pass
+
+
+# ---------------------------------------------------------------------------
+# GUI socket — session CRUD
+# ---------------------------------------------------------------------------
+
+SESSION_HISTORY_LIMIT = 200
+
+_ROLE_BY_ENTRY_TYPE = {"user_prompt": "user", "assistant_reply": "assistant"}
+
+
+def _session_error(message: str) -> dict:
+    return {"type": "session_error", "message": message}
+
+
+def _entries_to_messages(entries: list) -> list:
+    """Map conversation_log entries (chronological) to {role, content, timestamp}."""
+    messages = []
+    for entry in entries:
+        role = _ROLE_BY_ENTRY_TYPE.get((entry.get("metadata") or {}).get("type"))
+        if not role:
+            continue
+        messages.append(
+            {
+                "role": role,
+                "content": entry.get("content", ""),
+                "timestamp": entry.get("stored_at"),
+            }
+        )
+    return messages
+
+
+def _handle_list_sessions(app: Any, msg: dict) -> dict:
+    if not app.sessions.available:
+        return _session_error("Sessions unavailable (memory disabled)")
+    limit = msg.get("limit", 50)
+    offset = msg.get("offset", 0)
+    sessions = app.sessions.list(limit=limit, offset=offset)
+    return {"type": "session_list", "sessions": [s.to_dict() for s in sessions]}
+
+
+def _handle_create_session(app: Any, msg: dict) -> dict:
+    if not app.sessions.available:
+        return _session_error("Sessions unavailable (memory disabled)")
+    session = app.sessions.new_session(title=msg.get("title") or None)
+    if not session:
+        return _session_error("Failed to create session")
+    return {"type": "session_switched", "session": session.to_dict(), "messages": []}
+
+
+def _handle_switch_session(app: Any, msg: dict) -> dict:
+    session_id = msg.get("id", "")
+    if not session_id:
+        return _session_error("switch_session requires 'id'")
+    if not app.sessions.available:
+        return _session_error("Sessions unavailable (memory disabled)")
+    session = app.sessions.switch(session_id)
+    if not session:
+        return _session_error(f"No session matches '{session_id}'")
+    recall_result = app.contextor.recall(
+        "conversation_log", limit=SESSION_HISTORY_LIMIT, session_id=session.id
+    )
+    messages = _entries_to_messages(recall_result.get("entries", []))
+    return {
+        "type": "session_switched",
+        "session": session.to_dict(),
+        "messages": messages,
+    }
+
+
+def _handle_rename_session(app: Any, msg: dict) -> dict:
+    session_id = msg.get("id", "")
+    title = msg.get("title", "")
+    if not session_id or not title:
+        return _session_error("rename_session requires 'id' and 'title'")
+    if not app.sessions.available:
+        return _session_error("Sessions unavailable (memory disabled)")
+    if not app.sessions.rename(title, session_id=session_id):
+        return _session_error(f"Rename failed for '{session_id}'")
+    sessions = app.sessions.list(limit=50)
+    return {"type": "session_list", "sessions": [s.to_dict() for s in sessions]}
+
+
+def _handle_delete_session(app: Any, msg: dict) -> dict:
+    session_id = msg.get("id", "")
+    if not session_id:
+        return _session_error("delete_session requires 'id'")
+    if not app.sessions.available:
+        return _session_error("Sessions unavailable (memory disabled)")
+    if not app.sessions.delete(session_id):
+        return _session_error(f"Delete failed for '{session_id}'")
+    sessions = app.sessions.list(limit=50)
+    return {"type": "session_list", "sessions": [s.to_dict() for s in sessions]}
+
+
+async def _reply_or_broadcast(
+    app: Any, writer: asyncio.StreamWriter, response: dict
+) -> None:
+    """Session mutations reflect shared daemon state, so success broadcasts
+    to every GUI client; errors are specific to the requester's malformed
+    request and go back to them alone."""
+    if response.get("type") == "session_error":
+        await _gui_write(writer, response)
+    else:
+        await broadcast_to_gui_clients(app, response)
 
 
 async def set_gui_state(app: Any, state: str) -> None:

--- a/tests/test_gui_session_socket.py
+++ b/tests/test_gui_session_socket.py
@@ -1,0 +1,232 @@
+"""Unit tests for the GUI socket's session CRUD handlers (jarvis/runtime/io.py)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from jarvis.runtime import io as runtime_io
+from jarvis.sessions.model import Session
+
+
+def _make_app(sessions=None, contextor=None):
+    return SimpleNamespace(sessions=sessions or Mock(), contextor=contextor or Mock())
+
+
+def _sample_session(id_="abc12345", title="Test chat"):
+    return Session(id=id_, title=title, created_at="t0", updated_at="t1", entry_count=2)
+
+
+@pytest.mark.unit
+class TestEntriesToMessages:
+    def test_maps_known_roles_in_order(self):
+        entries = [
+            {"content": "hi", "metadata": {"type": "user_prompt"}, "stored_at": 1.0},
+            {
+                "content": "hello!",
+                "metadata": {"type": "assistant_reply"},
+                "stored_at": 2.0,
+            },
+        ]
+        messages = runtime_io._entries_to_messages(entries)
+        assert messages == [
+            {"role": "user", "content": "hi", "timestamp": 1.0},
+            {"role": "assistant", "content": "hello!", "timestamp": 2.0},
+        ]
+
+    def test_skips_entries_with_unknown_or_missing_type(self):
+        entries = [
+            {"content": "noise", "metadata": {"type": "something_else"}},
+            {"content": "no metadata at all"},
+        ]
+        assert runtime_io._entries_to_messages(entries) == []
+
+
+@pytest.mark.unit
+class TestHandleListSessions:
+    def test_returns_error_when_sessions_unavailable(self):
+        app = _make_app(sessions=Mock(available=False))
+        result = runtime_io._handle_list_sessions(app, {})
+        assert result["type"] == "session_error"
+
+    def test_returns_serialized_session_list(self):
+        sessions_mock = Mock(available=True)
+        sessions_mock.list.return_value = [
+            _sample_session("aaa"),
+            _sample_session("bbb"),
+        ]
+        app = _make_app(sessions=sessions_mock)
+
+        result = runtime_io._handle_list_sessions(app, {"limit": 10, "offset": 0})
+
+        assert result["type"] == "session_list"
+        assert [s["id"] for s in result["sessions"]] == ["aaa", "bbb"]
+        sessions_mock.list.assert_called_once_with(limit=10, offset=0)
+
+
+@pytest.mark.unit
+class TestHandleCreateSession:
+    def test_creates_and_returns_empty_history(self):
+        sessions_mock = Mock(available=True)
+        sessions_mock.new_session.return_value = _sample_session()
+        app = _make_app(sessions=sessions_mock)
+
+        result = runtime_io._handle_create_session(app, {"title": "New chat"})
+
+        assert result["type"] == "session_switched"
+        assert result["messages"] == []
+        assert result["session"]["title"] == "Test chat"
+        sessions_mock.new_session.assert_called_once_with(title="New chat")
+
+    def test_failure_returns_error(self):
+        sessions_mock = Mock(available=True)
+        sessions_mock.new_session.return_value = None
+        app = _make_app(sessions=sessions_mock)
+
+        result = runtime_io._handle_create_session(app, {})
+
+        assert result["type"] == "session_error"
+
+
+@pytest.mark.unit
+class TestHandleSwitchSession:
+    def test_requires_id(self):
+        app = _make_app()
+        result = runtime_io._handle_switch_session(app, {})
+        assert result["type"] == "session_error"
+
+    def test_switches_and_attaches_history(self):
+        sessions_mock = Mock(available=True)
+        sessions_mock.switch.return_value = _sample_session("abc12345")
+        contextor_mock = Mock()
+        contextor_mock.recall.return_value = {
+            "entries": [
+                {
+                    "content": "hi",
+                    "metadata": {"type": "user_prompt"},
+                    "stored_at": 1.0,
+                },
+            ]
+        }
+        app = _make_app(sessions=sessions_mock, contextor=contextor_mock)
+
+        result = runtime_io._handle_switch_session(app, {"id": "abc12345"})
+
+        assert result["type"] == "session_switched"
+        assert result["session"]["id"] == "abc12345"
+        assert result["messages"] == [
+            {"role": "user", "content": "hi", "timestamp": 1.0}
+        ]
+        contextor_mock.recall.assert_called_once_with(
+            "conversation_log",
+            limit=runtime_io.SESSION_HISTORY_LIMIT,
+            session_id="abc12345",
+        )
+
+    def test_no_match_returns_error(self):
+        sessions_mock = Mock(available=True)
+        sessions_mock.switch.return_value = None
+        app = _make_app(sessions=sessions_mock)
+
+        result = runtime_io._handle_switch_session(app, {"id": "nope"})
+
+        assert result["type"] == "session_error"
+
+
+@pytest.mark.unit
+class TestHandleRenameSession:
+    def test_requires_id_and_title(self):
+        app = _make_app()
+        assert (
+            runtime_io._handle_rename_session(app, {"id": "x"})["type"]
+            == "session_error"
+        )
+        assert (
+            runtime_io._handle_rename_session(app, {"title": "y"})["type"]
+            == "session_error"
+        )
+
+    def test_rename_success_returns_refreshed_list(self):
+        sessions_mock = Mock(available=True)
+        sessions_mock.rename.return_value = True
+        sessions_mock.list.return_value = [_sample_session("abc", title="Renamed")]
+        app = _make_app(sessions=sessions_mock)
+
+        result = runtime_io._handle_rename_session(
+            app, {"id": "abc", "title": "Renamed"}
+        )
+
+        assert result["type"] == "session_list"
+        sessions_mock.rename.assert_called_once_with("Renamed", session_id="abc")
+
+    def test_rename_failure_returns_error(self):
+        sessions_mock = Mock(available=True)
+        sessions_mock.rename.return_value = False
+        app = _make_app(sessions=sessions_mock)
+
+        result = runtime_io._handle_rename_session(app, {"id": "abc", "title": "x"})
+
+        assert result["type"] == "session_error"
+
+
+@pytest.mark.unit
+class TestHandleDeleteSession:
+    def test_requires_id(self):
+        app = _make_app()
+        assert runtime_io._handle_delete_session(app, {})["type"] == "session_error"
+
+    def test_delete_success_returns_refreshed_list(self):
+        sessions_mock = Mock(available=True)
+        sessions_mock.delete.return_value = True
+        sessions_mock.list.return_value = []
+        app = _make_app(sessions=sessions_mock)
+
+        result = runtime_io._handle_delete_session(app, {"id": "abc"})
+
+        assert result["type"] == "session_list"
+        sessions_mock.delete.assert_called_once_with("abc")
+
+    def test_delete_failure_returns_error(self):
+        sessions_mock = Mock(available=True)
+        sessions_mock.delete.return_value = False
+        app = _make_app(sessions=sessions_mock)
+
+        result = runtime_io._handle_delete_session(app, {"id": "abc"})
+
+        assert result["type"] == "session_error"
+
+
+@pytest.mark.unit
+class TestReplyOrBroadcast:
+    @pytest.mark.asyncio
+    async def test_error_goes_to_requester_only(self):
+        app = _make_app()
+        writer = Mock()
+        with (
+            patch.object(runtime_io, "_gui_write", new=AsyncMock()) as gui_write,
+            patch.object(
+                runtime_io, "broadcast_to_gui_clients", new=AsyncMock()
+            ) as broadcast,
+        ):
+            await runtime_io._reply_or_broadcast(
+                app, writer, {"type": "session_error", "message": "boom"}
+            )
+        gui_write.assert_awaited_once_with(
+            writer, {"type": "session_error", "message": "boom"}
+        )
+        broadcast.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_success_broadcasts_to_all_clients(self):
+        app = _make_app()
+        writer = Mock()
+        response = {"type": "session_list", "sessions": []}
+        with (
+            patch.object(runtime_io, "_gui_write", new=AsyncMock()) as gui_write,
+            patch.object(
+                runtime_io, "broadcast_to_gui_clients", new=AsyncMock()
+            ) as broadcast,
+        ):
+            await runtime_io._reply_or_broadcast(app, writer, response)
+        broadcast.assert_awaited_once_with(app, response)
+        gui_write.assert_not_awaited()


### PR DESCRIPTION
## Summary

Closes #145.

`jarvis/sessions/manager.py`'s `SessionManager` already supports full session CRUD (`new_session`, `list`, `switch`, `rename`, `delete`), fully delegated to the contextor binary — none of it was reachable by GUI clients. The socket only exposed `message`/`start_listening`/`stop_listening`/`stop_stream`/`confirmation_response`/`ping`.

- Adds five client → daemon message types: `list_sessions`, `create_session`, `switch_session`, `rename_session`, `delete_session` — all thin wrappers around the existing `SessionManager` methods. No new session logic; this is pure protocol exposure.
- `switch_session` additionally recalls the session's `conversation_log` entries from contextor and returns them as a normalized `{role, content, timestamp}` history, so a client can render a session's full history the moment it switches to it.
- Session mutations (create/switch/rename/delete) broadcast their result to every connected GUI client, since there's one shared "current session" pointer on the daemon, not a per-client one — consistent with how `set_gui_state()` already broadcasts state changes. Read-only `list_sessions` and error responses go back to the requester only.
- Updated `jarvisos-app`'s `CLAUDE.md` protocol table to match (separate small PR in that repo, since it's the authoritative GUI-protocol reference doc).

## Test plan

- [x] 17 unit tests against the handler functions directly (`tests/test_gui_session_socket.py`) — covers success paths, "sessions unavailable," "no session matches," and the broadcast-vs-direct-reply dispatch in `_reply_or_broadcast`
- [x] A real end-to-end run of the actual asyncio GUI socket server over a Unix socket (not mocked at the transport layer) — round-tripped real JSON messages through the full create → switch → rename → delete lifecycle, including the error path, and verified the initial `{"type": "state", ...}` push still fires correctly on connect
- [x] Full default test suite (`make test`'s filter) — 44 passed, no regressions
- [x] `black`/`flake8` clean (flake8's actual CI gate — `E9,F63,F7,F82` — passes; `make typecheck` only covers one unrelated file, so mypy wasn't a relevant gate here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5

---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_