### PR TITLE
Add silence timeout after wake word, return to idle if nothing is said

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,9 +162,9 @@ Built on [Textual](https://textual.textualize.io/). All platform-agnostic.
 | `tts/` | Piper TTS provider |
 | `activation/` | Wake-word detection (Vosk-based) |
 
-Voice runs in a background thread (`voice_activation_thread.py` in `runtime/`). When a wake word fires, it injects a `VOICE_INPUT` event into `EventMerger`. TTS output is triggered by `output_manager.py` after ROOT responds.
+Voice runs in a background thread (`voice_activation_thread.py` in `runtime/`). When a wake word fires, it opens the STT capture window and injects a `VOICE_INPUT` event into `EventMerger` once an utterance completes. If the user says nothing within `VOICE_ACTIVATION_TIMEOUT` seconds, capture is abandoned and control returns to wake-word mode without processing anything; the timeout is disabled the moment speech is detected, so mid-sentence pauses never cut a command off early. Every capture attempt broadcasts its `listening`/`idle` state over the GUI socket.
 
-Config: `WAKE_WORDS`, `VOICE_ACTIVATION_SENSITIVITY`, `VOSK_MODEL_PATH`, `TTS_MODEL_ONNX`/`TTS_MODEL_JSON` — all in `~/.config/jarvis/jarvis.conf`.
+Config: `WAKE_WORDS`, `VOICE_ACTIVATION_SENSITIVITY`, `VOICE_ACTIVATION_TIMEOUT`, `VOSK_MODEL_PATH`, `TTS_MODEL_ONNX`/`TTS_MODEL_JSON` — all in `~/.config/jarvis/jarvis.conf`.
 
 ---
 

--- a/jarvis/.env.example
+++ b/jarvis/.env.example
@@ -67,6 +67,10 @@ WAKE_WORDS=jarvis,hey jarvis,okay jarvis
 # Lower values = less sensitive (might miss wake words)
 VOICE_ACTIVATION_SENSITIVITY=0.8
 
+# Seconds of silence after a wake word before giving up and returning to
+# wake-word mode, without processing anything. 0 disables the timeout.
+VOICE_ACTIVATION_TIMEOUT=4.0
+
 # ===========================================
 # CLI Output Mode Configuration
 # ===========================================

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -78,6 +78,9 @@ class Config:
     VOICE_ACTIVATION_SENSITIVITY = float(
         os.getenv("VOICE_ACTIVATION_SENSITIVITY", "0.8")
     )
+    # Seconds of silence after a wake word before giving up and returning to
+    # wake-word mode. Disabled (never times out) when <= 0.
+    VOICE_ACTIVATION_TIMEOUT = float(os.getenv("VOICE_ACTIVATION_TIMEOUT", "4.0"))
 
     # CLI Output Mode Configuration
     OUTPUT_MODE = os.getenv("OUTPUT_MODE", "voice")  # voice or text

--- a/jarvis/dispatch/event_merger.py
+++ b/jarvis/dispatch/event_merger.py
@@ -152,6 +152,17 @@ class EventMerger:
 
         self._loop.call_soon_threadsafe(_put)
 
+    def call_soon_threadsafe(self, callback: Callable[[], None]) -> None:
+        """Schedule a plain callback on the event loop from any thread.
+
+        For voice/socket threads that need to trigger async work (e.g.
+        broadcasting a GUI state change) without going through the merged
+        event queue.
+        """
+        if self._loop is None:
+            return
+        self._loop.call_soon_threadsafe(callback)
+
     def request_shutdown(self) -> None:
         """Thread-safe request to shut down the event loop (e.g. from signal handler)."""
         if self._loop is None:

--- a/jarvis/runtime/voice_activation_thread.py
+++ b/jarvis/runtime/voice_activation_thread.py
@@ -2,27 +2,72 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from logging import Logger
 from typing import Any
 
+from ..config import Config
+
+
+def _broadcast_gui_state(app: Any, state: str) -> None:
+    """Thread-safe: schedule a GUI-socket state broadcast onto the event loop."""
+    events = getattr(app, "events", None)
+    if events is None:
+        return
+
+    from .io import set_gui_state
+
+    events.call_soon_threadsafe(lambda: asyncio.create_task(set_gui_state(app, state)))
+
 
 def process_voice_command_inject(app: Any, logger: Logger) -> None:
-    """Process voice command and inject into event loop (no direct ask)."""
+    """Process voice command and inject into event loop (no direct ask).
+
+    Gives up and returns to wake-word mode if the user hasn't started
+    speaking within ``VOICE_ACTIVATION_TIMEOUT`` seconds -- ``iter_results()``
+    never yields during pure silence, so a plain ``for`` loop over it can't
+    detect "nothing was said" (see Project-JARVIS#137). ``read()`` polls with
+    a bounded wait instead, so the deadline is actually checked.
+    """
     try:
         app.voice_manager.activation.stop_listening()
         app.voice_manager.stt.start()
+        _broadcast_gui_state(app, "listening")
         try:
-            for text, is_final in app.voice_manager.stt.iter_results():
+            timeout = Config.VOICE_ACTIVATION_TIMEOUT
+            deadline = time.monotonic() + timeout if timeout > 0 else None
+            speech_started = False
+
+            while app.voice_manager.stt.is_running():
+                poll_timeout = 0.2
+                if deadline is not None and not speech_started:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        logger.info(
+                            "JARVIS: No speech detected after wake word, "
+                            "returning to wake-word mode"
+                        )
+                        return
+                    poll_timeout = min(poll_timeout, remaining)
+
+                result = app.voice_manager.stt.read(timeout=poll_timeout)
+                if result is None:
+                    continue
+
+                text, is_final = result
+                if text.strip():
+                    speech_started = True
                 if is_final and text.strip():
                     logger.info(f"Voice input: {text}")
                     app.events.inject_user_input(text.strip())
-                    break
+                    return
         finally:
             app.voice_manager.stt.stop()
     except Exception as e:
         logger.error(f"JARVIS: Voice processing error: {e}")
     finally:
+        _broadcast_gui_state(app, "idle")
         if app._running and hasattr(app.voice_manager, "activation"):
             app.voice_manager.activation.start_listening()
 

--- a/jarvis/voice/base.py
+++ b/jarvis/voice/base.py
@@ -31,7 +31,17 @@ class STTProvider(ABC):
         """Yield ``(text, is_final)`` tuples as speech is recognised.
 
         Must block between results and stop iterating when the provider
-        is no longer running.
+        is no longer running. Yields nothing during pure silence -- callers
+        that need to detect "no speech at all" (e.g. a post-wake-word
+        timeout) must use ``read()`` instead, since a silent ``for`` loop
+        over this generator never re-enters its body to check a deadline.
+        """
+
+    @abstractmethod
+    def read(self, timeout: Optional[float] = None) -> Optional[Tuple[str, bool]]:
+        """Pop the next ``(text, is_final)`` result, waiting up to ``timeout``
+        seconds. Returns None if none arrives in time, so callers can bound
+        how long they wait through stretches of silence.
         """
 
     @abstractmethod

--- a/tests/test_voice_activation_timeout.py
+++ b/tests/test_voice_activation_timeout.py
@@ -1,0 +1,146 @@
+"""Tests for the post-wake-word silence timeout (Project-JARVIS#137).
+
+``iter_results()`` never yields during pure silence, so a plain ``for`` loop
+over it can't detect "the user said nothing" -- these tests cover the fix in
+``process_voice_command_inject``, which polls via ``read()`` instead so a
+deadline can actually be checked between results.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from jarvis.config import Config
+from jarvis.runtime import voice_activation_thread as vat
+
+
+def _make_app(stt_read_side_effect, is_running=True):
+    stt = Mock()
+    stt.read.side_effect = stt_read_side_effect
+    stt.is_running.return_value = is_running
+
+    activation = Mock()
+    events = Mock()
+    events.call_soon_threadsafe = Mock()
+
+    voice_manager = SimpleNamespace(stt=stt, activation=activation)
+    return (
+        SimpleNamespace(
+            voice_manager=voice_manager,
+            events=events,
+            _running=True,
+        ),
+        stt,
+        activation,
+        events,
+    )
+
+
+@pytest.mark.unit
+class TestSilenceTimeout:
+    def test_no_speech_within_timeout_returns_without_processing(self):
+        app, stt, activation, events = _make_app(stt_read_side_effect=lambda **_: None)
+        clock = iter([0.0, 0.5, 2.0, 4.5])
+
+        with (
+            patch.object(Config, "VOICE_ACTIVATION_TIMEOUT", 4.0),
+            patch.object(vat.time, "monotonic", side_effect=lambda: next(clock)),
+        ):
+            vat.process_voice_command_inject(app, Mock())
+
+        events.inject_user_input.assert_not_called()
+        stt.stop.assert_called_once()
+        activation.start_listening.assert_called()
+
+    def test_timeout_disabled_when_zero(self):
+        app, stt, activation, events = _make_app(
+            stt_read_side_effect=[None, None, ("hi", True)]
+        )
+
+        with patch.object(Config, "VOICE_ACTIVATION_TIMEOUT", 0):
+            vat.process_voice_command_inject(app, Mock())
+
+        events.inject_user_input.assert_called_once_with("hi")
+
+    def test_speech_finishing_before_timeout_is_processed(self):
+        app, stt, activation, events = _make_app(
+            stt_read_side_effect=[("hel", False), ("hello world", True)]
+        )
+
+        with patch.object(Config, "VOICE_ACTIVATION_TIMEOUT", 4.0):
+            vat.process_voice_command_inject(app, Mock())
+
+        events.inject_user_input.assert_called_once_with("hello world")
+        stt.stop.assert_called_once()
+        activation.start_listening.assert_called()
+
+    def test_timeout_disabled_once_speech_has_started(self):
+        # Speech starts immediately, then several silent polls follow.
+        # monotonic() must only be consulted while waiting for speech to
+        # start -- once it has, the deadline check must not run again, no
+        # matter how much (real) time the rest of the utterance takes.
+        app, stt, activation, events = _make_app(
+            stt_read_side_effect=[("hel", False)] + [None] * 5 + [("hello world", True)]
+        )
+        clock_calls = [0.0, 0.1]
+
+        def fake_monotonic():
+            if not clock_calls:
+                raise AssertionError(
+                    "deadline should not be rechecked once speech_started is True"
+                )
+            return clock_calls.pop(0)
+
+        with (
+            patch.object(Config, "VOICE_ACTIVATION_TIMEOUT", 4.0),
+            patch.object(vat.time, "monotonic", side_effect=fake_monotonic),
+        ):
+            vat.process_voice_command_inject(app, Mock())
+
+        events.inject_user_input.assert_called_once_with("hello world")
+
+    def test_stops_early_if_stt_no_longer_running(self):
+        app, stt, activation, events = _make_app(
+            stt_read_side_effect=lambda **_: None, is_running=False
+        )
+
+        with patch.object(Config, "VOICE_ACTIVATION_TIMEOUT", 4.0):
+            vat.process_voice_command_inject(app, Mock())
+
+        stt.read.assert_not_called()
+        events.inject_user_input.assert_not_called()
+
+    def test_activation_restarted_only_when_app_running(self):
+        app, stt, activation, events = _make_app(stt_read_side_effect=[("hi", True)])
+        app._running = False
+
+        with patch.object(Config, "VOICE_ACTIVATION_TIMEOUT", 4.0):
+            vat.process_voice_command_inject(app, Mock())
+
+        activation.start_listening.assert_not_called()
+
+
+@pytest.mark.unit
+class TestBroadcastGuiState:
+    @pytest.mark.asyncio
+    async def test_schedules_set_gui_state_onto_the_loop(self):
+        app = SimpleNamespace(events=Mock())
+        loop = asyncio.get_running_loop()
+        app.events.call_soon_threadsafe = lambda cb: loop.call_soon(cb)
+
+        with patch("jarvis.runtime.io.set_gui_state") as mock_set_state:
+            mock_set_state.side_effect = lambda *a, **kw: _noop()
+            vat._broadcast_gui_state(app, "listening")
+            await asyncio.sleep(0)
+
+        mock_set_state.assert_called_once_with(app, "listening")
+
+    def test_noop_when_app_has_no_events(self):
+        app = SimpleNamespace(events=None)
+        vat._broadcast_gui_state(app, "idle")  # must not raise
+
+
+async def _noop():
+    return None


### PR DESCRIPTION
## Summary

Closes #137.

- `process_voice_command_inject` looped over `stt.iter_results()` forever once a wake word fired. That generator only yields when Vosk actually recognizes speech — on pure silence the `for` loop body never re-enters, so no deadline check was ever reachable and the mic stayed open indefinitely.
- Switched to `STTProvider.read(timeout=...)`, which polls with a bounded wait, so `VOICE_ACTIVATION_TIMEOUT` (new config, default 4s) can actually be enforced. The timeout is disabled the instant any speech (partial or final) is detected, so it never cuts off a slow talker mid-utterance — Vosk's own internal silence detection still finalizes the utterance shortly after the user stops talking.
- Promoted `read()` from a Vosk-specific extra method to a required `STTProvider` abstract method, since any STT provider needs a bounded poll to support a silence timeout at all — `VoskSTT` already implemented it.
- Wires `listening`/`idle` GUI-socket state broadcasts around each capture attempt. The voice thread has no event loop of its own, so this goes through a new `EventMerger.call_soon_threadsafe()` — the same cross-thread pattern `inject_user_input`/`inject_confirmation_response` already use, just generalized to schedule an arbitrary callback instead of only queueing merged events.
- `VOICE_ACTIVATION_TIMEOUT` documented in `config.py`, `.env.example`, and `docs/architecture.md`.

## Verification

- New unit test suite (`tests/test_voice_activation_timeout.py`, 8 tests) covering: no speech within timeout → returns without processing; timeout disabled when `VOICE_ACTIVATION_TIMEOUT=0`; speech completing before timeout is processed; timeout correctly disabled once speech has started (with a fake clock asserting `monotonic()` is never rechecked after that point); early exit when the STT provider itself stops running; activation only restarted when the app is still running; `_broadcast_gui_state` schedules `set_gui_state` onto a real event loop.
- Real end-to-end smoke test (not committed, ad hoc verification): an actual background `threading.Thread` running `process_voice_command_inject` against a live `asyncio` event loop and real `EventMerger` — confirms speech is genuinely injected as a `user_input` event across the thread boundary, GUI states broadcast in the correct `listening → idle` order, and the silence-timeout path actually elapses real wall-clock time (~0.16s for a 0.15s configured timeout) before returning with nothing injected.
- Confirmed the 12 pre-existing failures in `test_integration_llm.py`/`test_integration_e2e.py` (unrelated `ollama` module / `LLM.__init__` signature mismatches) exist identically on a clean checkout of this branch before these changes — not a regression.
- `black`, `flake8 --select=E9,F63,F7,F82` clean on all changed files.

## Test plan

- [ ] Run the daemon with voice enabled, say "Hey Jarvis" and then nothing — confirm it returns to wake-word mode after ~4s without invoking the LLM
- [ ] Say "Hey Jarvis" then speak slowly with natural pauses — confirm it doesn't cut off before the utterance finishes
- [ ] Watch the GUI socket (or `jarvisos-app`) during a capture attempt — confirm `listening` then `idle` states arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5

---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_