### PR TITLE
Track pending confirmations persistently; add CLI + socket parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,12 @@ requests to the best available channel:
 3. **Socket** — JSON over output socket for external clients
 4. **CLI prompt** — stdin `[y/N]` fallback
 
-Auto-denies after 30 seconds if no response.
+Pending confirmations are tracked in a persistent, queryable list
+(`ConfirmationManager.list_pending()`), reviewable anytime via `jarvis
+confirmations` (CLI) or `list_confirmations`/`approve_confirmation`/
+`deny_confirmation`/`approve_all_confirmations` (GUI socket) rather than
+expiring on a clock. `CONFIRMATION_TIMEOUT` defaults to `0` (disabled);
+set it > 0 to restore auto-deny for unattended/headless setups.
 
 ### Socket Security
 

--- a/docs/tla-confirmation-design.md
+++ b/docs/tla-confirmation-design.md
@@ -21,7 +21,11 @@ loop, which prevents it from misrepresenting the action.
    keeping the LLM and dispatcher fully async.
 4. **Channel-agnostic** — confirmation works across desktop notifications,
    CLI stdin, and socket IPC.  The kernel picks the best available channel.
-5. **Deny-safe** — timeout and "no channel available" both default to denial.
+5. **Persistent by default** — pending confirmations are tracked in a
+   queryable list (`ConfirmationManager.list_pending()`, exposed via CLI
+   and socket), reviewable at any time rather than expiring on a clock.
+   Auto-deny-on-timeout is opt-in (`CONFIRMATION_TIMEOUT` > 0) for
+   unattended/headless setups that want the old fail-safe behavior back.
 
 ## Configuration
 
@@ -29,7 +33,7 @@ loop, which prevents it from misrepresenting the action.
 |---|---|---|
 | `CONFIRMATION_MODE` | `smart` | `allow_all` / `smart` / `ask_all` |
 | `NOTIFICATION_SILENT` | `false` | Suppress desktop notifications (socket/CLI only) |
-| `CONFIRMATION_TIMEOUT` | `30` | Seconds to wait before auto-deny |
+| `CONFIRMATION_TIMEOUT` | `0` | Seconds before auto-deny; `0` disables it (persistent list instead) |
 
 ### Modes
 
@@ -82,7 +86,9 @@ User: "delete my temp files"
         │       ├─ Desktop: notify-send runs as async subprocess
         │       ├─ Socket:  JSON broadcast to connected clients
         │       └─ CLI:     input() in executor thread
-        ├─ 3. Start timeout task (auto-deny after N seconds)
+        ├─ 3. Start timeout task, only if CONFIRMATION_TIMEOUT > 0
+        │      (default 0 -- stays pending indefinitely, reviewable via
+        │      list_pending()/CLI/socket instead of expiring)
         └─ 4. Return {"awaiting_confirmation": True} immediately
             │
             ▼

--- a/jarvis/.env.example
+++ b/jarvis/.env.example
@@ -168,8 +168,12 @@ CONFIRMATION_MODE=smart
 # (false = show notify-send popup; true = socket/CLI only)
 # NOTIFICATION_SILENT=false
 
-# Timeout (seconds) for user to respond to a confirmation prompt
-CONFIRMATION_TIMEOUT=30
+# Timeout (seconds) for user to respond to a confirmation prompt before
+# auto-denying. 0 (default) disables the timeout -- pending confirmations
+# are tracked in a persistent list, queryable anytime via CLI/socket, so
+# nothing needs to expire on a clock. Set a positive value to restore
+# auto-deny for unattended/headless setups.
+CONFIRMATION_TIMEOUT=0
 
 # ===========================================
 # Data Directory

