### PR TITLE
Formalize the voice/response session state machine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,7 @@ make check                  # Format + lint + typecheck + tests
 | `jarvis/core/confirmation_manager.py` | Multi-channel confirmation gate |
 | `jarvis/core/socket_security.py` | Socket hardening |
 | `jarvis/core/command_parser.py` | LLM response parser + action registry |
+| `jarvis/core/voice_state.py` | `VoiceState` — formal voice/response session state machine |
 | `jarvis/dispatch/adapter.py` | Python wrapper for Rust dispatch binary |
 | `jarvis/dispatch/discovery.py` | Embedding search via dmcp vector index |
 | `jarvis/dispatch/dmcp_registry.py` | dmcp CLI wrappers (install, tools, config) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,9 +162,27 @@ Built on [Textual](https://textual.textualize.io/). All platform-agnostic.
 | `tts/` | Piper TTS provider |
 | `activation/` | Wake-word detection (Vosk-based) |
 
-Voice runs in a background thread (`voice_activation_thread.py` in `runtime/`). When a wake word fires, it opens the STT capture window and injects a `VOICE_INPUT` event into `EventMerger` once an utterance completes. If the user says nothing within `VOICE_ACTIVATION_TIMEOUT` seconds, capture is abandoned and control returns to wake-word mode without processing anything; the timeout is disabled the moment speech is detected, so mid-sentence pauses never cut a command off early. Every capture attempt broadcasts its `listening`/`idle` state over the GUI socket.
+Voice runs in a background thread (`voice_activation_thread.py` in `runtime/`). When a wake word fires, it opens the STT capture window and injects a `VOICE_INPUT` event into `EventMerger` once an utterance completes. If the user says nothing within `VOICE_ACTIVATION_TIMEOUT` seconds, capture is abandoned and control returns to wake-word mode without processing anything; the timeout is disabled the moment speech is detected, so mid-sentence pauses never cut a command off early.
 
 Config: `WAKE_WORDS`, `VOICE_ACTIVATION_SENSITIVITY`, `VOICE_ACTIVATION_TIMEOUT`, `VOSK_MODEL_PATH`, `TTS_MODEL_ONNX`/`TTS_MODEL_JSON` — all in `~/.config/jarvis/jarvis.conf`.
+
+### Voice/response session state machine (`jarvis/core/voice_state.py`)
+
+`VoiceState` is the single source of truth for the daemon's voice + response lifecycle:
+
+```
+IDLE (wake-word listening)
+  → WOKEN       (wake word fired, chime plays -- hook point exists, no chime yet)
+    → CAPTURING (STT active, subject to the silence timeout above)
+      → IDLE       (nothing usable was said -- discarded)
+      → PROCESSING (LLM + dispatch running; also entered directly for GUI/CLI/stdin text input)
+        → SPEAKING (TTS playing the reply)
+          → IDLE
+```
+
+Every transition broadcasts over the GUI socket as a structured event: `{"type": "state", "state": "<value>", "meta": {...}}`. `meta` is omitted unless the transition carries extra detail (currently only the CAPTURING → IDLE discard case, with `{"reason": "discard", "detail": "..."}`). `jarvis.runtime.io.set_gui_state(app, state, meta=None)` is the only place a transition should be broadcast from; `state` is a `VoiceState` member for anything in the diagram above, or the plain string `"listening"`/`"idle"` for the separate, orthogonal `start_listening`/`stop_listening` GUI toggle (whether the wake-word listener is enabled at all — not part of this state machine).
+
+**Known limitation:** `OutputManager._output_voice()` still calls TTS synthesis/playback synchronously on the event loop thread (a pre-existing characteristic, not introduced by this state machine). SPEAKING and the following IDLE are broadcast at the logically correct points around that call, but because the call blocks the loop, delivery to socket clients can lag behind the exact moment TTS starts/stops. Making TTS playback non-blocking is tracked separately.
 
 ---
 

--- a/jarvis/core/__init__.py
+++ b/jarvis/core/__init__.py
@@ -11,6 +11,7 @@ from .component_factory import ComponentFactory
 from .confirmation_manager import ConfirmationManager
 from .output_manager import OutputManager
 from .system_info import SystemInfo
+from .voice_state import VoiceState
 
 __all__ = [
     "SystemInfo",
@@ -18,4 +19,5 @@ __all__ = [
     "ConfirmationManager",
     "OutputManager",
     "ComponentFactory",
+    "VoiceState",
 ]

--- a/jarvis/core/output_manager.py
+++ b/jarvis/core/output_manager.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from ..config import Config
 from .logger import get_logger
+from .voice_state import VoiceState
 
 logger = get_logger(__name__)
 
@@ -25,6 +26,23 @@ class OutputManager:
         self._output_callbacks: List[Callable[[Dict[str, Any]], None]] = []
         self._activity_callbacks: List[Callable[[Dict[str, Any]], None]] = []
         self._suppress_stdout = suppress_stdout
+        self._state_callback: Optional[Callable[[VoiceState], None]] = None
+
+    def set_state_callback(self, cb: Optional[Callable[[VoiceState], None]]) -> None:
+        """Register a callback notified of SPEAKING/IDLE around TTS playback.
+
+        Wired by lifecycle.py to broadcast the transition over the GUI
+        socket. Left unset in contexts with no daemon/socket (bare CLI use).
+        """
+        self._state_callback = cb
+
+    def _notify_state(self, state: VoiceState) -> None:
+        if self._state_callback is None:
+            return
+        try:
+            self._state_callback(state)
+        except Exception as e:
+            logger.warning(f"State callback error: {e}")
 
     def add_output_callback(self, cb: Callable[[Dict[str, Any]], None]) -> None:
         """Register a callback to receive every response (for app/stream integration)."""
@@ -95,11 +113,14 @@ class OutputManager:
             text: Text to speak
         """
         if self._has_tts and self.tts is not None:
+            self._notify_state(VoiceState.SPEAKING)
             try:
                 self.tts.say(text)
             except Exception as e:
                 logger.warning(f"TTS failed, falling back to text output: {e}")
                 self._output_text(text)
+            finally:
+                self._notify_state(VoiceState.IDLE)
         else:
             logger.info("Voice output requested but TTS unavailable, using text output")
             self._output_text(text)

--- a/jarvis/core/voice_state.py
+++ b/jarvis/core/voice_state.py
@@ -1,0 +1,31 @@
+"""Formal voice/response session state machine (Project-JARVIS#141).
+
+Single source of truth for the daemon's voice + response lifecycle:
+
+    IDLE (wake-word listening)
+      -> WOKEN       (wake word fired, chime plays)
+        -> CAPTURING (STT active; silence timeout in voice_activation_thread.py)
+          -> IDLE       (nothing usable was said -- discarded)
+          -> PROCESSING (LLM + dispatch running)
+            -> SPEAKING (TTS playing the reply)
+              -> IDLE
+
+Every transition is broadcast over the GUI socket via
+``jarvis.runtime.io.set_gui_state`` as a structured ``{"type": "state", ...}``
+event so TUI, jarvisos-app, and any future widget render the same states
+without guessing from ad hoc strings.
+
+The manual ``start_listening``/``stop_listening`` GUI messages are a
+separate, orthogonal concept (whether the wake-word listener is enabled at
+all) and are not part of this enum.
+"""
+
+from enum import Enum
+
+
+class VoiceState(str, Enum):
+    IDLE = "idle"
+    WOKEN = "woken"
+    CAPTURING = "capturing"
+    PROCESSING = "processing"
+    SPEAKING = "speaking"

--- a/jarvis/runtime/io.py
+++ b/jarvis/runtime/io.py
@@ -9,6 +9,7 @@ from logging import Logger
 from typing import Any
 
 from ..config import Config
+from ..core.voice_state import VoiceState
 from ..platform import current as platform
 
 
@@ -297,7 +298,7 @@ async def _process_gui_message(
     if msg_type == "message":
         content = msg.get("content", "").strip()
         if content:
-            await set_gui_state(app, "processing")
+            await set_gui_state(app, VoiceState.PROCESSING)
             app.events.inject_user_input(content)
             logger.info(f"JARVIS: GUI input: {content[:80]}...")
 
@@ -305,6 +306,10 @@ async def _process_gui_message(
         app.events.inject_confirmation_response(msg)
 
     elif msg_type == "start_listening":
+        # Toggles whether the wake-word listener is enabled at all -- a
+        # separate, orthogonal concept from the WOKEN/CAPTURING/PROCESSING/
+        # SPEAKING session lifecycle in VoiceState, so it keeps its own
+        # plain-string state rather than reusing VoiceState.IDLE.
         if app.voice_manager and hasattr(app.voice_manager, "activation"):
             app.voice_manager.activation.start_listening()
         await set_gui_state(app, "listening")
@@ -318,7 +323,7 @@ async def _process_gui_message(
         await broadcast_to_gui_clients(
             app, {"type": "response", "content": "", "done": True}
         )
-        await set_gui_state(app, "idle")
+        await set_gui_state(app, VoiceState.IDLE)
 
     elif msg_type == "list_sessions":
         await _gui_write(writer, _handle_list_sessions(app, msg))
@@ -447,10 +452,23 @@ async def _reply_or_broadcast(
         await broadcast_to_gui_clients(app, response)
 
 
-async def set_gui_state(app: Any, state: str) -> None:
-    """Update tracked GUI state and broadcast to all GUI clients."""
-    app._gui_state = state
-    await broadcast_to_gui_clients(app, {"type": "state", "state": state})
+async def set_gui_state(
+    app: Any, state: VoiceState | str, meta: dict | None = None
+) -> None:
+    """Update tracked GUI state and broadcast to all GUI clients.
+
+    `state` is normally a VoiceState member; the manual start_listening/
+    stop_listening toggle passes a plain string instead (see its call site).
+    `meta` carries transition-specific detail (e.g. a discard reason) and is
+    omitted from the wire payload entirely when empty, keeping the common
+    case a plain `{"type": "state", "state": ...}` message.
+    """
+    state_value = state.value if isinstance(state, VoiceState) else state
+    app._gui_state = state_value
+    message: dict[str, Any] = {"type": "state", "state": state_value}
+    if meta:
+        message["meta"] = meta
+    await broadcast_to_gui_clients(app, message)
 
 
 def on_gui_output(app: Any, response: dict[str, Any]) -> None:
@@ -463,13 +481,21 @@ def on_gui_output(app: Any, response: dict[str, Any]) -> None:
 
 
 async def _gui_output_and_idle(app: Any, response: dict[str, Any]) -> None:
-    """Translate daemon output into GUI protocol and reset state to idle."""
+    """Translate daemon output into GUI protocol and reset state to idle.
+
+    Skips the idle reset when the response is about to be spoken -- the
+    OutputManager's own SPEAKING/IDLE bracket around the actual TTS call
+    (wired in lifecycle.py) is the accurate signal for when speech ends,
+    and firing idle here first would just flash it prematurely.
+    """
     text = response.get("output", "")
     if text:
         await broadcast_to_gui_clients(
             app, {"type": "response", "content": text, "done": True}
         )
-    await set_gui_state(app, "idle")
+    about_to_speak = Config.OUTPUT_MODE == "voice" and app.output_manager.has_tts()
+    if not about_to_speak:
+        await set_gui_state(app, VoiceState.IDLE)
 
 
 async def broadcast_to_gui_clients(app: Any, message: dict) -> None:

--- a/jarvis/runtime/lifecycle.py
+++ b/jarvis/runtime/lifecycle.py
@@ -10,8 +10,9 @@ from logging import Logger
 from typing import Any, Optional
 
 from ..config import Config
+from ..core.voice_state import VoiceState
 from ..platform import current as platform
-from .io import broadcast_to_gui_clients
+from .io import broadcast_to_gui_clients, set_gui_state
 from .voice_activation_thread import run_voice_activation
 
 
@@ -73,6 +74,18 @@ def _broadcast_confirmation_notice(app: Any, message: dict[str, Any]) -> None:
         )
 
 
+def _notify_voice_output_state(app: Any, state: VoiceState) -> None:
+    """Bridge OutputManager's synchronous SPEAKING/IDLE callback onto the
+    event loop. handle_response() already runs on the loop thread (called
+    from async ROOT handlers), so this only needs to schedule a task -- no
+    cross-thread handoff, unlike the voice thread's own state broadcasts."""
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(set_gui_state(app, state))
+    except RuntimeError:
+        pass
+
+
 def stdin_is_tty() -> bool:
     """True if stdin is a TTY (interactive chat mode)."""
     return hasattr(sys.stdin, "isatty") and sys.stdin.isatty()
@@ -93,6 +106,10 @@ async def start_runtime_services(
     app.events.start(
         signal_window_source=app.dispatch.get_signal_window,
         user_source=user_source,
+    )
+
+    app.output_manager.set_state_callback(
+        lambda state: _notify_voice_output_state(app, state)
     )
 
     if app.voice_manager:

--- a/jarvis/runtime/root_handlers.py
+++ b/jarvis/runtime/root_handlers.py
@@ -7,7 +7,8 @@ import json
 from logging import Logger
 from typing import Any
 
-from .io import broadcast_to_gui_clients
+from ..core.voice_state import VoiceState
+from .io import broadcast_to_gui_clients, set_gui_state
 from .llm_bridge import ask_llm
 from .output_hooks import emit_activity
 from .root_context import build_root_context, compact_payload_for_llm
@@ -21,6 +22,11 @@ _NO_LLM_MSG = (
 
 async def on_user_input(app: Any, logger: Logger, text: str) -> None:
     logger.info(f"JARVIS: User input: '{text}'")
+
+    # Single funnel for every input source (voice, GUI/CLI socket, stdin) --
+    # the GUI "message" handler already broadcasts this for its own path,
+    # but voice-injected input had no PROCESSING signal at all before this.
+    await set_gui_state(app, VoiceState.PROCESSING)
 
     if text.startswith("/"):
         handled = handle_slash_command(app, text)

--- a/jarvis/runtime/voice_activation_thread.py
+++ b/jarvis/runtime/voice_activation_thread.py
@@ -8,9 +8,10 @@ from logging import Logger
 from typing import Any
 
 from ..config import Config
+from ..core.voice_state import VoiceState
 
 
-def _broadcast_gui_state(app: Any, state: str) -> None:
+def _broadcast_gui_state(app: Any, state: VoiceState, meta: dict | None = None) -> None:
     """Thread-safe: schedule a GUI-socket state broadcast onto the event loop."""
     events = getattr(app, "events", None)
     if events is None:
@@ -18,7 +19,9 @@ def _broadcast_gui_state(app: Any, state: str) -> None:
 
     from .io import set_gui_state
 
-    events.call_soon_threadsafe(lambda: asyncio.create_task(set_gui_state(app, state)))
+    events.call_soon_threadsafe(
+        lambda: asyncio.create_task(set_gui_state(app, state, meta))
+    )
 
 
 def process_voice_command_inject(app: Any, logger: Logger) -> None:
@@ -30,10 +33,11 @@ def process_voice_command_inject(app: Any, logger: Logger) -> None:
     detect "nothing was said" (see Project-JARVIS#137). ``read()`` polls with
     a bounded wait instead, so the deadline is actually checked.
     """
+    idle_meta: dict | None = None
     try:
         app.voice_manager.activation.stop_listening()
         app.voice_manager.stt.start()
-        _broadcast_gui_state(app, "listening")
+        _broadcast_gui_state(app, VoiceState.CAPTURING)
         try:
             timeout = Config.VOICE_ACTIVATION_TIMEOUT
             deadline = time.monotonic() + timeout if timeout > 0 else None
@@ -48,6 +52,10 @@ def process_voice_command_inject(app: Any, logger: Logger) -> None:
                             "JARVIS: No speech detected after wake word, "
                             "returning to wake-word mode"
                         )
+                        idle_meta = {
+                            "reason": "discard",
+                            "detail": "no speech detected within timeout",
+                        }
                         return
                     poll_timeout = min(poll_timeout, remaining)
 
@@ -67,7 +75,7 @@ def process_voice_command_inject(app: Any, logger: Logger) -> None:
     except Exception as e:
         logger.error(f"JARVIS: Voice processing error: {e}")
     finally:
-        _broadcast_gui_state(app, "idle")
+        _broadcast_gui_state(app, VoiceState.IDLE, idle_meta)
         if app._running and hasattr(app.voice_manager, "activation"):
             app.voice_manager.activation.start_listening()
 
@@ -87,6 +95,9 @@ def run_voice_activation(app: Any, logger: Logger) -> None:
         while app._running:
             if getattr(app.voice_manager, "_wake_word_detected", False):
                 app.voice_manager._wake_word_detected = False
+                # WOKEN is deliberately transient -- no chime plays yet
+                # (Project-JARVIS#139), but this is the hook point for it.
+                _broadcast_gui_state(app, VoiceState.WOKEN)
                 process_voice_command_inject(app, logger)
             time.sleep(0.3)
     except Exception as e:

--- a/tests/test_voice_activation_timeout.py
+++ b/tests/test_voice_activation_timeout.py
@@ -1,4 +1,6 @@
-"""Tests for the post-wake-word silence timeout (Project-JARVIS#137).
+"""Tests for the post-wake-word silence timeout (Project-JARVIS#137) and the
+WOKEN/CAPTURING/discard state broadcasts layered on top for the formal voice
+state machine (Project-JARVIS#141).
 
 ``iter_results()`` never yields during pure silence, so a plain ``for`` loop
 over it can't detect "the user said nothing" -- these tests cover the fix in
@@ -13,6 +15,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from jarvis.config import Config
+from jarvis.core.voice_state import VoiceState
 from jarvis.runtime import voice_activation_thread as vat
 
 
@@ -36,6 +39,39 @@ def _make_app(stt_read_side_effect, is_running=True):
         activation,
         events,
     )
+
+
+def _run_and_record_states(action, events_mock):
+    """Run `action` (which schedules state broadcasts via events.call_soon_
+    threadsafe) with io.set_gui_state faked out, then execute each scheduled
+    callback and return the (state, meta) pairs it recorded.
+
+    _broadcast_gui_state imports set_gui_state locally at call time, so the
+    patch must be active while `action` itself runs -- not just while the
+    scheduled callbacks are later replayed.
+    """
+    calls = []
+
+    async def fake_set_gui_state(app, state, meta=None):
+        calls.append((state, meta))
+
+    with patch("jarvis.runtime.io.set_gui_state", new=fake_set_gui_state):
+        action()
+
+        loop = asyncio.new_event_loop()
+        try:
+            for call in events_mock.call_soon_threadsafe.call_args_list:
+                cb = call.args[0]
+                loop.run_until_complete(_run_callback(cb))
+        finally:
+            loop.close()
+    return calls
+
+
+async def _run_callback(cb):
+    task = cb()
+    if task is not None:
+        await task
 
 
 @pytest.mark.unit
@@ -123,6 +159,64 @@ class TestSilenceTimeout:
 
 
 @pytest.mark.unit
+class TestVoiceStateBroadcasts:
+    def test_capturing_then_idle_with_no_meta_on_success(self):
+        app, stt, activation, events = _make_app(stt_read_side_effect=[("hi", True)])
+
+        def action():
+            with patch.object(Config, "VOICE_ACTIVATION_TIMEOUT", 4.0):
+                vat.process_voice_command_inject(app, Mock())
+
+        states = _run_and_record_states(action, events)
+        assert states == [
+            (VoiceState.CAPTURING, None),
+            (VoiceState.IDLE, None),
+        ]
+
+    def test_idle_carries_discard_meta_on_timeout(self):
+        app, stt, activation, events = _make_app(stt_read_side_effect=lambda **_: None)
+        clock = iter([0.0, 0.5, 4.5])
+
+        def action():
+            with (
+                patch.object(Config, "VOICE_ACTIVATION_TIMEOUT", 4.0),
+                patch.object(vat.time, "monotonic", side_effect=lambda: next(clock)),
+            ):
+                vat.process_voice_command_inject(app, Mock())
+
+        states = _run_and_record_states(action, events)
+        assert states[0] == (VoiceState.CAPTURING, None)
+        assert states[1][0] == VoiceState.IDLE
+        assert states[1][1]["reason"] == "discard"
+
+    def test_woken_broadcast_before_capture_starts(self):
+        vm = SimpleNamespace(stt=Mock(), activation=Mock(), _wake_word_detected=False)
+        vm.stt.is_running.return_value = False  # end the capture loop immediately
+
+        def fake_start_listening():
+            # run_voice_activation resets _wake_word_detected=False on entry,
+            # then wires activation and starts listening -- simulate the
+            # (mocked-out) wake-word engine firing right after that.
+            vm._wake_word_detected = True
+            return True
+
+        vm.activation.start_listening.side_effect = fake_start_listening
+        events = Mock()
+        events.call_soon_threadsafe = Mock()
+        app = SimpleNamespace(voice_manager=vm, events=events, _running=True)
+
+        def stop_after_one_pass(_seconds):
+            app._running = False  # exit run_voice_activation's while loop next check
+
+        def action():
+            with patch.object(vat.time, "sleep", side_effect=stop_after_one_pass):
+                vat.run_voice_activation(app, Mock())
+
+        states = _run_and_record_states(action, events)
+        assert states[0] == (VoiceState.WOKEN, None)
+
+
+@pytest.mark.unit
 class TestBroadcastGuiState:
     @pytest.mark.asyncio
     async def test_schedules_set_gui_state_onto_the_loop(self):
@@ -132,14 +226,14 @@ class TestBroadcastGuiState:
 
         with patch("jarvis.runtime.io.set_gui_state") as mock_set_state:
             mock_set_state.side_effect = lambda *a, **kw: _noop()
-            vat._broadcast_gui_state(app, "listening")
+            vat._broadcast_gui_state(app, VoiceState.CAPTURING)
             await asyncio.sleep(0)
 
-        mock_set_state.assert_called_once_with(app, "listening")
+        mock_set_state.assert_called_once_with(app, VoiceState.CAPTURING, None)
 
     def test_noop_when_app_has_no_events(self):
         app = SimpleNamespace(events=None)
-        vat._broadcast_gui_state(app, "idle")  # must not raise
+        vat._broadcast_gui_state(app, VoiceState.IDLE)  # must not raise
 
 
 async def _noop():

--- a/tests/test_voice_state_machine.py
+++ b/tests/test_voice_state_machine.py
@@ -1,0 +1,171 @@
+"""Tests for the formal voice/response state machine (Project-JARVIS#141):
+VoiceState, the structured `set_gui_state` broadcast, the PROCESSING funnel
+in `on_user_input`, and the SPEAKING/IDLE bracket around TTS playback.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from jarvis.config import Config
+from jarvis.core.output_manager import OutputManager
+from jarvis.core.voice_state import VoiceState
+from jarvis.runtime import io as runtime_io
+from jarvis.runtime import root_handlers
+
+
+@pytest.mark.unit
+class TestVoiceStateEnum:
+    def test_members_serialize_to_their_plain_string_value(self):
+        assert json.dumps({"state": VoiceState.PROCESSING}) == '{"state": "processing"}'
+
+    def test_expected_members_exist(self):
+        assert {s.value for s in VoiceState} == {
+            "idle",
+            "woken",
+            "capturing",
+            "processing",
+            "speaking",
+        }
+
+
+def _make_gui_app():
+    return SimpleNamespace(_gui_state="idle", _gui_clients={Mock()})
+
+
+@pytest.mark.unit
+class TestSetGuiState:
+    @pytest.mark.asyncio
+    async def test_broadcasts_plain_value_with_no_meta_key(self):
+        app = _make_gui_app()
+        with patch.object(
+            runtime_io, "broadcast_to_gui_clients", new=AsyncMock()
+        ) as broadcast:
+            await runtime_io.set_gui_state(app, VoiceState.PROCESSING)
+
+        assert app._gui_state == "processing"
+        broadcast.assert_awaited_once_with(
+            app, {"type": "state", "state": "processing"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_includes_meta_when_provided(self):
+        app = _make_gui_app()
+        meta = {"reason": "discard", "detail": "no speech detected"}
+        with patch.object(
+            runtime_io, "broadcast_to_gui_clients", new=AsyncMock()
+        ) as broadcast:
+            await runtime_io.set_gui_state(app, VoiceState.IDLE, meta)
+
+        broadcast.assert_awaited_once_with(
+            app, {"type": "state", "state": "idle", "meta": meta}
+        )
+
+    @pytest.mark.asyncio
+    async def test_accepts_plain_string_for_manual_listen_toggle(self):
+        app = _make_gui_app()
+        with patch.object(
+            runtime_io, "broadcast_to_gui_clients", new=AsyncMock()
+        ) as broadcast:
+            await runtime_io.set_gui_state(app, "listening")
+
+        assert app._gui_state == "listening"
+        broadcast.assert_awaited_once_with(app, {"type": "state", "state": "listening"})
+
+
+@pytest.mark.unit
+class TestOnUserInputBroadcastsProcessing:
+    @pytest.mark.asyncio
+    async def test_broadcasts_processing_even_when_llm_unconfigured(self):
+        app = SimpleNamespace(llm=None, output_manager=Mock())
+        with patch.object(
+            root_handlers, "set_gui_state", new=AsyncMock()
+        ) as mock_state:
+            await root_handlers.on_user_input(app, Mock(), "hello")
+
+        mock_state.assert_awaited_once_with(app, VoiceState.PROCESSING)
+        app.output_manager.display.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_broadcasts_processing_before_slash_command_handling(self):
+        app = SimpleNamespace(llm=Mock())
+        with (
+            patch.object(root_handlers, "set_gui_state", new=AsyncMock()) as mock_state,
+            patch.object(
+                root_handlers, "handle_slash_command", return_value=True
+            ) as mock_slash,
+        ):
+            await root_handlers.on_user_input(app, Mock(), "/help")
+
+        mock_state.assert_awaited_once_with(app, VoiceState.PROCESSING)
+        mock_slash.assert_called_once_with(app, "/help")
+
+
+@pytest.mark.unit
+class TestOutputManagerSpeakingState:
+    def test_speaking_then_idle_around_tts_call(self):
+        tts = Mock()
+        om = OutputManager(tts=tts)
+        states = []
+        om.set_state_callback(states.append)
+
+        with patch.object(Config, "OUTPUT_MODE", "voice"):
+            om.handle_response({"output": "hello"})
+
+        assert states == [VoiceState.SPEAKING, VoiceState.IDLE]
+        tts.say.assert_called_once_with("hello")
+
+    def test_idle_still_fires_when_tts_raises(self):
+        tts = Mock()
+        tts.say.side_effect = RuntimeError("boom")
+        om = OutputManager(tts=tts, suppress_stdout=True)
+        states = []
+        om.set_state_callback(states.append)
+
+        with patch.object(Config, "OUTPUT_MODE", "voice"):
+            om.handle_response({"output": "hello"})  # must not raise
+
+        assert states == [VoiceState.SPEAKING, VoiceState.IDLE]
+
+    def test_no_state_calls_when_tts_unavailable(self):
+        om = OutputManager(tts=None, suppress_stdout=True)
+        states = []
+        om.set_state_callback(states.append)
+
+        with patch.object(Config, "OUTPUT_MODE", "voice"):
+            om.handle_response({"output": "hello"})
+
+        assert states == []
+
+    def test_no_state_calls_in_text_mode(self):
+        tts = Mock()
+        om = OutputManager(tts=tts, suppress_stdout=True)
+        states = []
+        om.set_state_callback(states.append)
+
+        with patch.object(Config, "OUTPUT_MODE", "text"):
+            om.handle_response({"output": "hello"})
+
+        assert states == []
+        tts.say.assert_not_called()
+
+    def test_state_callback_errors_are_swallowed(self):
+        tts = Mock()
+        om = OutputManager(tts=tts)
+        om.set_state_callback(Mock(side_effect=RuntimeError("cb boom")))
+
+        with patch.object(Config, "OUTPUT_MODE", "voice"):
+            om.handle_response({"output": "hello"})  # must not raise
+
+        tts.say.assert_called_once()
+
+    def test_no_state_calls_when_no_callback_registered(self):
+        tts = Mock()
+        om = OutputManager(tts=tts)  # set_state_callback never called
+
+        with patch.object(Config, "OUTPUT_MODE", "voice"):
+            om.handle_response({"output": "hello"})  # must not raise
+
+        tts.say.assert_called_once()


### PR DESCRIPTION
## Summary

Closes #141.

Voice/daemon state was a loose collection of ad hoc strings (`idle`/`listening`/`processing`/`speaking`) with real gaps: voice-triggered input never broadcast a processing state at all, nothing distinguished "waiting for a wake word" from "actively capturing a command," and TTS playback had no visible state despite being the single longest phase of any voice interaction.

- **`jarvis/core/voice_state.py`** (new) — `VoiceState` enum, the single source of truth:
  ```
  IDLE (wake-word listening)
    → WOKEN       (wake word fired, chime plays -- hook point, no chime yet)
      → CAPTURING (STT active, subject to #137's silence timeout)
        → IDLE       (nothing usable was said -- discarded)
        → PROCESSING (LLM + dispatch running; also entered directly for text input)
          → SPEAKING (TTS playing the reply)
            → IDLE
  ```
- **`jarvis/runtime/io.py`** — `set_gui_state(app, state, meta=None)` now broadcasts a structured `{"type": "state", "state": ..., "meta": {...}}` event instead of a bare string. `meta` is omitted from the payload when empty, so the common case is unchanged wire format wise. `_gui_output_and_idle` defers the idle reset to `OutputManager`'s own bracket when a response is about to be spoken.
- **`jarvis/runtime/voice_activation_thread.py`** — `run_voice_activation` broadcasts `WOKEN` the instant a wake word fires; `process_voice_command_inject` broadcasts `CAPTURING`, and `IDLE` with `meta={"reason": "discard", ...}` when #137's silence timeout fires with nothing said.
- **`jarvis/runtime/root_handlers.py`** — `on_user_input`, the single funnel for voice/GUI/CLI/stdin input, now broadcasts `PROCESSING` — closing the gap where voice-triggered input never announced it was being processed at all.
- **`jarvis/core/output_manager.py`** + **`jarvis/runtime/lifecycle.py`** — `OutputManager` gains a `state_callback` hook that brackets the actual TTS call with `SPEAKING`/`IDLE` (including on the exception/fallback-to-text path), wired from `lifecycle.py` the same way `on_gui_output` already schedules its own broadcasts.
- The manual `start_listening`/`stop_listening` GUI toggle (whether the wake-word listener is enabled at all) is a separate, orthogonal concept from this session lifecycle and intentionally keeps its own plain-string state — noted in code and docs to avoid future confusion.

**Known limitation** (documented in `docs/architecture.md`): TTS playback still runs synchronously on the event loop thread — a pre-existing characteristic, not introduced here. `SPEAKING`/`IDLE` broadcast at the logically correct points around that call, but because the call blocks the loop, wire delivery can lag the exact moment playback starts/stops. Making TTS non-blocking is a separate concern.

Per #141's own acceptance criteria ("jarvisos-app and TUI both consume the same state values"): the TUI has no voice-state consumer today (nothing to reconcile), and `jarvisos-app`'s `main.js` gracefully falls back to an "Offline" label for any state string it doesn't recognize — so `woken`/`capturing` won't crash it, but also won't render distinctly yet. Filed as a small follow-up in that repo to extend its `STATE_LABEL`/`STATE_COLOR` maps.

## Verification

- 24 unit tests across `tests/test_voice_activation_timeout.py` (extended) and `tests/test_voice_state_machine.py` (new): `VoiceState` values and JSON serialization, `set_gui_state`'s meta handling and plain-string passthrough for the manual toggle, `WOKEN`/`CAPTURING`/discard-`IDLE` broadcasts (including a fake-clock assertion that the discard path carries the right reason), the `PROCESSING` funnel in `on_user_input` (including the no-LLM and slash-command paths), and the `SPEAKING`/`IDLE` bracket around TTS (success, exception, TTS-unavailable, text-mode, and no-callback-registered paths).
- Real end-to-end smoke test (ad hoc, not committed): an actual background thread firing a simulated wake word through `process_voice_command_inject` against a live `asyncio` loop and `EventMerger`, asserting the wire-level sequence `woken → capturing → idle` for a captured utterance; plus a second scenario exercising the exact `lifecycle._notify_voice_output_state` production wiring around a real `OutputManager.handle_response()` call, asserting `speaking → idle` and that TTS actually received the text.
- Full test suite: 218 passed, same 12 pre-existing unrelated failures (`ollama` module / `LLM.__init__` signature mismatches) confirmed present before these changes too.
- `black`, `flake8 --select=E9,F63,F7,F82` clean on all changed files.

## Test plan

- [ ] Run the daemon with voice enabled; watch the GUI socket during "Hey Jarvis" → speaking → reply — confirm `woken → capturing → processing → speaking → idle` all arrive in order
- [ ] Trigger the silence-timeout discard path (say nothing after the wake word) — confirm the `idle` event carries `meta.reason == "discard"`
- [ ] Send a GUI/CLI text message — confirm `processing → speaking → idle` (or `→ idle` directly in text mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5

---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_