### PR TITLE
Expose settings + provider CRUD over the GUI socket for jarvisos-app#12

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,8 @@ make check                  # Format + lint + typecheck + tests
 | `jarvis/voice/chime.py` | Wake-word earcon: path validation + best-effort playback |
 | `jarvis/voice/audio.py` | Audio device detection + `passes_noise_gate` RMS filter |
 | `jarvis/voice/aec/webrtc_aec.py` | `WebRtcAEC` — acoustic echo cancellation (barge-in fix, #143) |
+| `jarvis/runtime/io.py` | Input/GUI/output sockets — confirmation queries, session CRUD, settings + provider CRUD |
+| `jarvis/core/providers.py` | Provider pool CRUD (`providers.json`), shared by CLI, TUI, and the GUI socket |
 | `jarvis/dispatch/adapter.py` | Python wrapper for Rust dispatch binary |
 | `jarvis/dispatch/discovery.py` | Embedding search via dmcp vector index |
 | `jarvis/dispatch/dmcp_registry.py` | dmcp CLI wrappers (install, tools, config) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,6 +242,8 @@ A short, pre-rendered earcon (not TTS) plays the instant a wake word fires, so a
 
 `WAKE_CHIME_PATH` is writable by any connected GUI-socket client via a single-purpose `{"type": "set_wake_chime_path", "path": "..."}` message (`jarvis.runtime.io._handle_set_wake_chime_path`) — validated the same way, persisted via the same `.env`/`jarvis.conf` write path the TUI settings modal and provider config already use, and broadcasts `{"type": "config_updated", "key": "WAKE_CHIME_PATH", "value": "..."}` to every connected client on success (or `{"type": "config_error", ...}` to the requester only on failure). This is deliberately a single dedicated message, not a generic "set any config key" — a generic writer over an unauthenticated local socket would let any connected client silently rewrite security-relevant settings like `CONFIRMATION_MODE`.
 
+`{"type": "reset_wake_chime_path"}` restores `WAKE_CHIME_PATH` to `Config.DEFAULT_WAKE_CHIME_PATH` (the bundled two-tone WAV) — the settings-panel counterpart to a custom-path write, for a "restore default" action.
+
 ### GUI socket settings + provider CRUD (jarvisos-app#12)
 
 `jarvis/runtime/io.py` exposes the same settings surface the TUI's config

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,6 +242,18 @@ A short, pre-rendered earcon (not TTS) plays the instant a wake word fires, so a
 
 `WAKE_CHIME_PATH` is writable by any connected GUI-socket client via a single-purpose `{"type": "set_wake_chime_path", "path": "..."}` message (`jarvis.runtime.io._handle_set_wake_chime_path`) — validated the same way, persisted via the same `.env`/`jarvis.conf` write path the TUI settings modal and provider config already use, and broadcasts `{"type": "config_updated", "key": "WAKE_CHIME_PATH", "value": "..."}` to every connected client on success (or `{"type": "config_error", ...}` to the requester only on failure). This is deliberately a single dedicated message, not a generic "set any config key" — a generic writer over an unauthenticated local socket would let any connected client silently rewrite security-relevant settings like `CONFIRMATION_MODE`.
 
+### GUI socket settings + provider CRUD (jarvisos-app#12)
+
+`jarvis/runtime/io.py` exposes the same settings surface the TUI's config
+modal (`jarvis/tui/config_modal.py`) already has in-process, so `jarvisos-app`
+can build an equivalent settings panel without a special-cased protocol:
+
+- `{"type": "get_settings"}` → `{"type": "settings", "confirmation_mode": ..., "wake_chime_path": ...}` — a small, explicit whitelist (matching `set_wake_chime_path`'s existing rationale: no generic arbitrary-key reader/writer over the socket).
+- `{"type": "set_confirmation_mode", "mode": "smart"|"ask_all"|"allow_all"}` → validated the same way as `set_wake_chime_path`, live-applies via `Config.CONFIRMATION_MODE` (read fresh by `ConfirmationManager` on every check, so this takes effect immediately, no restart) and persists via `_update_env_setting`. Broadcasts `config_updated`/replies `config_error` with the exact same shape `set_wake_chime_path` uses.
+- `{"type": "list_providers"}` → replies `{"type": "provider_list", "providers": [...]}` (requester only, a read query).
+- `{"type": "add_provider", "ptype": ..., "model": ..., "name": ..., "url": ..., "api_key": ..., "temperature": ...}`, `{"type": "edit_provider", "name": ..., "fields": {...}}`, `{"type": "remove_provider", "name": ...}` — thin wrappers around `jarvis/core/providers.py`'s existing CRUD (already shared between CLI and TUI). A successful mutation broadcasts the refreshed `provider_list` to every GUI client (providers.json is shared daemon state, same rationale as session CRUD's `_reply_or_broadcast`); a `ValueError` (unknown type, missing required field, duplicate name, not found) replies `provider_error` to the requester only.
+- **Known limitation, not introduced by this protocol**: there is no live `ProviderPool` reload. Like the TUI's own provider modal, a provider add/edit/remove only takes effect for the *next* daemon start — `create_llm()` builds the pool once from `providers.json` at startup. Any settings-panel UI built on this should say so.
+
 ### Voice/response session state machine (`jarvis/core/voice_state.py`)
 
 `VoiceState` is the single source of truth for the daemon's voice + response lifecycle:

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -84,10 +84,10 @@ class Config:
     # Short local earcon played the instant a wake word fires -- not TTS, so
     # it plays with no model warm-up and no dependency on any GUI being
     # attached. Falls back to the bundled default when unset.
-    WAKE_CHIME_PATH = os.getenv(
-        "WAKE_CHIME_PATH",
-        os.path.join(os.path.dirname(__file__), "assets", "wake_chime.wav"),
+    DEFAULT_WAKE_CHIME_PATH = os.path.join(
+        os.path.dirname(__file__), "assets", "wake_chime.wav"
     )
+    WAKE_CHIME_PATH = os.getenv("WAKE_CHIME_PATH", DEFAULT_WAKE_CHIME_PATH)
     # Minimum RMS amplitude (0-32767, int16 PCM) a raw audio chunk must have
     # to reach the STT/wake-word recognizer at all -- quiet ambient noise is
     # dropped before it ever becomes a Vosk hypothesis. Typical quiet-room

--- a/jarvis/runtime/io.py
+++ b/jarvis/runtime/io.py
@@ -335,6 +335,9 @@ async def _process_gui_message(
     elif msg_type == "set_wake_chime_path":
         await _handle_set_wake_chime_path(app, msg, writer)
 
+    elif msg_type == "reset_wake_chime_path":
+        await _handle_reset_wake_chime_path(app, writer)
+
     elif msg_type == "get_settings":
         await _gui_write(
             writer,
@@ -410,6 +413,18 @@ async def _handle_set_wake_chime_path(
     _update_env_setting("WAKE_CHIME_PATH", path)
     await broadcast_to_gui_clients(
         app, {"type": "config_updated", "key": "WAKE_CHIME_PATH", "value": path}
+    )
+
+
+async def _handle_reset_wake_chime_path(app: Any, writer: asyncio.StreamWriter) -> None:
+    """Restore WAKE_CHIME_PATH to the bundled default -- the settings-panel
+    counterpart to `_handle_set_wake_chime_path`'s custom-path write."""
+    from ..cli import _update_env_setting
+
+    default = Config.DEFAULT_WAKE_CHIME_PATH
+    _update_env_setting("WAKE_CHIME_PATH", default)
+    await broadcast_to_gui_clients(
+        app, {"type": "config_updated", "key": "WAKE_CHIME_PATH", "value": default}
     )
 
 

--- a/jarvis/runtime/io.py
+++ b/jarvis/runtime/io.py
@@ -9,6 +9,12 @@ from logging import Logger
 from typing import Any
 
 from ..config import Config
+from ..core.providers import (
+    add_provider,
+    edit_provider,
+    list_providers,
+    remove_provider,
+)
 from ..core.voice_state import VoiceState
 from ..platform import current as platform
 from ..voice.chime import validate_chime_path
@@ -329,6 +335,33 @@ async def _process_gui_message(
     elif msg_type == "set_wake_chime_path":
         await _handle_set_wake_chime_path(app, msg, writer)
 
+    elif msg_type == "get_settings":
+        await _gui_write(
+            writer,
+            {
+                "type": "settings",
+                "confirmation_mode": Config.CONFIRMATION_MODE,
+                "wake_chime_path": Config.WAKE_CHIME_PATH,
+            },
+        )
+
+    elif msg_type == "set_confirmation_mode":
+        await _handle_set_confirmation_mode(app, msg, writer)
+
+    elif msg_type == "list_providers":
+        await _gui_write(
+            writer, {"type": "provider_list", "providers": list_providers()}
+        )
+
+    elif msg_type == "add_provider":
+        await _reply_or_broadcast_providers(app, writer, _handle_add_provider(msg))
+
+    elif msg_type == "edit_provider":
+        await _reply_or_broadcast_providers(app, writer, _handle_edit_provider(msg))
+
+    elif msg_type == "remove_provider":
+        await _reply_or_broadcast_providers(app, writer, _handle_remove_provider(msg))
+
     elif msg_type == "list_sessions":
         await _gui_write(writer, _handle_list_sessions(app, msg))
 
@@ -378,6 +411,97 @@ async def _handle_set_wake_chime_path(
     await broadcast_to_gui_clients(
         app, {"type": "config_updated", "key": "WAKE_CHIME_PATH", "value": path}
     )
+
+
+_VALID_CONFIRMATION_MODES = ("smart", "ask_all", "allow_all")
+
+
+async def _handle_set_confirmation_mode(
+    app: Any, msg: dict, writer: asyncio.StreamWriter
+) -> None:
+    """Validated, single-purpose config write for CONFIRMATION_MODE only --
+    same rationale as `_handle_set_wake_chime_path`: no generic config setter
+    over the GUI socket, only specific, whitelisted, validated keys.
+    """
+    mode = msg.get("mode", "")
+    if mode not in _VALID_CONFIRMATION_MODES:
+        await _gui_write(
+            writer,
+            {
+                "type": "config_error",
+                "key": "CONFIRMATION_MODE",
+                "message": f"Invalid mode '{mode}'. Use one of: "
+                f"{', '.join(_VALID_CONFIRMATION_MODES)}.",
+            },
+        )
+        return
+
+    from ..cli import _update_env_setting
+
+    _update_env_setting("CONFIRMATION_MODE", mode)
+    await broadcast_to_gui_clients(
+        app, {"type": "config_updated", "key": "CONFIRMATION_MODE", "value": mode}
+    )
+
+
+# ---------------------------------------------------------------------------
+# GUI socket — provider CRUD
+# ---------------------------------------------------------------------------
+
+
+def _provider_error(message: str) -> dict:
+    return {"type": "provider_error", "message": message}
+
+
+def _handle_add_provider(msg: dict) -> dict:
+    try:
+        add_provider(
+            msg.get("ptype", ""),
+            msg.get("model", ""),
+            name=msg.get("name") or None,
+            url=msg.get("url") or None,
+            api_key=msg.get("api_key") or None,
+            temperature=msg.get("temperature"),
+        )
+    except ValueError as e:
+        return _provider_error(str(e))
+    return {"type": "provider_list", "providers": list_providers()}
+
+
+def _handle_edit_provider(msg: dict) -> dict:
+    name = msg.get("name", "")
+    fields = msg.get("fields") or {}
+    if not name or not fields:
+        return _provider_error("edit_provider requires 'name' and 'fields'")
+    try:
+        edit_provider(name, **fields)
+    except ValueError as e:
+        return _provider_error(str(e))
+    return {"type": "provider_list", "providers": list_providers()}
+
+
+def _handle_remove_provider(msg: dict) -> dict:
+    name = msg.get("name", "")
+    if not name:
+        return _provider_error("remove_provider requires 'name'")
+    try:
+        remove_provider(name)
+    except ValueError as e:
+        return _provider_error(str(e))
+    return {"type": "provider_list", "providers": list_providers()}
+
+
+async def _reply_or_broadcast_providers(
+    app: Any, writer: asyncio.StreamWriter, response: dict
+) -> None:
+    """Provider config is shared daemon state (providers.json), so a
+    successful mutation broadcasts the refreshed list to every GUI client,
+    matching `_reply_or_broadcast`'s session-CRUD pattern; errors are
+    specific to the requester's malformed/invalid request."""
+    if response.get("type") == "provider_error":
+        await _gui_write(writer, response)
+    else:
+        await broadcast_to_gui_clients(app, response)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gui_settings_socket.py
+++ b/tests/test_gui_settings_socket.py
@@ -1,0 +1,231 @@
+"""Tests for the GUI socket's settings + provider CRUD handlers
+(jarvis/runtime/io.py), added for jarvisos-app#12's settings panel.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from jarvis.config import Config
+from jarvis.runtime import io as runtime_io
+
+
+def _make_app():
+    return SimpleNamespace(_gui_clients={Mock()})
+
+
+@pytest.mark.unit
+class TestGetSettings:
+    @pytest.mark.asyncio
+    async def test_returns_whitelisted_settings_only(self):
+        app = _make_app()
+        writer = Mock()
+        with (
+            patch.object(Config, "CONFIRMATION_MODE", "smart"),
+            patch.object(Config, "WAKE_CHIME_PATH", "/some/chime.wav"),
+            patch.object(runtime_io, "_gui_write", new=AsyncMock()) as gw,
+        ):
+            await runtime_io._process_gui_message(
+                app, Mock(), {"type": "get_settings"}, writer
+            )
+        gw.assert_awaited_once_with(
+            writer,
+            {
+                "type": "settings",
+                "confirmation_mode": "smart",
+                "wake_chime_path": "/some/chime.wav",
+            },
+        )
+
+
+@pytest.mark.unit
+class TestSetConfirmationMode:
+    @pytest.mark.asyncio
+    async def test_valid_mode_persists_and_broadcasts(self):
+        app = _make_app()
+        writer = Mock()
+        with (
+            patch("jarvis.cli._update_env_setting") as mock_update,
+            patch.object(runtime_io, "broadcast_to_gui_clients", new=AsyncMock()) as bc,
+        ):
+            await runtime_io._handle_set_confirmation_mode(
+                app, {"mode": "ask_all"}, writer
+            )
+        mock_update.assert_called_once_with("CONFIRMATION_MODE", "ask_all")
+        bc.assert_awaited_once_with(
+            app,
+            {"type": "config_updated", "key": "CONFIRMATION_MODE", "value": "ask_all"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_invalid_mode_replies_error_to_requester_only(self):
+        app = _make_app()
+        writer = Mock()
+        with (
+            patch("jarvis.cli._update_env_setting") as mock_update,
+            patch.object(runtime_io, "broadcast_to_gui_clients", new=AsyncMock()) as bc,
+            patch.object(runtime_io, "_gui_write", new=AsyncMock()) as gw,
+        ):
+            await runtime_io._handle_set_confirmation_mode(
+                app, {"mode": "yolo"}, writer
+            )
+        mock_update.assert_not_called()
+        bc.assert_not_awaited()
+        gw.assert_awaited_once_with(
+            writer,
+            {
+                "type": "config_error",
+                "key": "CONFIRMATION_MODE",
+                "message": "Invalid mode 'yolo'. Use one of: smart, ask_all, allow_all.",
+            },
+        )
+
+
+@pytest.mark.unit
+class TestProviderCrudHandlers:
+    """Exercises the real jarvis.core.providers file-based CRUD (a temp
+    providers.json), not mocks -- these handlers are thin wrappers, so the
+    thing worth actually proving is the real read-modify-write round-trips
+    and that failures surface as provider_error."""
+
+    def test_add_provider_success_returns_refreshed_list(self, tmp_path):
+        providers_file = str(tmp_path / "providers.json")
+        with patch.object(Config, "PROVIDERS_FILE", providers_file):
+            result = runtime_io._handle_add_provider(
+                {"ptype": "ollama", "model": "qwen3:8b", "name": "my-ollama"}
+            )
+        assert result["type"] == "provider_list"
+        assert [p["name"] for p in result["providers"]] == ["my-ollama"]
+
+    def test_add_provider_failure_returns_provider_error(self, tmp_path):
+        providers_file = str(tmp_path / "providers.json")
+        with patch.object(Config, "PROVIDERS_FILE", providers_file):
+            result = runtime_io._handle_add_provider({"ptype": "bogus", "model": "x"})
+        assert result["type"] == "provider_error"
+        assert "bogus" in result["message"]
+
+    def test_edit_provider_requires_name_and_fields(self):
+        assert runtime_io._handle_edit_provider({})["type"] == "provider_error"
+        assert (
+            runtime_io._handle_edit_provider({"name": "x"})["type"] == "provider_error"
+        )
+
+    def test_edit_provider_success_updates_and_returns_list(self, tmp_path):
+        providers_file = str(tmp_path / "providers.json")
+        with patch.object(Config, "PROVIDERS_FILE", providers_file):
+            runtime_io._handle_add_provider(
+                {"ptype": "ollama", "model": "qwen3:8b", "name": "my-ollama"}
+            )
+            result = runtime_io._handle_edit_provider(
+                {"name": "my-ollama", "fields": {"model": "qwen3:14b"}}
+            )
+        assert result["type"] == "provider_list"
+        assert result["providers"][0]["model"] == "qwen3:14b"
+
+    def test_edit_provider_not_found_returns_provider_error(self, tmp_path):
+        providers_file = str(tmp_path / "providers.json")
+        with patch.object(Config, "PROVIDERS_FILE", providers_file):
+            result = runtime_io._handle_edit_provider(
+                {"name": "nope", "fields": {"model": "x"}}
+            )
+        assert result["type"] == "provider_error"
+
+    def test_remove_provider_requires_name(self):
+        assert runtime_io._handle_remove_provider({})["type"] == "provider_error"
+
+    def test_remove_provider_success_returns_refreshed_list(self, tmp_path):
+        providers_file = str(tmp_path / "providers.json")
+        with patch.object(Config, "PROVIDERS_FILE", providers_file):
+            runtime_io._handle_add_provider(
+                {"ptype": "ollama", "model": "qwen3:8b", "name": "my-ollama"}
+            )
+            result = runtime_io._handle_remove_provider({"name": "my-ollama"})
+        assert result["type"] == "provider_list"
+        assert result["providers"] == []
+
+    def test_remove_provider_not_found_returns_provider_error(self, tmp_path):
+        providers_file = str(tmp_path / "providers.json")
+        with patch.object(Config, "PROVIDERS_FILE", providers_file):
+            result = runtime_io._handle_remove_provider({"name": "nope"})
+        assert result["type"] == "provider_error"
+
+
+@pytest.mark.unit
+class TestReplyOrBroadcastProviders:
+    @pytest.mark.asyncio
+    async def test_error_goes_to_requester_only(self):
+        app = _make_app()
+        writer = Mock()
+        with (
+            patch.object(runtime_io, "_gui_write", new=AsyncMock()) as gui_write,
+            patch.object(
+                runtime_io, "broadcast_to_gui_clients", new=AsyncMock()
+            ) as broadcast,
+        ):
+            await runtime_io._reply_or_broadcast_providers(
+                app, writer, {"type": "provider_error", "message": "boom"}
+            )
+        gui_write.assert_awaited_once_with(
+            writer, {"type": "provider_error", "message": "boom"}
+        )
+        broadcast.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_success_broadcasts_to_all_clients(self):
+        app = _make_app()
+        writer = Mock()
+        response = {"type": "provider_list", "providers": []}
+        with (
+            patch.object(runtime_io, "_gui_write", new=AsyncMock()) as gui_write,
+            patch.object(
+                runtime_io, "broadcast_to_gui_clients", new=AsyncMock()
+            ) as broadcast,
+        ):
+            await runtime_io._reply_or_broadcast_providers(app, writer, response)
+        broadcast.assert_awaited_once_with(app, response)
+        gui_write.assert_not_awaited()
+
+
+@pytest.mark.unit
+class TestProcessGuiMessageRouting:
+    """Confirms _process_gui_message actually wires the new message types
+    to their handlers end-to-end through the real dispatch function."""
+
+    @pytest.mark.asyncio
+    async def test_list_providers_replies_with_real_list(self, tmp_path):
+        providers_file = str(tmp_path / "providers.json")
+        app = _make_app()
+        writer = Mock()
+        with (
+            patch.object(Config, "PROVIDERS_FILE", providers_file),
+            patch.object(runtime_io, "_gui_write", new=AsyncMock()) as gw,
+        ):
+            runtime_io._handle_add_provider(
+                {"ptype": "ollama", "model": "qwen3:8b", "name": "solo"}
+            )
+            await runtime_io._process_gui_message(
+                app, Mock(), {"type": "list_providers"}, writer
+            )
+        gw.assert_awaited_once()
+        payload = gw.await_args.args[1]
+        assert payload["type"] == "provider_list"
+        assert [p["name"] for p in payload["providers"]] == ["solo"]
+
+    @pytest.mark.asyncio
+    async def test_add_provider_broadcasts_on_success(self, tmp_path):
+        providers_file = str(tmp_path / "providers.json")
+        app = _make_app()
+        writer = Mock()
+        with (
+            patch.object(Config, "PROVIDERS_FILE", providers_file),
+            patch.object(runtime_io, "broadcast_to_gui_clients", new=AsyncMock()) as bc,
+        ):
+            await runtime_io._process_gui_message(
+                app,
+                Mock(),
+                {"type": "add_provider", "ptype": "ollama", "model": "qwen3:8b"},
+                writer,
+            )
+        bc.assert_awaited_once()
+        assert bc.await_args.args[1]["type"] == "provider_list"

--- a/tests/test_gui_settings_socket.py
+++ b/tests/test_gui_settings_socket.py
@@ -40,6 +40,30 @@ class TestGetSettings:
 
 
 @pytest.mark.unit
+class TestResetWakeChimePath:
+    @pytest.mark.asyncio
+    async def test_restores_bundled_default_and_broadcasts(self):
+        app = _make_app()
+        writer = Mock()
+        with (
+            patch("jarvis.cli._update_env_setting") as mock_update,
+            patch.object(runtime_io, "broadcast_to_gui_clients", new=AsyncMock()) as bc,
+        ):
+            await runtime_io._handle_reset_wake_chime_path(app, writer)
+        mock_update.assert_called_once_with(
+            "WAKE_CHIME_PATH", Config.DEFAULT_WAKE_CHIME_PATH
+        )
+        bc.assert_awaited_once_with(
+            app,
+            {
+                "type": "config_updated",
+                "key": "WAKE_CHIME_PATH",
+                "value": Config.DEFAULT_WAKE_CHIME_PATH,
+            },
+        )
+
+
+@pytest.mark.unit
 class TestSetConfirmationMode:
     @pytest.mark.asyncio
     async def test_valid_mode_persists_and_broadcasts(self):


### PR DESCRIPTION
## What changed

- `get_settings` → returns a small, explicit whitelist (`confirmation_mode`, `wake_chime_path`), matching `set_wake_chime_path`'s existing "no generic config reader/writer over the socket" stance
- `set_confirmation_mode` → validated single-purpose write for `CONFIRMATION_MODE`, reusing `set_wake_chime_path`'s exact `config_updated`/`config_error` wire shape
- `list_providers` / `add_provider` / `edit_provider` / `remove_provider` → thin GUI-socket wrappers around `jarvis/core/providers.py`'s existing CRUD (already shared between the CLI and TUI's config modal); a successful mutation broadcasts the refreshed `provider_list` to every connected GUI client, mirroring session CRUD's `_reply_or_broadcast` pattern; failures reply `provider_error` to the requester only

## Why this change

`jarvisos-app`#12 wants a settings panel covering provider management, voice toggle, confirmation mode, and the wake-sound picker. Voice toggle (`start_listening`/`stop_listening`) and the wake-chime picker (`set_wake_chime_path`) already existed on the socket; this closes the remaining two gaps (provider CRUD, confirmation mode) so the settings panel can be built entirely against the daemon's existing socket protocol, the same way the TUI's config modal already works in-process.

Confirmation mode changes take effect immediately — `ConfirmationManager` reads `Config.CONFIRMATION_MODE` fresh on every check, no restart needed. Provider changes do **not** take effect until the next daemon start (no live `ProviderPool` reload) — this is a pre-existing limitation shared with the TUI's own provider modal, not something this PR introduces; documented explicitly in `docs/architecture.md` so a settings-panel UI built on top knows to say so.

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests

Commands run:

```bash
python3 -m pytest tests/ -q -m unit   # 134 passed, 1 skipped (pre-existing)
python3 -m black --check .
python3 -m isort --check-only .
python3 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude .venv
```

New test file `tests/test_gui_settings_socket.py`: real `providers.json` read-modify-write round-trips via `tmp_path` (not mocked) for add/edit/remove, `get_settings`/`set_confirmation_mode` validation and broadcast behavior, and end-to-end `_process_gui_message` routing checks.

## Checklist

- [x] I added or updated tests for behavior changes
- [x] I updated documentation where needed (`docs/architecture.md`, `CLAUDE.md`)
- [x] I did not include secrets or sensitive data
- [x] I verified there are no unrelated changes in this PR

## Risk and rollout notes

Purely additive to the GUI socket protocol — no existing message types changed. Provider CRUD reuses already-battle-tested `jarvis/core/providers.py` functions (same code path the CLI/TUI already use), so the main new surface area is the socket routing/reply shape itself, covered by tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_