--- a/jarvis/cli.py
+++ b/jarvis/cli.py
@@ -14,6 +14,7 @@ Usage:
 """
 
 import asyncio
+import json
 import os
 import socket
 import sys
@@ -52,6 +53,31 @@ else:
     ENV_FILE = _platform.config_dir() / "jarvis.conf"
 
 
+def _find_ipc_endpoint() -> "str | None":
+    """Locate and ownership-verify a running JARVIS instance's input socket.
+
+    Prints its own error and returns None on failure so callers can decide
+    whether to exit.
+    """
+    from .platform import current as platform
+
+    candidates = [Config.JARVIS_INPUT_SOCKET, "/run/jarvis/input.sock"]
+    path = None
+    for p in candidates:
+        if p and _ipc_endpoint_exists(p):
+            path = p
+            break
+    if not path:
+        print("Error: JARVIS IPC endpoint not found.")
+        print("  Tried:", ", ".join(p for p in candidates if p))
+        print("  Is JARVIS running? Start with 'jarvis' or 'jarvis run'.")
+        return None
+    if not platform.ipc_verify_owner(path):
+        print("Error: IPC endpoint ownership check failed.")
+        return None
+    return path
+
+
 def _cmd_send() -> None:
     """Send a message to a running JARVIS instance via IPC."""
     from .platform import current as platform
@@ -65,19 +91,8 @@ def _cmd_send() -> None:
     if not msg:
         print("Error: Message cannot be empty")
         sys.exit(1)
-    candidates = [Config.JARVIS_INPUT_SOCKET, "/run/jarvis/input.sock"]
-    path = None
-    for p in candidates:
-        if p and _ipc_endpoint_exists(p):
-            path = p
-            break
+    path = _find_ipc_endpoint()
     if not path:
-        print("Error: JARVIS IPC endpoint not found.")
-        print("  Tried:", ", ".join(p for p in candidates if p))
-        print("  Is JARVIS running? Start with 'jarvis' or 'jarvis run'.")
-        sys.exit(1)
-    if not platform.ipc_verify_owner(path):
-        print("Error: IPC endpoint ownership check failed.")
         sys.exit(1)
     try:
         sock = platform.ipc_connect(path)
@@ -94,6 +109,79 @@ def _cmd_send() -> None:
 def _ipc_endpoint_exists(path: str) -> bool:
     """Check if an IPC endpoint exists (socket file or port file)."""
     return os.path.exists(path) or os.path.exists(path + ".port")
+
+
+def _cmd_confirmations() -> None:
+    """List or resolve pending tool confirmations on a running JARVIS instance."""
+    from .platform import current as platform
+
+    if len(sys.argv) == 2:
+        request = {"type": "list_confirmations"}
+    else:
+        subcmd = sys.argv[2]
+        if subcmd == "approve-all":
+            request = {"type": "approve_all_confirmations"}
+        elif subcmd in ("approve", "deny") and len(sys.argv) >= 4:
+            request = {
+                "type": (
+                    "approve_confirmation"
+                    if subcmd == "approve"
+                    else "deny_confirmation"
+                ),
+                "id": sys.argv[3],
+            }
+        else:
+            _show_confirmations_usage()
+            sys.exit(1)
+
+    path = _find_ipc_endpoint()
+    if not path:
+        sys.exit(1)
+
+    try:
+        sock = platform.ipc_connect(path)
+        try:
+            sock.sendall((json.dumps(request) + "\n").encode("utf-8"))
+            sock.settimeout(5.0)
+            response_line = sock.makefile().readline()
+        finally:
+            sock.close()
+    except (socket.error, OSError) as e:
+        print(f"Error: Could not reach JARVIS: {e}")
+        sys.exit(1)
+
+    if not response_line:
+        print("Error: No response from JARVIS.")
+        sys.exit(1)
+
+    try:
+        response = json.loads(response_line)
+    except json.JSONDecodeError:
+        print("Error: Invalid response from JARVIS.")
+        sys.exit(1)
+
+    if response.get("type") == "confirmation_list":
+        confirmations = response.get("confirmations", [])
+        if not confirmations:
+            print("No pending confirmations.")
+            return
+        print(f"Pending confirmations ({len(confirmations)}):")
+        for c in confirmations:
+            tools = ", ".join(c.get("tool_names", []))
+            print(f"  [{c['id']}] {tools}")
+    elif response.get("type") == "ack":
+        print(response.get("message", "Done."))
+    else:
+        print(f"Error: {response.get('message', 'Unexpected response')}")
+        sys.exit(1)
+
+
+def _show_confirmations_usage() -> None:
+    print("Usage:")
+    print("  jarvis confirmations               # List pending confirmations")
+    print("  jarvis confirmations approve <id>  # Approve one")
+    print("  jarvis confirmations deny <id>      # Deny one")
+    print("  jarvis confirmations approve-all    # Approve all pending")
 
 
 def set_output_mode(mode: str) -> None:
@@ -386,6 +474,12 @@ def show_usage() -> None:
     print("  jarvis sudo disable       # Disable sudo access (requires root)")
     print("  jarvis sudo               # Show current sudo access status")
     print()
+    print("Pending Confirmations:")
+    print("  jarvis confirmations               # List pending confirmations")
+    print("  jarvis confirmations approve <id>  # Approve one")
+    print("  jarvis confirmations deny <id>      # Deny one")
+    print("  jarvis confirmations approve-all    # Approve all pending")
+    print()
     print("Provider Pool:")
     print("  jarvis providers                                    # List providers")
     print("  jarvis providers add --type ollama --model <model>  # Add Ollama")
@@ -524,6 +618,9 @@ def main() -> None:
         else:
             print("Usage: jarvis sudo [enable|disable]")
             sys.exit(1)
+
+    elif command == "confirmations":
+        _cmd_confirmations()
 
     elif command == "model":
         _legacy_redirect("jarvis model")

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -202,8 +202,13 @@ class Config:
     #          (lets external apps render their own confirmation UI)
     NOTIFICATION_SILENT = os.getenv("NOTIFICATION_SILENT", "false").lower() == "true"
 
-    # Timeout (seconds) for user to respond to a confirmation prompt
-    CONFIRMATION_TIMEOUT = int(os.getenv("CONFIRMATION_TIMEOUT", "30"))
+    # Timeout (seconds) for user to respond to a confirmation prompt before
+    # auto-denying. 0 disables the timeout entirely -- pending confirmations
+    # are tracked in a persistent, queryable list (CLI/socket) instead, so
+    # nothing needs to expire just because nobody answered within N seconds.
+    # Set a positive value to restore the old auto-deny behavior for
+    # unattended/headless setups.
+    CONFIRMATION_TIMEOUT = int(os.getenv("CONFIRMATION_TIMEOUT", "0"))
 
     # Logging Configuration
     LOG_LEVEL = os.getenv(

--- a/jarvis/core/confirmation_manager.py
+++ b/jarvis/core/confirmation_manager.py
@@ -37,6 +37,7 @@ The global ``CONFIRMATION_MODE`` (config) controls overall behaviour:
 import asyncio
 import json
 import sys
+import time
 import uuid
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
@@ -59,6 +60,10 @@ class PendingConfirmation:
     approved_tasks: List[Dict[str, Any]] = field(default_factory=list)
     # Dispatch sub-chain context to resume after confirmation.
     dispatch_context: Optional[Dict[str, Any]] = None
+    # Retained so a later list_pending() query can describe what's waiting --
+    # the original request only computes these locally otherwise.
+    tool_names: List[str] = field(default_factory=list)
+    created_at: float = field(default_factory=time.time)
 
 
 class ConfirmationManager:
@@ -160,18 +165,19 @@ class ConfirmationManager:
             notification_silent: Suppress desktop notification.
             timeout: Seconds before auto-deny.
         """
