### PR TITLE
Add acoustic echo cancellation to prevent mic from hearing JARVIS's own TTS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ set it > 0 to restore auto-deny for unattended/headless setups.
 | `jarvis-ai` | Core daemon (text I/O, LLM, dispatch) |
 | `jarvis-ai[tui]` | Textual TUI (`jarvis tui`) |
 | `jarvis-ai[voice]` | Vosk STT + Piper TTS |
+| `jarvis-ai[voice-aec]` | Voice + acoustic echo cancellation (native-compiled, barge-in fix) |
 | `jarvis-ai[dev]` | pytest, black, isort, flake8, mypy, pre-commit |
 | `jarvis-ai[all]` | Everything above |
 
@@ -166,6 +167,7 @@ make check                  # Format + lint + typecheck + tests
 | `jarvis/core/voice_state.py` | `VoiceState` — formal voice/response session state machine |
 | `jarvis/voice/chime.py` | Wake-word earcon: path validation + best-effort playback |
 | `jarvis/voice/audio.py` | Audio device detection + `passes_noise_gate` RMS filter |
+| `jarvis/voice/aec/webrtc_aec.py` | `WebRtcAEC` — acoustic echo cancellation (barge-in fix, #143) |
 | `jarvis/dispatch/adapter.py` | Python wrapper for Rust dispatch binary |
 | `jarvis/dispatch/discovery.py` | Embedding search via dmcp vector index |
 | `jarvis/dispatch/dmcp_registry.py` | dmcp CLI wrappers (install, tools, config) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,11 +165,12 @@ Built on [Textual](https://textual.textualize.io/). All platform-agnostic.
 |------|------|
 | `manager.py` | `VoiceManager` — coordinates STT, TTS, wake-word detection |
 | `audio.py` | Shared audio device init (PyAudio / sounddevice) |
-| `base.py` | `BaseSTT`, `BaseTTS` ABCs |
+| `base.py` | `STTProvider`, `TTSProvider`, `ActivationProvider`, `EchoCanceller` ABCs |
 | `chime.py` | Wake-word earcon: path validation + best-effort playback |
 | `stt/` | Vosk STT provider |
 | `tts/` | Piper TTS provider |
 | `activation/` | Wake-word detection (Vosk-based) |
+| `aec/` | Acoustic echo cancellation provider (WebRTC-backed) |
 
 Voice runs in a background thread (`voice_activation_thread.py` in `runtime/`). When a wake word fires: the daemon unconditionally broadcasts `{"type": "wake_word_detected"}` over the GUI socket, transitions to `VoiceState.WOKEN`, plays the wake chime (blocking — see below), then opens the STT capture window and injects a `VOICE_INPUT` event into `EventMerger` once an utterance completes. If the user says nothing within `VOICE_ACTIVATION_TIMEOUT` seconds, capture is abandoned and control returns to wake-word mode without processing anything; the timeout is disabled the moment speech is detected, so mid-sentence pauses never cut a command off early.
 
@@ -177,7 +178,7 @@ Voice runs in a background thread (`voice_activation_thread.py` in `runtime/`). 
 
 Wake-word listening restarts the moment capture ends — not after the full LLM/dispatch/TTS turn — in both the daemon path (`voice_activation_thread.py`) and the standalone `VoiceManager` path (`manager.py`). Saying "Hey Jarvis, do B" while A is still being worked on captures and queues B via `EventMerger`. Since #154, B doesn't wait for A's entire turn to conclude — each queued input is dispatched as its own task (see "Concurrent goal execution" above), so B gets a real LLM turn (and `GoalManager.add_goal()` creates a second concurrent root goal) as soon as the LLM is free, typically while A is still mid-dispatch waiting on its own tools. Goal A's task results arrive later as dispatch signals and interleave back into the same queue. When new input arrives while goals are already active, the PROCESSING broadcast carries `meta: {"concurrent_goals": N}`.
 
-A wake word detected **while TTS is speaking** barges in: the voice thread calls `OutputManager.stop_speaking()`, which sets a stop flag checked between synthesis chunks in `PiperTTS.say()` (`stream.abort()` discards already-buffered audio), then the WOKEN broadcast carries `meta: {"barge_in": true}` and capture proceeds normally. Known risk: the mic is live during TTS, so JARVIS can hear its own voice — acoustic echo cancellation is the real fix, tracked separately (#143).
+A wake word detected **while TTS is speaking** barges in: the voice thread calls `OutputManager.stop_speaking()`, which sets a stop flag checked between synthesis chunks in `PiperTTS.say()` (`stream.abort()` discards already-buffered audio), then the WOKEN broadcast carries `meta: {"barge_in": true}` and capture proceeds normally. The mic is live during TTS, so JARVIS can hear its own voice (including its own wake word) — acoustic echo cancellation (below) is the fix.
 
 Config: `WAKE_WORDS`, `VOICE_ACTIVATION_SENSITIVITY`, `VOICE_ACTIVATION_TIMEOUT`, `WAKE_CHIME_PATH`, `NOISE_GATE_RMS_THRESHOLD`, `VOSK_MODEL_PATH`, `TTS_MODEL_ONNX`/`TTS_MODEL_JSON` — all in `~/.config/jarvis/jarvis.conf`.
 
@@ -188,6 +189,50 @@ Raw int16 PCM chunks are RMS-gated in both `VoskSTT` (`stt/vosk_stt.py`) and `Vo
 Wake-word matching (`VoskActivation._check_for_wake_word`) only runs on Vosk's *finalized* results now — partial hypotheses (Vosk's least reliable output) are never checked, removing a source of false-positive wake triggers.
 
 `VoskSTT`'s `phrase_timeout` parameter was removed — it was accepted by the constructor and set by `component_factory.py`, but never actually read anywhere in `_process_loop`; only `silence_timeout` (pause-based endpointing) was ever wired up.
+
+### Acoustic echo cancellation (`jarvis/voice/aec/`, Project-JARVIS#143)
+
+`WebRtcAEC` (`aec/webrtc_aec.py`) wraps `aec-audio-processing`, which vendors
+freedesktop.org's `webrtc-audio-processing` — the same AEC engine behind
+PipeWire's own `module-echo-cancel` — via a SWIG binding, rather than a
+bespoke DSP filter. It's an optional native-compiled extra
+(`project-jarvis[voice-aec]`), gated by `AEC_ENABLED` (default `false`).
+
+`ComponentFactory.create_echo_canceller_optional()` builds one shared
+instance (matching the TTS provider's own sample rate for the reference
+signal) after TTS is constructed, and hands it to `PiperTTS` (as
+`echo_canceller`, feeding `feed_reference()` with every synthesized chunk)
+and to `VoskSTT`/`VoskActivation` (as `echo_canceller`, calling `process()`
+on the raw mic chunk before the noise gate in `_process_loop`/`_listen_loop`).
+A single instance must be shared across all three — the mic-side cancellation
+and the TTS-side reference feed only make sense against the same adaptive
+filter state. A failure in `process()`/`feed_reference()` is caught and
+logged, falling back to raw audio — AEC is a quality improvement, not a
+dependency STT/TTS should ever break on.
+
+Two non-obvious constraints, found only by exercising the library, not from
+its docs:
+
+- `aec-audio-processing`'s `process_reverse_stream` computes frame size from
+  the *forward* stream's configured rate regardless of what
+  `set_reverse_stream_format` declares (confirmed by reading its C++ source).
+  `WebRtcAEC` therefore always frames both streams at `sample_rate` (16kHz,
+  matching Vosk) and resamples the TTS reference down from its own rate
+  before framing, rather than trusting the reverse-rate field to do it.
+- WebRTC's internal echo-path tracking needs forward/reverse `process_stream`/
+  `process_reverse_stream` calls interleaved roughly one-for-one. Buffering
+  each side's producer chunks (VoskSTT's 250ms mic callbacks; Piper's
+  independently-sized TTS chunks) and draining each side's queue in an
+  uninterrupted burst measured ~6dB attenuation on synthetic echo — buffering
+  both sides and draining one matched frame pair at a time (`_drain_locked`)
+  recovered ~30-50dB, matching true lockstep. See
+  `tests/test_echo_cancellation.py` for the measurements.
+
+`AEC_STREAM_DELAY_MS` (expected speaker → air → mic round-trip delay) is the
+single most sensitive tuning parameter — a value far from the real acoustic
+path measurably degrades cancellation even with correct interleaving, and
+there's no universally-correct default; it needs empirical measurement per
+device.
 
 ### Wake chime (`jarvis/voice/chime.py`)
 

--- a/jarvis/.env.example
+++ b/jarvis/.env.example
@@ -82,6 +82,21 @@ VOICE_ACTIVATION_TIMEOUT=4.0
 NOISE_GATE_RMS_THRESHOLD=150
 
 # ===========================================
+# Acoustic Echo Cancellation (AEC)
+# ===========================================
+# Prevents the mic from picking up JARVIS's own TTS output (including its
+# own wake word, "Jarvis") during barge-in. Requires the optional
+# `project-jarvis[voice-aec]` extra (native-compiled, needs a C++ toolchain).
+# false (default): AEC disabled -- no effect if the extra isn't installed.
+AEC_ENABLED=false
+
+# Expected speaker -> air -> mic round-trip delay in milliseconds. This is
+# the single most sensitive AEC tuning parameter -- measure it for your own
+# hardware rather than trusting the default; a delay far from the real
+# acoustic path measurably degrades cancellation.
+AEC_STREAM_DELAY_MS=80
+
+# ===========================================
 # CLI Output Mode Configuration
 # ===========================================
 # Output mode for CLI: "text" or "voice"

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -94,6 +94,18 @@ class Config:
     # noise sits well under 150; normal speech is usually 1000+.
     NOISE_GATE_RMS_THRESHOLD = int(os.getenv("NOISE_GATE_RMS_THRESHOLD", "150"))
 
+    # Acoustic echo cancellation (Project-JARVIS#143) -- prevents the mic
+    # from picking up JARVIS's own TTS output (esp. its own wake word) during
+    # barge-in. Off by default: it's a native-compiled optional extra
+    # (`project-jarvis[voice-aec]`) and only matters when the user actually
+    # talks over JARVIS's replies.
+    AEC_ENABLED = os.getenv("AEC_ENABLED", "false").lower() == "true"
+    # Expected speaker -> air -> mic round-trip delay in milliseconds. The
+    # single most sensitive AEC tuning parameter -- a delay far from the real
+    # acoustic path measurably degrades cancellation. Needs empirical
+    # measurement per device; there is no universal correct default.
+    AEC_STREAM_DELAY_MS = int(os.getenv("AEC_STREAM_DELAY_MS", "80"))
+
     # CLI Output Mode Configuration
     OUTPUT_MODE = os.getenv("OUTPUT_MODE", "voice")  # voice or text
 

--- a/jarvis/core/component_factory.py
+++ b/jarvis/core/component_factory.py
@@ -221,6 +221,43 @@ class ComponentFactory:
             return None
 
     @staticmethod
+    def create_echo_canceller_optional(tts: Optional[any]) -> Optional[any]:
+        """
+        Create the shared acoustic echo canceller (AEC) if enabled and available.
+
+        Requires an active TTS provider -- it supplies the far-end reference
+        signal, and with no TTS there is nothing for the mic to echo. The
+        returned instance must be shared between the TTS output path and
+        every mic-reading STT/activation provider: they need to agree on
+        what "JARVIS's own voice" sounds like right now (Project-JARVIS#143).
+        """
+        if not Config.AEC_ENABLED:
+            return None
+        if tts is None:
+            logger.debug("AEC disabled: no TTS provider active (nothing to echo)")
+            return None
+
+        try:
+            from ..voice.aec import create_echo_canceller
+        except ImportError as e:
+            logger.warning(f"AEC dependencies not available: {e}")
+            return None
+
+        try:
+            logger.info("Initiating acoustic echo canceller (webrtc)...")
+            aec = create_echo_canceller(
+                provider="webrtc",
+                sample_rate=16000,
+                reference_sample_rate=getattr(tts, "sample_rate", 22050),
+                stream_delay_ms=Config.AEC_STREAM_DELAY_MS,
+            )
+            logger.info("Echo canceller initialized successfully")
+            return aec
+        except Exception as e:
+            logger.warning(f"Failed to initialize echo canceller (non-fatal): {e}")
+            return None
+
+    @staticmethod
     def create_output_manager(
         tts: Optional[any] = None,
         suppress_stdout: bool = False,
@@ -234,7 +271,9 @@ class ComponentFactory:
         return OutputManager(tts, suppress_stdout=suppress_stdout)
 
     @staticmethod
-    def create_voice_manager_optional(on_command) -> Optional[any]:
+    def create_voice_manager_optional(
+        on_command, echo_canceller: Optional[any] = None
+    ) -> Optional[any]:
         """
         Create VoiceManager if voice input is enabled and audio is available.
 
@@ -243,6 +282,7 @@ class ComponentFactory:
 
         Args:
             on_command: Callback for voice commands.
+            echo_canceller: Optional shared AEC instance (Project-JARVIS#143).
 
         Returns:
             VoiceManager instance or None if unavailable.
@@ -272,6 +312,7 @@ class ComponentFactory:
                 chunk_size=4000,
                 silence_timeout=1.0,
                 noise_gate_threshold=Config.NOISE_GATE_RMS_THRESHOLD,
+                echo_canceller=echo_canceller,
             )
 
             activation = create_activation(
@@ -280,6 +321,7 @@ class ComponentFactory:
                 model_path=Config.VOSK_MODEL_PATH,
                 sensitivity=Config.VOICE_ACTIVATION_SENSITIVITY,
                 noise_gate_threshold=Config.NOISE_GATE_RMS_THRESHOLD,
+                echo_canceller=echo_canceller,
             )
 
             vm = VoiceManager(
@@ -386,6 +428,15 @@ class ComponentFactory:
         # TTS (optional - only if voice output enabled and available)
         components["tts"] = ComponentFactory.create_tts_optional()
 
+        # Shared echo canceller (Project-JARVIS#143) -- built after TTS so it
+        # can match the reference signal's sample rate, then handed to TTS
+        # (reference feed) and STT/activation (mic-side cancellation) alike.
+        components["echo_canceller"] = ComponentFactory.create_echo_canceller_optional(
+            components["tts"]
+        )
+        if components["echo_canceller"] is not None and components["tts"] is not None:
+            components["tts"].echo_canceller = components["echo_canceller"]
+
         # Dependent components
         components["output_manager"] = ComponentFactory.create_output_manager(
             components["tts"],
@@ -395,7 +446,9 @@ class ComponentFactory:
         # Voice input components (only if not in text mode and available)
         if not text_mode and on_voice_command:
             components["voice_manager"] = (
-                ComponentFactory.create_voice_manager_optional(on_voice_command)
+                ComponentFactory.create_voice_manager_optional(
+                    on_voice_command, echo_canceller=components["echo_canceller"]
+                )
             )
         else:
             components["voice_manager"] = None

--- a/jarvis/voice/activation/vosk_activation.py
+++ b/jarvis/voice/activation/vosk_activation.py
@@ -7,7 +7,7 @@ from typing import Callable, List, Optional
 
 from ...core.logger import get_logger
 from ..audio import passes_noise_gate
-from ..base import ActivationProvider
+from ..base import ActivationProvider, EchoCanceller
 
 logger = get_logger(__name__)
 
@@ -24,6 +24,7 @@ class VoskActivation(ActivationProvider):
         sensitivity: float = 0.8,
         noise_gate_threshold: int = 150,
         on_wake_word: Optional[Callable[[], None]] = None,
+        echo_canceller: Optional[EchoCanceller] = None,
     ):
         self.wake_words = [w.lower() for w in (wake_words or ["jarvis", "hey jarvis"])]
         self.model_path = model_path
@@ -32,6 +33,7 @@ class VoskActivation(ActivationProvider):
         self.sensitivity = sensitivity
         self.noise_gate_threshold = noise_gate_threshold
         self.on_wake_word = on_wake_word
+        self.echo_canceller = echo_canceller
 
         try:
             import json as _json
@@ -178,6 +180,14 @@ class VoskActivation(ActivationProvider):
                     data = self._audio_buffer.get(timeout=0.1)
                 except Empty:
                     continue
+
+                if self.echo_canceller is not None:
+                    try:
+                        data = self.echo_canceller.process(data)
+                    except Exception as e:
+                        logger.warning(
+                            f"Echo cancellation failed, using raw audio: {e}"
+                        )
 
                 if not passes_noise_gate(data, self.noise_gate_threshold):
                     continue

--- a/jarvis/voice/aec/__init__.py
+++ b/jarvis/voice/aec/__init__.py
@@ -1,0 +1,31 @@
+"""
+Acoustic echo canceller (AEC) provider sub-package.
+
+Use ``create_echo_canceller()`` to get the right provider by name.
+"""
+
+from ..base import EchoCanceller
+
+
+def create_echo_canceller(provider: str = "webrtc", **kwargs) -> EchoCanceller:
+    """Create an AEC provider instance.
+
+    Args:
+        provider: Provider name (currently ``"webrtc"``).
+        **kwargs: Passed through to the provider constructor
+                  (sample_rate, reference_sample_rate, etc.).
+
+    Returns:
+        An initialised EchoCanceller.
+
+    Raises:
+        ValueError: If the provider name is unknown.
+    """
+    if provider == "webrtc":
+        from .webrtc_aec import WebRtcAEC
+
+        return WebRtcAEC(**kwargs)
+    raise ValueError(f"Unknown AEC provider: '{provider}'. Available: webrtc")
+
+
+__all__ = ["EchoCanceller", "create_echo_canceller"]

--- a/jarvis/voice/aec/webrtc_aec.py
+++ b/jarvis/voice/aec/webrtc_aec.py
@@ -1,0 +1,143 @@
+"""WebRTC-based acoustic echo canceller (Project-JARVIS#143)."""
+
+import threading
+from typing import Optional
+
+from ...core.logger import get_logger
+from ..audio import AudioUnavailableError
+from ..base import EchoCanceller
+
+logger = get_logger(__name__)
+
+
+class WebRtcAEC(EchoCanceller):
+    """Acoustic echo cancellation backed by ``aec-audio-processing``.
+
+    That package vendors freedesktop.org's ``webrtc-audio-processing`` --
+    the same AEC engine PipeWire's own ``module-echo-cancel`` uses -- via a
+    SWIG binding, so this wraps a mature, field-tested implementation
+    rather than a bespoke DSP filter.
+
+    The underlying ``AudioProcessor`` always frames both the near-end (mic)
+    and far-end (reference) streams at 10ms using the *forward* stream's
+    sample rate, regardless of what rate ``set_reverse_stream_format``
+    declares (confirmed by reading the wrapper's C++ source -- its
+    ``process_reverse_stream`` computes frame size from the forward config).
+    Reference audio is therefore resampled to ``sample_rate`` before
+    framing, rather than relying on the reverse-rate field to do it.
+    """
+
+    def __init__(
+        self,
+        sample_rate: int = 16000,
+        reference_sample_rate: int = 22050,
+        stream_delay_ms: int = 80,
+    ):
+        try:
+            import numpy as np
+            from aec_audio_processing import AudioProcessor
+        except ImportError as e:
+            raise AudioUnavailableError(
+                "aec-audio-processing (and numpy) not installed. "
+                "Install with: pip install project-jarvis[voice-aec]"
+            ) from e
+
+        self._np = np
+        self.sample_rate = sample_rate
+        self.reference_sample_rate = reference_sample_rate
+        self.stream_delay_ms = stream_delay_ms
+        self._frame_bytes = 0
+        self._lock = threading.Lock()
+        self._mic_buf = bytearray()
+        self._ref_buf = bytearray()
+        self._out_buf = bytearray()
+        self._AudioProcessor = AudioProcessor
+        self._build_processor()
+
+    # -- EchoCanceller interface ------------------------------------------
+
+    def process(self, mic_frame: bytes) -> bytes:
+        if not mic_frame:
+            return b""
+        with self._lock:
+            self._mic_buf.extend(mic_frame)
+            self._drain_locked()
+            out = bytes(self._out_buf)
+            self._out_buf.clear()
+            return out
+
+    def feed_reference(self, reference_frame: bytes) -> None:
+        if not reference_frame:
+            return
+        resampled = self._resample(
+            reference_frame, self.reference_sample_rate, self.sample_rate
+        )
+        with self._lock:
+            self._ref_buf.extend(resampled)
+            self._drain_locked()
+
+    def reset(self) -> None:
+        with self._lock:
+            self._mic_buf.clear()
+            self._ref_buf.clear()
+            self._out_buf.clear()
+            self._build_processor()
+
+    # -- internals ----------------------------------------------------------
+
+    def _drain_locked(self) -> None:
+        """Push buffered whole frames through the underlying processor.
+
+        Must interleave forward/reverse calls roughly one-for-one --
+        draining an entire callback's worth of frames from one side in an
+        uninterrupted burst (e.g. 25 reverse calls back-to-back, then 25
+        forward calls) measurably breaks the internal echo-path tracking
+        (~30dB attenuation with 1:1 interleaving degrades to ~6dB with
+        bursts, on identical synthetic-echo input -- see
+        tests/test_echo_cancellation.py). Mic input producers (sounddevice
+        callbacks) and TTS reference chunks arrive as arbitrarily-sized,
+        independently-timed bursts, so this is what actually keeps calls
+        alternating regardless of caller chunk size.
+        """
+        frame_bytes = self._frame_bytes
+        while len(self._ref_buf) >= frame_bytes and len(self._mic_buf) >= frame_bytes:
+            ref_frame = bytes(self._ref_buf[:frame_bytes])
+            del self._ref_buf[:frame_bytes]
+            self._ap.process_reverse_stream(ref_frame)
+
+            mic_frame = bytes(self._mic_buf[:frame_bytes])
+            del self._mic_buf[:frame_bytes]
+            self._out_buf.extend(self._ap.process_stream(mic_frame))
+
+        # No reference data waiting (e.g. TTS isn't playing) -- still push
+        # mic audio through rather than holding it hostage to a reverse
+        # stream that may never arrive.
+        while len(self._mic_buf) >= frame_bytes:
+            mic_frame = bytes(self._mic_buf[:frame_bytes])
+            del self._mic_buf[:frame_bytes]
+            self._out_buf.extend(self._ap.process_stream(mic_frame))
+
+    def _build_processor(self) -> None:
+        self._ap = self._AudioProcessor(
+            enable_aec=True, enable_ns=False, enable_agc=False, enable_vad=False
+        )
+        self._ap.set_stream_format(sample_rate_in=self.sample_rate, channel_count_in=1)
+        self._ap.set_reverse_stream_format(
+            sample_rate_in=self.sample_rate, channel_count_in=1
+        )
+        self._ap.set_stream_delay(self.stream_delay_ms)
+        self._frame_bytes = self._ap.get_frame_size() * 2  # int16 mono
+
+    def _resample(self, pcm_bytes: bytes, from_rate: int, to_rate: Optional[int]):
+        if from_rate == to_rate or not pcm_bytes:
+            return pcm_bytes
+        np = self._np
+        data = np.frombuffer(pcm_bytes, dtype=np.int16).astype(np.float64)
+        if len(data) == 0:
+            return b""
+        duration = len(data) / from_rate
+        n_out = max(1, int(round(duration * to_rate)))
+        x_old = np.linspace(0, duration, num=len(data), endpoint=False)
+        x_new = np.linspace(0, duration, num=n_out, endpoint=False)
+        resampled = np.interp(x_new, x_old, data)
+        return np.clip(resampled, -32768, 32767).astype(np.int16).tobytes()

--- a/jarvis/voice/base.py
+++ b/jarvis/voice/base.py
@@ -73,6 +73,39 @@ class TTSProvider(ABC):
         """
 
 
+class EchoCanceller(ABC):
+    """Abstract acoustic echo canceller (AEC).
+
+    Removes JARVIS's own TTS output from the live microphone signal so
+    the wake word ("Jarvis" -- the assistant's own name) and STT don't
+    mistake JARVIS's own voice for user speech during barge-in
+    (Project-JARVIS#143). Implementations see two independent int16 mono
+    PCM streams -- the near-end microphone and the far-end reference
+    (JARVIS's own TTS output) -- and must keep them aligned internally.
+    """
+
+    @abstractmethod
+    def process(self, mic_frame: bytes) -> bytes:
+        """Return an echo-cancelled copy of a near-end (mic) chunk.
+
+        ``mic_frame`` may be any length; implementations that require
+        fixed-size internal frames buffer partial input and may return
+        fewer bytes than they were given, catching up on the next call.
+        """
+
+    @abstractmethod
+    def feed_reference(self, reference_frame: bytes) -> None:
+        """Feed a chunk of far-end audio (JARVIS's own TTS output) as it plays.
+
+        Must be called from the TTS output path in real time -- the AEC
+        needs this to know what echo to expect on the mic.
+        """
+
+    @abstractmethod
+    def reset(self) -> None:
+        """Clear internal adaptive-filter/buffer state, e.g. between turns."""
+
+
 class ActivationProvider(ABC):
     """Abstract wake-word / activation provider.
 

--- a/jarvis/voice/stt/vosk_stt.py
+++ b/jarvis/voice/stt/vosk_stt.py
@@ -12,7 +12,7 @@ from ..audio import (
     check_audio_input_available,
     passes_noise_gate,
 )
-from ..base import STTProvider
+from ..base import EchoCanceller, STTProvider
 
 logger = get_logger(__name__)
 
@@ -39,6 +39,7 @@ class VoskSTT(STTProvider):
         silence_timeout: float = 1.0,
         noise_gate_threshold: int = 150,
         device_index: Optional[int] = None,
+        echo_canceller: Optional[EchoCanceller] = None,
     ):
         try:
             import sounddevice as sd
@@ -69,6 +70,7 @@ class VoskSTT(STTProvider):
         self.silence_timeout = silence_timeout
         self.noise_gate_threshold = noise_gate_threshold
         self.device_index = device_index
+        self.echo_canceller = echo_canceller
 
         self._result_q: Queue[Tuple[str, bool]] = Queue()
         self._model: Optional[Any] = None
@@ -217,6 +219,14 @@ class VoskSTT(STTProvider):
                     data = self._audio_buffer.get(timeout=0.1)
                 except Empty:
                     continue
+
+                if self.echo_canceller is not None:
+                    try:
+                        data = self.echo_canceller.process(data)
+                    except Exception as e:
+                        logger.warning(
+                            f"Echo cancellation failed, using raw audio: {e}"
+                        )
 
                 if not passes_noise_gate(data, self.noise_gate_threshold):
                     continue

--- a/jarvis/voice/tts/piper_tts.py
+++ b/jarvis/voice/tts/piper_tts.py
@@ -1,6 +1,7 @@
 """Piper-based text-to-speech provider."""
 
 import threading
+from typing import Optional
 
 from ...core.logger import get_logger
 from ..audio import (
@@ -8,7 +9,7 @@ from ..audio import (
     check_audio_output_available,
     get_default_output_device,
 )
-from ..base import TTSProvider
+from ..base import EchoCanceller, TTSProvider
 
 logger = get_logger(__name__)
 
@@ -16,11 +17,19 @@ logger = get_logger(__name__)
 class PiperTTS(TTSProvider):
     """Offline text-to-speech using Piper (ONNX)."""
 
-    def __init__(self, model_path: str, config_path: str):
+    def __init__(
+        self,
+        model_path: str,
+        config_path: str,
+        echo_canceller: Optional[EchoCanceller] = None,
+    ):
         """
         Args:
             model_path: Path to Piper TTS ONNX model file.
             config_path: Path to Piper TTS JSON config file.
+            echo_canceller: Optional AEC fed this provider's own output as
+                the far-end reference signal, so the mic doesn't pick up
+                JARVIS's own voice during barge-in (Project-JARVIS#143).
 
         Raises:
             AudioUnavailableError: If audio packages or devices unavailable.
@@ -67,6 +76,8 @@ class PiperTTS(TTSProvider):
             logger.warning("No default output device found, using system default")
             self.device_index = self.sd.default.device[1]
 
+        self.sample_rate = self.tts.config.sample_rate
+        self.echo_canceller = echo_canceller
         self._stop_requested = threading.Event()
 
     # -- TTSProvider interface ------------------------------------------------
@@ -77,9 +88,8 @@ class PiperTTS(TTSProvider):
 
         self._stop_requested.clear()
         try:
-            sr = self.tts.config.sample_rate
             with self.sd.RawOutputStream(
-                samplerate=sr,
+                samplerate=self.sample_rate,
                 channels=1,
                 dtype="int16",
                 device=self.device_index,
@@ -90,6 +100,11 @@ class PiperTTS(TTSProvider):
                         logger.info("TTS playback interrupted (barge-in)")
                         stream.abort()
                         return
+                    if self.echo_canceller is not None:
+                        try:
+                            self.echo_canceller.feed_reference(chunk.audio_int16_bytes)
+                        except Exception as e:
+                            logger.warning(f"Echo reference feed failed: {e}")
                     stream.write(chunk.audio_int16_bytes)
         except Exception as e:
             logger.error(f"Error during TTS synthesis: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,15 @@ voice = [
     "numpy>=2.2.0",
 ]
 
+# Acoustic echo cancellation (Project-JARVIS#143) -- prevents the mic from
+# picking up JARVIS's own TTS output (esp. its own wake word) during
+# barge-in. Native-compiled (needs a C++ toolchain); pulls in `voice` since
+# it needs both the mic path and the TTS reference signal.
+voice-aec = [
+    "project-jarvis[voice]",
+    "aec-audio-processing>=1.0.1",
+]
+
 # Interactive terminal UI (OpenClaw-style chat with session sidebar).
 # Launch with `jarvis tui`.
 tui = [
@@ -94,7 +103,7 @@ docs = [
 # Everything - convenience group
 all = [
     "project-jarvis[tui]",
-    "project-jarvis[voice]",
+    "project-jarvis[voice-aec]",
     "project-jarvis[dev]",
     "project-jarvis[docs]",
 ]

--- a/tests/test_echo_cancellation.py
+++ b/tests/test_echo_cancellation.py
@@ -1,24 +1,43 @@
 """Tests for acoustic echo cancellation (Project-JARVIS#143).
 
-WebRtcAEC is exercised for real (aec-audio-processing + numpy are already
-installed here) with synthetic echo signals -- not mocked -- since that's
-the only way to actually prove cancellation happens rather than merely that
-methods were called. VoskSTT/VoskActivation/PiperTTS wiring is exercised
-against real instances driven by injected fake vosk/sounddevice/piper
-modules, matching this codebase's established pattern (tests/test_noise_gate.py,
+WebRtcAEC is exercised for real (where numpy + aec-audio-processing --
+the native-compiled `voice-aec` extra -- are installed) with synthetic
+echo signals, not mocked, since that's the only way to actually prove
+cancellation happens rather than merely that methods were called. CI's
+"Test suite" job installs only `.[dev]`, so tests needing the real native
+engine are skipped there via `requires_aec_native`; a dev environment with
+`.[voice-aec]` installed runs them for real. VoskSTT/VoskActivation/PiperTTS
+wiring needs neither and always runs, exercised against real instances
+driven by injected fake vosk/sounddevice/piper modules, matching this
+codebase's established pattern (tests/test_noise_gate.py,
 tests/test_concurrent_goals_barge_in.py).
 """
+
+from __future__ import annotations
 
 import sys
 import types
 from unittest.mock import MagicMock, Mock, patch
 
-import numpy as np
 import pytest
 
 from jarvis.voice.aec import create_echo_canceller
 from jarvis.voice.aec.webrtc_aec import WebRtcAEC
 from jarvis.voice.base import EchoCanceller
+
+try:
+    import aec_audio_processing  # noqa: F401
+    import numpy as np
+
+    _AEC_NATIVE_AVAILABLE = True
+except ImportError:
+    np = None
+    _AEC_NATIVE_AVAILABLE = False
+
+requires_aec_native = pytest.mark.skipif(
+    not _AEC_NATIVE_AVAILABLE,
+    reason="numpy/aec-audio-processing not installed (voice-aec extra)",
+)
 
 
 def _tone(freq: float, duration_s: float, sample_rate: int, amplitude: float = 0.5):
@@ -39,6 +58,7 @@ def _energy(samples: np.ndarray) -> float:
 
 @pytest.mark.unit
 class TestCreateEchoCanceller:
+    @requires_aec_native
     def test_webrtc_provider_returns_webrtc_aec(self):
         aec = create_echo_canceller(provider="webrtc")
         assert isinstance(aec, WebRtcAEC)
@@ -50,6 +70,7 @@ class TestCreateEchoCanceller:
 
 
 @pytest.mark.unit
+@requires_aec_native
 class TestWebRtcAecRealCancellation:
     """Real end-to-end proof: synthetic echo goes in, attenuated signal
     comes out. No mocking of the DSP itself -- this is the actual
@@ -412,6 +433,7 @@ class TestComponentFactoryEchoCanceller:
         with patch.object(cf.Config, "AEC_ENABLED", True):
             assert cf.ComponentFactory.create_echo_canceller_optional(None) is None
 
+    @requires_aec_native
     def test_enabled_with_tts_builds_webrtc_aec_matching_tts_sample_rate(self):
         from jarvis.core import component_factory as cf
 

--- a/tests/test_echo_cancellation.py
+++ b/tests/test_echo_cancellation.py
@@ -1,0 +1,466 @@
+"""Tests for acoustic echo cancellation (Project-JARVIS#143).
+
+WebRtcAEC is exercised for real (aec-audio-processing + numpy are already
+installed here) with synthetic echo signals -- not mocked -- since that's
+the only way to actually prove cancellation happens rather than merely that
+methods were called. VoskSTT/VoskActivation/PiperTTS wiring is exercised
+against real instances driven by injected fake vosk/sounddevice/piper
+modules, matching this codebase's established pattern (tests/test_noise_gate.py,
+tests/test_concurrent_goals_barge_in.py).
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock, Mock, patch
+
+import numpy as np
+import pytest
+
+from jarvis.voice.aec import create_echo_canceller
+from jarvis.voice.aec.webrtc_aec import WebRtcAEC
+from jarvis.voice.base import EchoCanceller
+
+
+def _tone(freq: float, duration_s: float, sample_rate: int, amplitude: float = 0.5):
+    n = int(sample_rate * duration_s)
+    t = np.arange(n) / sample_rate
+    return (amplitude * 32767 * np.sin(2 * np.pi * freq * t)).astype(np.int16)
+
+
+def _simulate_echo(far: np.ndarray, delay_samples: int, attenuation: float = 0.6):
+    echo = np.zeros(len(far), dtype=np.float64)
+    echo[delay_samples:] = attenuation * far[:-delay_samples].astype(np.float64)
+    return echo.astype(np.int16)
+
+
+def _energy(samples: np.ndarray) -> float:
+    return float(np.sum(samples.astype(np.float64) ** 2))
+
+
+@pytest.mark.unit
+class TestCreateEchoCanceller:
+    def test_webrtc_provider_returns_webrtc_aec(self):
+        aec = create_echo_canceller(provider="webrtc")
+        assert isinstance(aec, WebRtcAEC)
+        assert isinstance(aec, EchoCanceller)
+
+    def test_unknown_provider_raises(self):
+        with pytest.raises(ValueError, match="Unknown AEC provider"):
+            create_echo_canceller(provider="nonexistent")
+
+
+@pytest.mark.unit
+class TestWebRtcAecRealCancellation:
+    """Real end-to-end proof: synthetic echo goes in, attenuated signal
+    comes out. No mocking of the DSP itself -- this is the actual
+    webrtc-audio-processing engine (via aec-audio-processing)."""
+
+    def test_lockstep_10ms_frames_cancel_echo(self):
+        aec = WebRtcAEC(
+            sample_rate=16000, reference_sample_rate=16000, stream_delay_ms=10
+        )
+        sr = 16000
+        far = _tone(440, 1.0, sr)
+        mic = _simulate_echo(far, delay_samples=160)
+
+        frame_len = 160  # 10ms @ 16kHz
+        out = bytearray()
+        for i in range(len(mic) // frame_len):
+            far_frame = far[i * frame_len : (i + 1) * frame_len].tobytes()
+            mic_frame = mic[i * frame_len : (i + 1) * frame_len].tobytes()
+            aec.feed_reference(far_frame)
+            out.extend(aec.process(mic_frame))
+
+        out_arr = np.frombuffer(bytes(out), dtype=np.int16)
+        attenuation_db = 10 * np.log10(_energy(mic) / max(_energy(out_arr), 1e-9))
+        assert attenuation_db > 20, f"only {attenuation_db:.1f}dB attenuation"
+
+    def test_realistic_mismatched_chunk_sizes_still_cancel_echo(self):
+        """Mirrors real deployment: VoskSTT delivers fixed 250ms (4000-sample)
+        mic callbacks; Piper's TTS reference arrives as independently-sized,
+        differently-rated chunks. An earlier "buffer and drain each side in
+        isolation" design measured only ~6dB attenuation here (vs ~30dB+ in
+        lockstep) because WebRTC's echo-path tracking needs forward/reverse
+        calls interleaved roughly 1:1 -- this proves the fix holds under the
+        conditions that actually break it."""
+        aec = WebRtcAEC(
+            sample_rate=16000, reference_sample_rate=22050, stream_delay_ms=10
+        )
+        sr, ref_sr = 16000, 22050
+        far16 = _tone(440, 1.0, sr)
+        far_ref = _tone(440, 1.0, ref_sr)
+        mic = _simulate_echo(far16, delay_samples=160)
+
+        mic_chunk, ref_chunk = 4000, 2205  # deliberately misaligned, cross-rate
+        mic_bytes, ref_bytes = mic.tobytes(), far_ref.tobytes()
+
+        events = []
+        t_ms = 0.0
+        for i in range(0, len(mic_bytes), mic_chunk * 2):
+            events.append((t_ms, "mic", mic_bytes[i : i + mic_chunk * 2]))
+            t_ms += (mic_chunk / sr) * 1000
+        t_ms = 0.0
+        for i in range(0, len(ref_bytes), ref_chunk * 2):
+            events.append((t_ms, "ref", ref_bytes[i : i + ref_chunk * 2]))
+            t_ms += (ref_chunk / ref_sr) * 1000
+        events.sort(key=lambda e: (e[0], e[1] != "ref"))
+
+        out = bytearray()
+        for _, kind, chunk in events:
+            if kind == "ref":
+                aec.feed_reference(chunk)
+            else:
+                out.extend(aec.process(chunk))
+
+        out_arr = np.frombuffer(bytes(out), dtype=np.int16)
+        assert len(out_arr) == len(mic)
+        attenuation_db = 10 * np.log10(_energy(mic) / max(_energy(out_arr), 1e-9))
+        assert attenuation_db > 20, f"only {attenuation_db:.1f}dB attenuation"
+
+    def test_no_reference_signal_still_passes_mic_through(self):
+        """TTS isn't playing -- AEC must not withhold mic audio waiting for a
+        reverse stream that may never come."""
+        aec = WebRtcAEC(sample_rate=16000, reference_sample_rate=16000)
+        mic = np.random.randint(-3000, 3000, 4000, dtype=np.int16).tobytes()
+        out = aec.process(mic)
+        assert len(out) == len(mic)
+
+    def test_partial_frames_buffer_across_calls_without_crashing(self):
+        aec = WebRtcAEC(sample_rate=16000, reference_sample_rate=16000)
+        total = 0
+        for _ in range(50):
+            total += len(aec.process(b"\x01\x00" * 37))  # 37 samples, unaligned
+        assert total > 0
+        assert total % 320 == 0  # always whole 160-sample (320-byte) frames out
+
+    def test_reset_clears_state_without_raising(self):
+        aec = WebRtcAEC(sample_rate=16000, reference_sample_rate=16000)
+        aec.feed_reference(_tone(440, 0.1, 16000).tobytes())
+        aec.process(_tone(200, 0.1, 16000).tobytes())
+        aec.reset()  # must not raise
+        assert aec.process(_tone(200, 0.05, 16000).tobytes()) is not None
+
+
+def _fake_vosk_module():
+    fake = types.ModuleType("vosk")
+    fake.Model = Mock(return_value=Mock())
+    fake.KaldiRecognizer = Mock()
+    return fake
+
+
+def _fake_sounddevice_module():
+    fake = types.ModuleType("sounddevice")
+
+    class _Stream:
+        def __init__(self, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def close(self):
+            pass
+
+    fake.InputStream = _Stream
+    fake.query_devices = lambda: [
+        {"name": "fake-mic", "max_input_channels": 1, "max_output_channels": 1}
+    ]
+    fake.default = types.SimpleNamespace(device=[0, 0])
+    return fake
+
+
+@pytest.fixture
+def fake_audio_modules():
+    fake_vosk = _fake_vosk_module()
+    fake_sd = _fake_sounddevice_module()
+    with patch.dict(
+        sys.modules, {"vosk": fake_vosk, "sounddevice": fake_sd, "sd": fake_sd}
+    ):
+        yield fake_vosk, fake_sd
+
+
+class _StubEchoCanceller(EchoCanceller):
+    """Records every mic frame it's asked to process and returns a fixed,
+    recognisably-different payload -- proves the wiring actually routes
+    through the AEC rather than merely constructing one."""
+
+    def __init__(self):
+        self.processed = []
+        self.reference_fed = []
+
+    def process(self, mic_frame: bytes) -> bytes:
+        self.processed.append(mic_frame)
+        return b"CANCELLED" + mic_frame
+
+    def feed_reference(self, reference_frame: bytes) -> None:
+        self.reference_fed.append(reference_frame)
+
+    def reset(self) -> None:
+        pass
+
+
+class _RaisingEchoCanceller(EchoCanceller):
+    def process(self, mic_frame: bytes) -> bytes:
+        raise RuntimeError("boom")
+
+    def feed_reference(self, reference_frame: bytes) -> None:
+        raise RuntimeError("boom")
+
+    def reset(self) -> None:
+        pass
+
+
+@pytest.mark.unit
+class TestVoskSttEchoCancellerWiring:
+    def test_process_loop_applies_echo_canceller_before_recognizer(
+        self, fake_audio_modules
+    ):
+        from jarvis.voice.stt.vosk_stt import VoskSTT
+
+        aec = _StubEchoCanceller()
+        stt = VoskSTT(noise_gate_threshold=0, echo_canceller=aec)
+        recognizer = Mock()
+        recognizer.AcceptWaveform.return_value = False
+        recognizer.PartialResult.return_value = "{}"
+        stt._recognizer = recognizer
+        stt._running.set()
+
+        raw = b"\x10\x02" * 100
+        stt._audio_buffer.put(raw)
+
+        _run_loop_until_drained(stt._process_loop, stt._audio_buffer, stt._running)
+
+        assert aec.processed == [raw]
+        # the recognizer must see the AEC's *output*, not the raw mic bytes
+        recognizer.AcceptWaveform.assert_called_once_with(b"CANCELLED" + raw)
+
+    def test_echo_canceller_failure_falls_back_to_raw_audio(self, fake_audio_modules):
+        from jarvis.voice.stt.vosk_stt import VoskSTT
+
+        stt = VoskSTT(noise_gate_threshold=0, echo_canceller=_RaisingEchoCanceller())
+        recognizer = Mock()
+        recognizer.AcceptWaveform.return_value = False
+        recognizer.PartialResult.return_value = "{}"
+        stt._recognizer = recognizer
+        stt._running.set()
+
+        raw = b"\x10\x02" * 100
+        stt._audio_buffer.put(raw)
+
+        _run_loop_until_drained(stt._process_loop, stt._audio_buffer, stt._running)
+
+        recognizer.AcceptWaveform.assert_called_once_with(raw)
+
+    def test_no_echo_canceller_behaves_exactly_as_before(self, fake_audio_modules):
+        from jarvis.voice.stt.vosk_stt import VoskSTT
+
+        stt = VoskSTT(noise_gate_threshold=0)
+        recognizer = Mock()
+        recognizer.AcceptWaveform.return_value = False
+        recognizer.PartialResult.return_value = "{}"
+        stt._recognizer = recognizer
+        stt._running.set()
+
+        raw = b"\x10\x02" * 100
+        stt._audio_buffer.put(raw)
+
+        _run_loop_until_drained(stt._process_loop, stt._audio_buffer, stt._running)
+
+        recognizer.AcceptWaveform.assert_called_once_with(raw)
+
+
+@pytest.mark.unit
+class TestVoskActivationEchoCancellerWiring:
+    def test_listen_loop_applies_echo_canceller_before_recognizer(
+        self, fake_audio_modules
+    ):
+        from jarvis.voice.activation.vosk_activation import VoskActivation
+
+        aec = _StubEchoCanceller()
+        activation = VoskActivation(noise_gate_threshold=0, echo_canceller=aec)
+        recognizer = Mock()
+        recognizer.AcceptWaveform.return_value = False
+        activation._recognizer = recognizer
+        activation._running.set()
+
+        raw = b"\x10\x02" * 100
+        activation._audio_buffer.put(raw)
+
+        _run_loop_until_drained(
+            activation._listen_loop, activation._audio_buffer, activation._running
+        )
+
+        assert aec.processed == [raw]
+        recognizer.AcceptWaveform.assert_called_once_with(b"CANCELLED" + raw)
+
+    def test_echo_canceller_failure_falls_back_to_raw_audio(self, fake_audio_modules):
+        from jarvis.voice.activation.vosk_activation import VoskActivation
+
+        activation = VoskActivation(
+            noise_gate_threshold=0, echo_canceller=_RaisingEchoCanceller()
+        )
+        recognizer = Mock()
+        recognizer.AcceptWaveform.return_value = False
+        activation._recognizer = recognizer
+        activation._running.set()
+
+        raw = b"\x10\x02" * 100
+        activation._audio_buffer.put(raw)
+
+        _run_loop_until_drained(
+            activation._listen_loop, activation._audio_buffer, activation._running
+        )
+
+        recognizer.AcceptWaveform.assert_called_once_with(raw)
+
+
+@pytest.mark.unit
+class TestPiperTtsFeedsReferenceSignal:
+    def _make_piper(self, echo_canceller=None):
+        fake_sd = types.ModuleType("sounddevice")
+        stream = MagicMock()
+        stream.__enter__ = MagicMock(return_value=stream)
+        stream.__exit__ = MagicMock(return_value=False)
+        fake_sd.RawOutputStream = MagicMock(return_value=stream)
+        fake_sd.query_devices = lambda: [
+            {"name": "spk", "max_input_channels": 0, "max_output_channels": 2}
+        ]
+        fake_sd.default = types.SimpleNamespace(device=[0, 0])
+
+        fake_piper_voice = types.ModuleType("piper.voice")
+        fake_piper = types.ModuleType("piper")
+        voice = Mock()
+        voice.config.sample_rate = 22050
+        fake_piper_voice.PiperVoice = Mock(load=Mock(return_value=voice))
+        fake_piper.voice = fake_piper_voice
+
+        with patch.dict(
+            sys.modules,
+            {
+                "sounddevice": fake_sd,
+                "piper": fake_piper,
+                "piper.voice": fake_piper_voice,
+            },
+        ):
+            from jarvis.voice.tts.piper_tts import PiperTTS
+
+            tts = PiperTTS(
+                model_path="fake.onnx",
+                config_path="fake.json",
+                echo_canceller=echo_canceller,
+            )
+        return tts, voice, stream
+
+    @staticmethod
+    def _chunk(data=b"\x00\x00" * 100):
+        chunk = Mock()
+        chunk.audio_int16_bytes = data
+        return chunk
+
+    def test_sample_rate_exposed_for_component_factory_wiring(self):
+        tts, _, _ = self._make_piper()
+        assert tts.sample_rate == 22050
+
+    def test_each_synthesized_chunk_is_fed_as_reference(self):
+        aec = _StubEchoCanceller()
+        tts, voice, stream = self._make_piper(echo_canceller=aec)
+        chunks = [self._chunk(b"\x01\x00" * 10), self._chunk(b"\x02\x00" * 10)]
+        voice.synthesize.return_value = chunks
+
+        tts.say("hello world")
+
+        assert aec.reference_fed == [c.audio_int16_bytes for c in chunks]
+        assert stream.write.call_count == 2
+
+    def test_reference_feed_failure_does_not_interrupt_playback(self):
+        tts, voice, stream = self._make_piper(echo_canceller=_RaisingEchoCanceller())
+        voice.synthesize.return_value = [self._chunk(), self._chunk()]
+
+        tts.say("must keep playing")
+
+        assert stream.write.call_count == 2
+
+    def test_no_echo_canceller_behaves_exactly_as_before(self):
+        tts, voice, stream = self._make_piper(echo_canceller=None)
+        voice.synthesize.return_value = [self._chunk()]
+
+        tts.say("normal playback")
+
+        assert stream.write.call_count == 1
+
+
+@pytest.mark.unit
+class TestComponentFactoryEchoCanceller:
+    """Patches ``component_factory``'s own bound ``Config`` name (not a
+    freshly re-imported ``jarvis.config.Config``) -- ``test_config_direct.py``
+    does an ``importlib.reload(jarvis.config)`` elsewhere in the suite that
+    mints a second, distinct ``Config`` class object, so a fresh import here
+    can silently patch the wrong one depending on test run order."""
+
+    def test_disabled_by_config_returns_none(self):
+        from jarvis.core import component_factory as cf
+
+        with patch.object(cf.Config, "AEC_ENABLED", False):
+            assert cf.ComponentFactory.create_echo_canceller_optional(Mock()) is None
+
+    def test_no_tts_returns_none_even_when_enabled(self):
+        from jarvis.core import component_factory as cf
+
+        with patch.object(cf.Config, "AEC_ENABLED", True):
+            assert cf.ComponentFactory.create_echo_canceller_optional(None) is None
+
+    def test_enabled_with_tts_builds_webrtc_aec_matching_tts_sample_rate(self):
+        from jarvis.core import component_factory as cf
+
+        fake_tts = Mock()
+        fake_tts.sample_rate = 22050
+
+        with (
+            patch.object(cf.Config, "AEC_ENABLED", True),
+            patch.object(cf.Config, "AEC_STREAM_DELAY_MS", 42),
+        ):
+            aec = cf.ComponentFactory.create_echo_canceller_optional(fake_tts)
+
+        assert isinstance(aec, WebRtcAEC)
+        assert aec.sample_rate == 16000
+        assert aec.reference_sample_rate == 22050
+        assert aec.stream_delay_ms == 42
+
+    def test_missing_native_dependency_is_non_fatal(self):
+        """WebRtcAEC raises AudioUnavailableError when aec-audio-processing
+        isn't installed -- the factory must swallow it and return None
+        rather than take the whole daemon down."""
+        from jarvis.core import component_factory as cf
+        from jarvis.voice.audio import AudioUnavailableError
+
+        with (
+            patch.object(cf.Config, "AEC_ENABLED", True),
+            patch(
+                "jarvis.voice.aec.create_echo_canceller",
+                side_effect=AudioUnavailableError("aec-audio-processing not installed"),
+            ),
+        ):
+            assert cf.ComponentFactory.create_echo_canceller_optional(Mock()) is None
+
+
+def _run_loop_until_drained(loop_fn, buffer, running_flag, timeout=2.0):
+    """Run the real `loop_fn` (e.g. _process_loop/_listen_loop) in a
+    background thread against the pre-populated `buffer`, then stop it once
+    drained -- exercises the actual production loop, not a reimplementation."""
+    import threading
+    import time
+
+    thread = threading.Thread(target=loop_fn, daemon=True)
+    thread.start()
+
+    deadline = time.monotonic() + timeout
+    while not buffer.empty() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    time.sleep(0.05)  # let the last dequeued item finish processing
+
+    running_flag.clear()
+    thread.join(timeout=2.0)
+    assert not thread.is_alive(), "loop thread did not stop in time"


### PR DESCRIPTION
## What changed

- Add `EchoCanceller` ABC (`jarvis/voice/base.py`) alongside `STTProvider`/`TTSProvider`/`ActivationProvider`
- Add `WebRtcAEC` (`jarvis/voice/aec/webrtc_aec.py`), backed by `aec-audio-processing` — vendors freedesktop.org's `webrtc-audio-processing`, the same engine behind PipeWire's own `module-echo-cancel`
- Wire a single shared instance into `PiperTTS` (feeds its own output as the far-end reference) and `VoskSTT`/`VoskActivation` (cancels that reference out of the mic signal before the noise gate/recognizer)
- `ComponentFactory.create_echo_canceller_optional()` builds the shared instance after TTS, matching its sample rate; gated behind `AEC_ENABLED` (default `false`) and a new native-compiled `voice-aec` extra

## Why this change

Closes #143. Since #142's barge-in support, the mic stays live while JARVIS is speaking — but JARVIS's own wake word is literally its own name, so without cancellation it can hear (and react to) itself. This wires in acoustic echo cancellation so the mic only reacts to the user's actual voice.

Two integration details only surfaced from exercising the library with real synthetic-echo signals, not from its documentation:
- `aec-audio-processing`'s `process_reverse_stream` frames both streams at the *forward* stream's configured rate regardless of what the reverse-rate field declares (confirmed by reading its C++ source) — `WebRtcAEC` resamples the TTS reference to match rather than trusting that field.
- WebRTC's internal echo-path tracking needs forward/reverse calls interleaved roughly 1:1. Draining each side's buffered frames in an uninterrupted burst (matching how VoskSTT's 250ms mic callbacks and Piper's independently-sized TTS chunks actually arrive) measured only ~6dB attenuation on synthetic echo; interleaving one matched frame pair at a time recovered ~30-50dB, matching true lockstep. Both findings are captured as regression tests.

## Type of change

- [x] New feature
- [x] Tests only (test coverage for the new module)

## Test plan

- [x] Unit tests
- [x] Manual validation (synthetic-echo measurements against the real `aec-audio-processing` engine, not mocked)

Commands run:

```bash
python3 -m pytest tests/ -q -m unit   # 119 passed, 1 skipped (pre-existing)
python3 -m black --check .
python3 -m isort --check-only .
python3 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude .venv
```

## Checklist

- [x] I added or updated tests for behavior changes
- [x] I updated documentation where needed (`docs/architecture.md`, `CLAUDE.md`, `.env.example`)
- [x] I did not include secrets or sensitive data
- [x] I verified there are no unrelated changes in this PR

## Risk and rollout notes

Off by default (`AEC_ENABLED=false`) and behind a new optional `voice-aec` extra (native-compiled, needs a C++ toolchain) — zero impact on existing installs until explicitly enabled. `process()`/`feed_reference()` failures are caught and fall back to raw audio, so a misbehaving AEC can degrade cancellation quality but cannot break STT/TTS. The main remaining tuning risk for real deployments is `AEC_STREAM_DELAY_MS` (expected speaker→air→mic round-trip delay), which needs empirical measurement per device — documented in `docs/architecture.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_