+        # Build a human-readable summary of tools needing confirmation.
+        tool_names = [t["tool_name"] for t in tools_needing_confirmation]
+        tool_summaries = ", ".join(tool_names)
+
         pending = PendingConfirmation(
             request_id=request_id,
             tasks=tasks,
             approved_tasks=list(approved_tasks),
             denied_tools=list(denied_tools),
             dispatch_context=dispatch_context,
+            tool_names=tool_names,
         )
         self._pending[request_id] = pending
-
-        # Build a human-readable summary of tools needing confirmation.
-        tool_names = [t["tool_name"] for t in tools_needing_confirmation]
-        tool_summaries = ", ".join(tool_names)
 
         logger.info(
             f"Confirmation requested (non-blocking): id={request_id}, "
@@ -187,10 +193,26 @@ class ConfirmationManager:
             timeout=timeout,
         )
 
-        # Start timeout — auto-deny if no response within `timeout` seconds.
-        self._timeout_tasks[request_id] = asyncio.create_task(
-            self._auto_deny_after(request_id, timeout)
-        )
+        # Start timeout only if one is configured. The default (0) leaves
+        # the confirmation pending indefinitely -- it's tracked in
+        # list_pending() and reviewable via CLI/socket at any time, so
+        # nothing needs to expire on a clock. A positive value restores the
+        # old auto-deny behavior for unattended/headless setups.
+        if timeout and timeout > 0:
+            self._timeout_tasks[request_id] = asyncio.create_task(
+                self._auto_deny_after(request_id, timeout)
+            )
+
+    def list_pending(self) -> List[Dict[str, Any]]:
+        """Summaries of currently pending confirmations, for CLI/socket review."""
+        return [
+            {
+                "id": p.request_id,
+                "tool_names": p.tool_names,
+                "created_at": p.created_at,
+            }
+            for p in self._pending.values()
+        ]
 
     def resolve(self, response: Dict[str, Any]) -> Optional[PendingConfirmation]:
         """Process a confirmation response and return the pending data.
@@ -277,16 +299,14 @@ class ConfirmationManager:
             asyncio.create_task(self._notify_cli(request_id, tool_summary, timeout))
             return
 
-        # No channel available — auto-deny immediately.
-        logger.warning("No confirmation channel available, auto-denying")
-        if self._inject_confirmation:
-            self._inject_confirmation(
-                {
-                    "type": "confirmation_response",
-                    "id": request_id,
-                    "approved": False,
-                }
-            )
+        # No live channel available right now -- that's fine. The request
+        # stays in _pending, reviewable anytime via list_pending() (CLI or
+        # socket), rather than being auto-denied just because nobody
+        # happened to be watching at this exact moment.
+        logger.info(
+            f"No live confirmation channel available for id={request_id}; "
+            "left pending for CLI/socket review"
+        )
 
     # -- TUI (ConfirmModal) --------------------------------------------
 

--- a/jarvis/runtime/io.py
+++ b/jarvis/runtime/io.py
@@ -46,10 +46,14 @@ async def handle_socket_connection(
             if not text:
                 continue
 
-            # Check for confirmation responses — inject into event loop.
+            # Check for confirmation responses / queries — handled here,
+            # never treated as chat input.
             if text.startswith("{"):
                 try:
                     msg = json.loads(text)
+                    handled = await _handle_confirmation_query(app, msg, writer)
+                    if handled:
+                        continue
                     if msg.get("type") == "confirmation_response":
                         app.events.inject_confirmation_response(msg)
                         continue
@@ -66,6 +70,66 @@ async def handle_socket_connection(
             await writer.wait_closed()
         except Exception:
             pass
+
+
+async def _handle_confirmation_query(
+    app: Any, msg: dict, writer: asyncio.StreamWriter
+) -> bool:
+    """Handle list/approve/deny confirmation queries, shared by both sockets.
+
+    Returns True if `msg` was a confirmation query and has been handled (the
+    caller should not fall through to its own message routing for it).
+    """
+    msg_type = msg.get("type")
+
+    if msg_type == "list_confirmations":
+        await _gui_write(
+            writer,
+            {
+                "type": "confirmation_list",
+                "confirmations": app.confirmation.list_pending(),
+            },
+        )
+        return True
+
+    if msg_type == "approve_confirmation":
+        app.events.inject_confirmation_response(
+            {
+                "type": "confirmation_response",
+                "id": msg.get("id", ""),
+                "approved": True,
+            }
+        )
+        await _gui_write(
+            writer, {"type": "ack", "message": f"Approved {msg.get('id', '')}"}
+        )
+        return True
+
+    if msg_type == "deny_confirmation":
+        app.events.inject_confirmation_response(
+            {
+                "type": "confirmation_response",
+                "id": msg.get("id", ""),
+                "approved": False,
+            }
+        )
+        await _gui_write(
+            writer, {"type": "ack", "message": f"Denied {msg.get('id', '')}"}
+        )
+        return True
+
+    if msg_type == "approve_all_confirmations":
+        ids = [c["id"] for c in app.confirmation.list_pending()]
+        for cid in ids:
+            app.events.inject_confirmation_response(
+                {"type": "confirmation_response", "id": cid, "approved": True}
+            )
+        await _gui_write(
+            writer, {"type": "ack", "message": f"Approved {len(ids)} confirmation(s)"}
+        )
+        return True
+
+    return False
 
 
 def on_output_for_broadcast(app: Any, response: dict[str, Any]) -> None:
@@ -226,6 +290,9 @@ async def _process_gui_message(
 ) -> None:
     """Route an incoming GUI protocol message."""
     msg_type = msg.get("type")
+
+    if await _handle_confirmation_query(app, msg, writer):
+        return
 
     if msg_type == "message":
         content = msg.get("content", "").strip()

--- a/jarvis/runtime/lifecycle.py
+++ b/jarvis/runtime/lifecycle.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 
 from ..config import Config
 from ..platform import current as platform
+from .io import broadcast_to_gui_clients
 from .voice_activation_thread import run_voice_activation
 
 
@@ -49,6 +50,27 @@ async def bootstrap_tool_index_nonfatal(
             logger.info("JARVIS: No servers to index")
     except Exception as e:
         logger.warning(f"JARVIS: Tool index sync failed (non-fatal): {e}")
+
+
+def _broadcast_confirmation_notice(app: Any, message: dict[str, Any]) -> None:
+    """Forward a confirmation notification to whichever socket(s) have
+    clients connected, plus a refreshed pending list for GUI clients so an
+    already-open Permission Requests view updates the moment a new one
+    arrives, not just when one gets resolved.
+    """
+    if Config.JARVIS_OUTPUT_SOCKET and app._output_clients:
+        app._on_output_for_broadcast(message)
+    if app._gui_clients:
+        asyncio.create_task(broadcast_to_gui_clients(app, message))
+        asyncio.create_task(
+            broadcast_to_gui_clients(
+                app,
+                {
+                    "type": "confirmation_list",
+                    "confirmations": app.confirmation.list_pending(),
+                },
+            )
+        )
 
 
 def stdin_is_tty() -> bool:
@@ -99,10 +121,6 @@ async def start_runtime_services(
     output_socket_task: Optional[asyncio.Task] = None
     if Config.JARVIS_OUTPUT_SOCKET:
         app.output_manager.add_output_callback(app._on_output_for_broadcast)
-        app.confirmation.set_output_callback(
-            app._on_output_for_broadcast,
-            has_clients=lambda: len(app._output_clients) > 0,
-        )
         output_socket_task = asyncio.create_task(app._run_output_socket_listener())
         logger.info(f"JARVIS: Output socket at {Config.JARVIS_OUTPUT_SOCKET}")
 
@@ -114,6 +132,16 @@ async def start_runtime_services(
         app.output_manager.add_output_callback(app._on_gui_output)
         gui_socket_task = asyncio.create_task(app._run_gui_socket_listener())
         logger.info(f"JARVIS: GUI socket at {Config.JARVIS_GUI_SOCKET}")
+
+    # Confirmation notifications need to reach whichever socket(s) are
+    # actually enabled -- previously this only ever wired to the legacy
+    # output socket, so a GUI-only setup (no JARVIS_OUTPUT_SOCKET) never
+    # got a confirmation_request at all.
+    if Config.JARVIS_OUTPUT_SOCKET or Config.JARVIS_GUI_SOCKET:
+        app.confirmation.set_output_callback(
+            lambda message: _broadcast_confirmation_notice(app, message),
+            has_clients=lambda: bool(app._output_clients) or bool(app._gui_clients),
+        )
 
     return {
         "input_socket": input_socket_task,

--- a/jarvis/runtime/root_handlers.py
+++ b/jarvis/runtime/root_handlers.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from logging import Logger
 from typing import Any
 
+from .io import broadcast_to_gui_clients
 from .llm_bridge import ask_llm
 from .output_hooks import emit_activity
 from .root_context import build_root_context, compact_payload_for_llm
@@ -115,6 +117,21 @@ async def on_confirmation_response(
         f"approved={len(pending.approved_tasks)}, "
         f"denied={len(pending.denied_tools)}"
     )
+
+    # This is the one true point where _pending actually changes, regardless
+    # of which channel resolved it (CLI, GUI, TUI, desktop notification, or
+    # an opted-back-in timeout) -- so it's the right place to keep every
+    # connected GUI client's pending-confirmations view in sync.
+    if getattr(app, "_gui_clients", None):
+        asyncio.create_task(
+            broadcast_to_gui_clients(
+                app,
+                {
+                    "type": "confirmation_list",
+                    "confirmations": app.confirmation.list_pending(),
+                },
+            )
+        )
 
     if app.llm is None:
         logger.warning("Confirmation resolved but no LLM configured — ignoring")

--- a/jarvis/tui/config_modal.py
+++ b/jarvis/tui/config_modal.py
@@ -57,7 +57,7 @@ _SETTINGS: List[_SettingDef] = [
         "Confirmation timeout (s)",
         "Security",
         "int",
-        hint="Auto-deny after this many seconds",
+        hint="Auto-deny after N seconds; 0 disables (pending list instead)",
     ),
     _SettingDef(
         "RAG_TOP_K",

--- a/tests/test_confirmation_pending.py
+++ b/tests/test_confirmation_pending.py
@@ -1,0 +1,120 @@
+"""Tests for the persistent pending-confirmations list (Project-JARVIS#144)."""
+
+import asyncio
+from unittest.mock import Mock, patch
+
+import pytest
+
+from jarvis.core.confirmation_manager import ConfirmationManager
+
+
+def _tools_needing_confirmation(names):
+    return [{"tool_name": n, "params": {}} for n in names]
+
+
+@pytest.mark.unit
+class TestListPending:
+    @pytest.mark.asyncio
+    async def test_empty_when_nothing_pending(self):
+        mgr = ConfirmationManager()
+        assert mgr.list_pending() == []
+
+    @pytest.mark.asyncio
+    async def test_lists_tool_names_and_created_at(self):
+        mgr = ConfirmationManager()
+        mgr.set_event_injector(Mock())
+        await mgr.request_confirmation(
+            request_id="abc123",
+            tasks=[{"server": "s", "tool": "t", "params": {}}],
+            tools_needing_confirmation=_tools_needing_confirmation(["s.t"]),
+            approved_tasks=[],
+            denied_tools=[],
+            timeout=0,
+        )
+        pending = mgr.list_pending()
+        assert len(pending) == 1
+        assert pending[0]["id"] == "abc123"
+        assert pending[0]["tool_names"] == ["s.t"]
+        assert isinstance(pending[0]["created_at"], float)
+
+    @pytest.mark.asyncio
+    async def test_resolved_confirmation_is_removed(self):
+        mgr = ConfirmationManager()
+        mgr.set_event_injector(Mock())
+        await mgr.request_confirmation(
+            request_id="abc123",
+            tasks=[{"server": "s", "tool": "t"}],
+            tools_needing_confirmation=_tools_needing_confirmation(["s.t"]),
+            approved_tasks=[],
+            denied_tools=[],
+            timeout=0,
+        )
+        mgr.resolve({"id": "abc123", "approved": True})
+        assert mgr.list_pending() == []
+
+
+@pytest.mark.unit
+class TestTimeoutDisabledByDefault:
+    @pytest.mark.asyncio
+    async def test_zero_timeout_never_auto_denies(self):
+        mgr = ConfirmationManager()
+        injector = Mock()
+        mgr.set_event_injector(injector)
+        await mgr.request_confirmation(
+            request_id="abc",
+            tasks=[{"server": "s", "tool": "t"}],
+            tools_needing_confirmation=_tools_needing_confirmation(["s.t"]),
+            approved_tasks=[],
+            denied_tools=[],
+            timeout=0,
+        )
+        await asyncio.sleep(0.05)
+        injector.assert_not_called()
+        assert mgr.has_pending("abc")
+
+    @pytest.mark.asyncio
+    async def test_positive_timeout_still_auto_denies(self):
+        mgr = ConfirmationManager()
+        injector = Mock()
+        mgr.set_event_injector(injector)
+        await mgr.request_confirmation(
+            request_id="abc",
+            tasks=[{"server": "s", "tool": "t"}],
+            tools_needing_confirmation=_tools_needing_confirmation(["s.t"]),
+            approved_tasks=[],
+            denied_tools=[],
+            timeout=0.05,
+        )
+        await asyncio.sleep(0.2)
+        # _auto_deny_after's whole contract is firing this injection; actual
+        # removal from _pending only happens later, when resolve() runs off
+        # the real event loop's CONFIRMATION_RESPONSE handling -- not
+        # exercised by this isolated unit test.
+        injector.assert_called_once_with(
+            {"type": "confirmation_response", "id": "abc", "approved": False}
+        )
+
+
+@pytest.mark.unit
+class TestNoChannelAvailable:
+    @pytest.mark.asyncio
+    async def test_no_channel_leaves_it_pending_not_denied(self):
+        mgr = ConfirmationManager()
+        injector = Mock()
+        mgr.set_event_injector(injector)
+        with (
+            patch.object(ConfirmationManager, "_has_tty", return_value=False),
+            patch.object(
+                ConfirmationManager, "_has_desktop_notifications", return_value=False
+            ),
+        ):
+            await mgr.request_confirmation(
+                request_id="abc",
+                tasks=[{"server": "s", "tool": "t"}],
+                tools_needing_confirmation=_tools_needing_confirmation(["s.t"]),
+                approved_tasks=[],
+                denied_tools=[],
+                timeout=0,
+            )
+        injector.assert_not_called()
+        assert mgr.has_pending("abc")

--- a/tests/test_confirmation_socket.py
+++ b/tests/test_confirmation_socket.py
@@ -1,0 +1,154 @@
+"""Tests for confirmation query/mutation handling over both sockets, and the
+broadcast-on-resolve hook in root_handlers.py (Project-JARVIS#144)."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from jarvis.runtime import io as runtime_io
+from jarvis.runtime import root_handlers
+
+
+def _make_app(confirmations=None, gui_clients=None):
+    confirmation_mock = Mock()
+    confirmation_mock.list_pending.return_value = confirmations or []
+    return SimpleNamespace(
+        confirmation=confirmation_mock,
+        events=Mock(),
+        _gui_clients=gui_clients if gui_clients is not None else set(),
+    )
+
+
+@pytest.mark.unit
+class TestHandleConfirmationQuery:
+    @pytest.mark.asyncio
+    async def test_list_confirmations_writes_current_list(self):
+        app = _make_app(
+            confirmations=[{"id": "a", "tool_names": ["x"], "created_at": 1.0}]
+        )
+        writer = Mock()
+        with patch.object(runtime_io, "_gui_write", new=AsyncMock()) as gui_write:
+            handled = await runtime_io._handle_confirmation_query(
+                app, {"type": "list_confirmations"}, writer
+            )
+        assert handled is True
+        gui_write.assert_awaited_once_with(
+            writer,
+            {
+                "type": "confirmation_list",
+                "confirmations": [{"id": "a", "tool_names": ["x"], "created_at": 1.0}],
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_approve_confirmation_injects_approved_response(self):
+        app = _make_app()
+        writer = Mock()
+        with patch.object(runtime_io, "_gui_write", new=AsyncMock()):
+            handled = await runtime_io._handle_confirmation_query(
+                app, {"type": "approve_confirmation", "id": "abc"}, writer
+            )
+        assert handled is True
+        app.events.inject_confirmation_response.assert_called_once_with(
+            {"type": "confirmation_response", "id": "abc", "approved": True}
+        )
+
+    @pytest.mark.asyncio
+    async def test_deny_confirmation_injects_denied_response(self):
+        app = _make_app()
+        writer = Mock()
+        with patch.object(runtime_io, "_gui_write", new=AsyncMock()):
+            handled = await runtime_io._handle_confirmation_query(
+                app, {"type": "deny_confirmation", "id": "abc"}, writer
+            )
+        assert handled is True
+        app.events.inject_confirmation_response.assert_called_once_with(
+            {"type": "confirmation_response", "id": "abc", "approved": False}
+        )
+
+    @pytest.mark.asyncio
+    async def test_approve_all_injects_one_response_per_pending(self):
+        app = _make_app(
+            confirmations=[
+                {"id": "a", "tool_names": [], "created_at": 1.0},
+                {"id": "b", "tool_names": [], "created_at": 2.0},
+            ]
+        )
+        writer = Mock()
+        with patch.object(runtime_io, "_gui_write", new=AsyncMock()):
+            handled = await runtime_io._handle_confirmation_query(
+                app, {"type": "approve_all_confirmations"}, writer
+            )
+        assert handled is True
+        assert app.events.inject_confirmation_response.call_count == 2
+        calls = [
+            c.args[0] for c in app.events.inject_confirmation_response.call_args_list
+        ]
+        assert {"type": "confirmation_response", "id": "a", "approved": True} in calls
+        assert {"type": "confirmation_response", "id": "b", "approved": True} in calls
+
+    @pytest.mark.asyncio
+    async def test_non_confirmation_message_is_not_handled(self):
+        app = _make_app()
+        writer = Mock()
+        handled = await runtime_io._handle_confirmation_query(
+            app, {"type": "message"}, writer
+        )
+        assert handled is False
+
+
+@pytest.mark.unit
+class TestOnConfirmationResponseBroadcast:
+    @pytest.mark.asyncio
+    async def test_broadcasts_refreshed_list_when_gui_clients_connected(self):
+        app = _make_app(confirmations=[], gui_clients={Mock()})
+        app.confirmation.resolve.return_value = Mock(
+            request_id="abc", approved_tasks=[], denied_tools=[]
+        )
+        app.llm = None  # short-circuits right after the broadcast is scheduled
+
+        with patch.object(
+            root_handlers, "broadcast_to_gui_clients", new=AsyncMock()
+        ) as broadcast:
+            await root_handlers.on_confirmation_response(
+                app, Mock(), {"id": "abc", "approved": True}
+            )
+            await asyncio.sleep(0)  # let the scheduled create_task actually run
+
+        broadcast.assert_awaited_once_with(
+            app, {"type": "confirmation_list", "confirmations": []}
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_broadcast_when_no_gui_clients(self):
+        app = _make_app(confirmations=[], gui_clients=set())
+        app.confirmation.resolve.return_value = Mock(
+            request_id="abc", approved_tasks=[], denied_tools=[]
+        )
+        app.llm = None
+
+        with patch.object(
+            root_handlers, "broadcast_to_gui_clients", new=AsyncMock()
+        ) as broadcast:
+            await root_handlers.on_confirmation_response(
+                app, Mock(), {"id": "abc", "approved": True}
+            )
+            await asyncio.sleep(0)
+
+        broadcast.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_broadcast_when_resolve_returns_none(self):
+        app = _make_app(confirmations=[], gui_clients={Mock()})
+        app.confirmation.resolve.return_value = None
+
+        with patch.object(
+            root_handlers, "broadcast_to_gui_clients", new=AsyncMock()
+        ) as broadcast:
+            await root_handlers.on_confirmation_response(
+                app, Mock(), {"id": "unknown", "approved": True}
+            )
+
+        broadcast.assert_not_awaited()


### PR DESCRIPTION
## Summary

Closes #144.

`ConfirmationManager` treated every confirmation as an ephemeral one-shot prompt: fire a notification on whichever channel was available, then hard auto-deny after `CONFIRMATION_TIMEOUT` (30s) if nobody answered. Miss the prompt and it was just gone, denied, with no way to review it. `jarvisos-app`#11's Permission Requests tab needs a persistent, queryable list instead — this builds that.

- `PendingConfirmation` now retains `tool_names`/`created_at` (previously computed locally and discarded), so a later query has something to describe
- `ConfirmationManager.list_pending()` exposes the current pending set
- `CONFIRMATION_TIMEOUT` default changes from `30` to `0` (disabled); the auto-deny task is only scheduled when a positive timeout is configured, restoring the old fail-safe for unattended/headless setups that want it
- The "no notification channel available" path no longer auto-denies either — it now just leaves the request pending, since that's exactly what the persistent list is for
- New client → daemon message types on both the plain input socket and the GUI socket: `list_confirmations`, `approve_confirmation`, `deny_confirmation`, `approve_all_confirmations` — mirroring the session CRUD pattern from #145
- New `jarvis confirmations [approve|deny|approve-all]` CLI command family, giving CLI-only users parity with the GUI
- `root_handlers.on_confirmation_response` — the one true point where `_pending` actually changes, regardless of which channel resolved it — now broadcasts a refreshed `confirmation_list` to connected GUI clients

## A real adjacent gap found while wiring this up

`confirmation_request` notifications were only ever wired to the legacy output socket (`JARVIS_OUTPUT_SOCKET`), never the GUI socket `jarvisos-app` actually connects through — and confirmations had no socket channel at all when only `JARVIS_GUI_SOCKET` was configured. Both sockets are now wired for confirmation broadcasts, including an immediate `confirmation_list` push (not just the raw `confirmation_request`) when a GUI client is connected.

## Test plan

- [x] 14 unit tests: pending-list contents, timeout-disabled-by-default, no-channel-does-not-deny, socket query/mutation handlers, broadcast-on-resolve
- [x] Real end-to-end run of the actual asyncio plain-socket server, round-tripping `list_confirmations`/`approve_confirmation`/`deny_confirmation`/`approve_all_confirmations` over a Unix socket — plus confirming plain chat text and the pre-existing `confirmation_response` type still route correctly, and malformed JSON doesn't crash the connection
- [x] Real end-to-end run of the `jarvis confirmations` CLI command against a live socket server
- [x] Full default test suite (`make test`'s filter) — 58 passed, no regressions
- [x] `black --check` and flake8's actual CI gate (`E9,F63,F7,F82`) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5

---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_