### PR TITLE
Add connected-clients query and graceful shutdown_request protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,9 @@ make check                  # Format + lint + typecheck + tests
 | `jarvis/voice/chime.py` | Wake-word earcon: path validation + best-effort playback |
 | `jarvis/voice/audio.py` | Audio device detection + `passes_noise_gate` RMS filter |
 | `jarvis/voice/aec/webrtc_aec.py` | `WebRtcAEC` — acoustic echo cancellation (barge-in fix, #143) |
-| `jarvis/runtime/io.py` | Input/GUI/output sockets — confirmation queries, session CRUD, settings + provider CRUD |
+| `jarvis/runtime/io.py` | Input/GUI/output sockets — confirmation queries, session CRUD, settings + provider CRUD, client labeling/`list_clients`/`shutdown_request` |
+| `jarvis/runtime/lifecycle.py` | Signal handlers, startup service wiring, `shutdown_request`'s safe save-then-exit sequence |
+| `jarvis/dispatch/goal_manager.py` | `GoalManager` — goal tree + on-disk archive (`archive_all()` for shutdown) |
 | `jarvis/core/providers.py` | Provider pool CRUD (`providers.json`), shared by CLI, TUI, and the GUI socket |
 | `jarvis/dispatch/adapter.py` | Python wrapper for Rust dispatch binary |
 | `jarvis/dispatch/discovery.py` | Embedding search via dmcp vector index |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -256,6 +256,23 @@ can build an equivalent settings panel without a special-cased protocol:
 - `{"type": "add_provider", "ptype": ..., "model": ..., "name": ..., "url": ..., "api_key": ..., "temperature": ...}`, `{"type": "edit_provider", "name": ..., "fields": {...}}`, `{"type": "remove_provider", "name": ...}` — thin wrappers around `jarvis/core/providers.py`'s existing CRUD (already shared between CLI and TUI). A successful mutation broadcasts the refreshed `provider_list` to every GUI client (providers.json is shared daemon state, same rationale as session CRUD's `_reply_or_broadcast`); a `ValueError` (unknown type, missing required field, duplicate name, not found) replies `provider_error` to the requester only.
 - **Known limitation, not introduced by this protocol**: there is no live `ProviderPool` reload. Like the TUI's own provider modal, a provider add/edit/remove only takes effect for the *next* daemon start — `create_llm()` builds the pool once from `providers.json` at startup. Any settings-panel UI built on this should say so.
 
+### Connected-clients query + graceful shutdown (Project-JARVIS#146)
+
+`app._gui_clients` changed from a bare `set[StreamWriter]` to `dict[StreamWriter, str]` (writer → label), so a client can identify itself and every other connected client can see who's attached before requesting a shutdown:
+
+- `{"type": "hello", "label": "jarvis-app"}` — sets the sender's label (blank/missing labels are ignored, not cleared). Unlabeled clients default to `runtime.io.DEFAULT_CLIENT_LABEL` ("unlabeled") from the moment they connect, so `list_clients` always has something to show even for a client that never identifies itself.
+- `{"type": "list_clients"}` → replies `{"type": "client_list", "clients": [label, ...]}` — callable by any client, no restriction. Just labels (not writer identities or connection metadata) — enough for `jarvisos-app`#17 to show "N other clients are connected" before asking the user to confirm a shutdown.
+- `{"type": "shutdown_request"}` — callable by any connected client, **no daemon-enforced confirmation gate**. The socket's trust boundary is already "same local user" (`socket_security.py`); checking with the user first is each client's own job (`jarvisos-app`#17 does this by querying `list_clients` and requiring explicit confirmation before ever sending this). The handler is a one-liner: `app.stop()` — the same `request_stop()` a SIGTERM/SIGINT signal handler calls, so both triggers converge on identical behavior rather than two parallel shutdown paths.
+
+**The safe save-then-exit sequence**, run from `Jarvis.run()`'s `finally` block regardless of what triggered it (loop exit via `request_stop()`, whether from a signal or `shutdown_request`):
+
+1. `lifecycle.broadcast_shutdown_notice()` broadcasts `{"type": "DAEMON_SHUTDOWN", "state": ..., "goals": [...], "session_id": ..., "timestamp": ...}` to every connected GUI client — purely informational, no negotiation, no single "owner." **Must run before any socket-task cancellation**: cancelling the GUI listener task clears `app._gui_clients` in its own cleanup, so broadcasting after that reaches nobody. `goals` is every still-PENDING/ACTIVE/DEFERRED goal via `GoalManager.get_active_goals()`.
+2. Input/output/GUI socket listener tasks are cancelled, then `lifecycle.join_voice_thread_if_running()` blocks (bounded, 2s default) until the voice-activation thread's own loop notices `app._running is False` and exits — previously this daemon thread (`daemon=True`, never joined) was just left to die implicitly whenever the process happened to exit.
+3. In-flight event-handler tasks are awaited (pre-existing behavior from #154).
+4. `lifecycle.shutdown()` now calls `app.goals.archive_all()` **before** any other teardown — unlike `dismiss_completed()`/`dismiss_failed()` (which only ever handled terminal goals), this archives every goal regardless of status and clears in-memory state, so a PENDING/ACTIVE/DEFERRED goal that was mid-flight at shutdown has an on-disk record in `goal_archive.jsonl` instead of vanishing. Session/contextor writes need no explicit flush — `ContextorAdapter._send()` is already a synchronous round-trip per call, so `contextor.disconnect()` never races a pending write.
+
+**Explicitly not a security boundary**: the issue text is deliberate about this — it's a cooperative shutdown mechanism for a well-behaved daemon and client, not protection against a compromised one.
+
 ### Voice/response session state machine (`jarvis/core/voice_state.py`)
 
 `VoiceState` is the single source of truth for the daemon's voice + response lifecycle:

--- a/jarvis/dispatch/goal_manager.py
+++ b/jarvis/dispatch/goal_manager.py
@@ -322,6 +322,19 @@ class GoalManager:
     def clear(self):
         self._goals.clear()
 
+    def archive_all(self) -> List[Goal]:
+        """Archive every goal currently in memory, regardless of status, and
+        clear in-memory state. Unlike dismiss_completed/dismiss_failed (which
+        only ever touch terminal goals), this also covers PENDING/ACTIVE/
+        DEFERRED goals -- used on daemon shutdown (#146) so in-flight work
+        isn't silently lost with zero on-disk trace.
+        """
+        goals = list(self._goals)
+        if goals:
+            self._archive_goals(goals)
+        self._goals.clear()
+        return goals
+
     def _archive_goals(self, goals: List[Goal]):
         try:
             with open(self._archive_path, "a", encoding="utf-8") as f:

--- a/jarvis/main.py
+++ b/jarvis/main.py
@@ -30,9 +30,11 @@ from .runtime.dispatch_flow import get_tool_metadata as runtime_get_tool_metadat
 from .runtime.goal_updates import apply_goal_updates as runtime_apply_goal_updates
 from .runtime.lifecycle import (
     bootstrap_tool_index_nonfatal,
+    broadcast_shutdown_notice,
     cancel_task_if_running,
     connect_dispatch_nonfatal,
     install_signal_handlers,
+    join_voice_thread_if_running,
     request_stop,
     shutdown,
     start_runtime_services,
@@ -104,7 +106,9 @@ class Jarvis:
         self.confirmation = self.components["confirmation_manager"]
         self.voice_manager = self.components.get("voice_manager")
         self._output_clients: List[asyncio.StreamWriter] = []
-        self._gui_clients: set[asyncio.StreamWriter] = set()
+        # writer -> client-supplied label (Project-JARVIS#146's "hello" message),
+        # defaulting to DEFAULT_CLIENT_LABEL until a client identifies itself.
+        self._gui_clients: Dict[asyncio.StreamWriter, str] = {}
         self._gui_state: str = "idle"
 
         # Server docs scoped to the active dispatch chain — cleared on respond.
@@ -131,6 +135,7 @@ class Jarvis:
         socket_task = runtime_tasks["input_socket"]
         output_task = runtime_tasks["output_socket"]
         gui_task = runtime_tasks["gui_socket"]
+        voice_thread = runtime_tasks["voice_thread"]
 
         logger.info("JARVIS: Event loop started")
 
@@ -151,9 +156,14 @@ class Jarvis:
         except KeyboardInterrupt:
             logger.info("JARVIS: Interrupted")
         finally:
+            # Must run before the GUI socket listener is cancelled below --
+            # cancelling it clears self._gui_clients in its own cleanup, so
+            # anything broadcast after that point reaches nobody (#146).
+            await broadcast_shutdown_notice(self, logger)
             cancel_task_if_running(socket_task)
             cancel_task_if_running(output_task)
             cancel_task_if_running(gui_task)
+            join_voice_thread_if_running(voice_thread)
             if event_tasks:
                 logger.info(
                     f"JARVIS: Waiting for {len(event_tasks)} in-flight goal(s) to finish..."

--- a/jarvis/runtime/io.py
+++ b/jarvis/runtime/io.py
@@ -239,6 +239,9 @@ async def run_gui_socket_listener(app: Any, logger: Logger) -> None:
         platform.ipc_cleanup(path)
 
 
+DEFAULT_CLIENT_LABEL = "unlabeled"
+
+
 async def handle_gui_connection(
     app: Any,
     logger: Logger,
@@ -246,7 +249,7 @@ async def handle_gui_connection(
     writer: asyncio.StreamWriter,
 ) -> None:
     """Handle a bidirectional GUI client connection."""
-    app._gui_clients.add(writer)
+    app._gui_clients[writer] = DEFAULT_CLIENT_LABEL
     logger.info(f"JARVIS: GUI client connected ({len(app._gui_clients)} total)")
 
     try:
@@ -281,7 +284,7 @@ async def handle_gui_connection(
     except (ConnectionResetError, BrokenPipeError, asyncio.IncompleteReadError):
         pass
     finally:
-        app._gui_clients.discard(writer)
+        app._gui_clients.pop(writer, None)
         try:
             writer.close()
             await writer.wait_closed()
@@ -311,6 +314,22 @@ async def _process_gui_message(
 
     elif msg_type == "confirmation_response":
         app.events.inject_confirmation_response(msg)
+
+    elif msg_type == "hello":
+        label = str(msg.get("label", "")).strip()
+        if label:
+            app._gui_clients[writer] = label
+            logger.info(f"JARVIS: GUI client identified as '{label}'")
+
+    elif msg_type == "list_clients":
+        await _gui_write(
+            writer,
+            {"type": "client_list", "clients": list(app._gui_clients.values())},
+        )
+
+    elif msg_type == "shutdown_request":
+        logger.info("JARVIS: shutdown_request received over the GUI socket")
+        app.stop()
 
     elif msg_type == "start_listening":
         # Toggles whether the wake-word listener is enabled at all -- a
@@ -682,7 +701,8 @@ async def broadcast_to_gui_clients(app: Any, message: dict) -> None:
             await writer.drain()
         except (ConnectionResetError, BrokenPipeError, OSError):
             dead.add(writer)
-    app._gui_clients -= dead
+    for writer in dead:
+        app._gui_clients.pop(writer, None)
 
 
 async def _gui_write(writer: asyncio.StreamWriter, message: dict) -> None:

--- a/jarvis/runtime/lifecycle.py
+++ b/jarvis/runtime/lifecycle.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import asyncio
 import sys
 import threading
+import time
 from collections.abc import Callable
 from logging import Logger
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from ..config import Config
 from ..core.voice_state import VoiceState
@@ -98,9 +99,7 @@ def resolve_user_source(app: Any) -> Optional[Callable[[], Any]]:
     return app._await_user_input if stdin_is_tty() else None
 
 
-async def start_runtime_services(
-    app: Any, logger: Logger
-) -> dict[str, Optional[asyncio.Task]]:
+async def start_runtime_services(app: Any, logger: Logger) -> dict[str, Any]:
     """Start event sources and optional socket/voice runtime services."""
     user_source = resolve_user_source(app)
     app.events.start(
@@ -112,6 +111,7 @@ async def start_runtime_services(
         lambda state: _notify_voice_output_state(app, state)
     )
 
+    voice_thread: Optional[threading.Thread] = None
     if app.voice_manager:
         voice_thread = threading.Thread(
             target=run_voice_activation,
@@ -164,6 +164,7 @@ async def start_runtime_services(
         "input_socket": input_socket_task,
         "output_socket": output_socket_task,
         "gui_socket": gui_socket_task,
+        "voice_thread": voice_thread,
     }
 
 
@@ -173,8 +174,24 @@ def cancel_task_if_running(task: Optional[asyncio.Task]) -> None:
         task.cancel()
 
 
+def join_voice_thread_if_running(
+    thread: Optional[threading.Thread], timeout: float = 2.0
+) -> None:
+    """Best-effort join of the voice-activation thread on shutdown (#146).
+
+    request_stop() already flips app._running, which run_voice_activation's
+    loop notices within one poll interval and exits via -- this just waits
+    for that to actually happen instead of trusting the daemon thread to be
+    killed silently whenever the process happens to exit.
+    """
+    if thread and thread.is_alive():
+        thread.join(timeout=timeout)
+
+
 def request_stop(app: Any) -> None:
-    """Request graceful shutdown (e.g. from signal handler)."""
+    """Request graceful shutdown (e.g. from signal handler or a GUI client's
+    shutdown_request -- both funnel through here, so SIGTERM/SIGINT and the
+    socket protocol trigger the exact same sequence, per #146)."""
     app._running = False
     if app.voice_manager and hasattr(app.voice_manager, "activation"):
         try:
@@ -184,9 +201,44 @@ def request_stop(app: Any) -> None:
     app.events.request_shutdown()
 
 
+def build_shutdown_snapshot(app: Any) -> Dict[str, Any]:
+    """Final-state snapshot broadcast on shutdown_request (#146): current GUI
+    state, still-unresolved goals, the active session id, and a timestamp."""
+    return {
+        "state": app._gui_state,
+        "goals": [g.to_context() for g in app.goals.get_active_goals()],
+        "session_id": app.sessions.current_id if app.sessions else None,
+        "timestamp": time.time(),
+    }
+
+
+async def broadcast_shutdown_notice(app: Any, logger: Logger) -> None:
+    """Broadcast DAEMON_SHUTDOWN + the final-state snapshot to every
+    connected GUI client. Must run before the GUI socket listener task is
+    cancelled -- cancelling it clears app._gui_clients in its own cleanup,
+    so broadcasting after that point would silently reach nobody.
+    """
+    if not app._gui_clients:
+        return
+    logger.info(
+        f"JARVIS: Broadcasting shutdown notice to {len(app._gui_clients)} client(s)"
+    )
+    snapshot = build_shutdown_snapshot(app)
+    await broadcast_to_gui_clients(app, {"type": "DAEMON_SHUTDOWN", **snapshot})
+
+
 async def shutdown(app: Any, logger: Logger) -> None:
-    """Tear down event sources, sockets, dispatch, and contextor."""
+    """Tear down event sources, sockets, dispatch, and contextor.
+
+    Goal state is archived unconditionally first -- dismiss_completed/
+    dismiss_failed only ever ran for terminal goals, so without this any
+    still-PENDING/ACTIVE/DEFERRED goal had zero on-disk trace once the
+    process exited (#146).
+    """
     app._running = False
+    archived = app.goals.archive_all()
+    if archived:
+        logger.info(f"JARVIS: Archived {len(archived)} in-flight goal(s) on shutdown")
     app.output_manager.remove_output_callback(app._on_output_for_broadcast)
     app.output_manager.remove_output_callback(app._on_gui_output)
     await app.events.stop()

--- a/tests/test_daemon_shutdown.py
+++ b/tests/test_daemon_shutdown.py
@@ -1,0 +1,200 @@
+"""Tests for the connected-clients query + graceful shutdown protocol
+(Project-JARVIS#146): client labeling, list_clients, shutdown_request,
+the DAEMON_SHUTDOWN broadcast + final-state snapshot, and voice-thread
+join-on-shutdown.
+"""
+
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from jarvis.runtime import io as runtime_io
+from jarvis.runtime import lifecycle as runtime_lifecycle
+
+_UNSET = object()
+
+
+def _make_app(gui_clients=None, goals=None, sessions=_UNSET):
+    return SimpleNamespace(
+        _gui_clients=gui_clients if gui_clients is not None else {},
+        _gui_state="idle",
+        goals=goals or Mock(get_active_goals=Mock(return_value=[])),
+        sessions=Mock(current_id="sess-123") if sessions is _UNSET else sessions,
+        _running=True,
+        events=Mock(),
+        voice_manager=None,
+        stop=Mock(),
+    )
+
+
+@pytest.mark.unit
+class TestClientLabeling:
+    @pytest.mark.asyncio
+    async def test_hello_sets_the_client_label(self):
+        writer = Mock()
+        app = _make_app(gui_clients={writer: runtime_io.DEFAULT_CLIENT_LABEL})
+
+        await runtime_io._process_gui_message(
+            app, Mock(), {"type": "hello", "label": "jarvis-app"}, writer
+        )
+
+        assert app._gui_clients[writer] == "jarvis-app"
+
+    @pytest.mark.asyncio
+    async def test_hello_with_blank_label_is_ignored(self):
+        writer = Mock()
+        app = _make_app(gui_clients={writer: runtime_io.DEFAULT_CLIENT_LABEL})
+
+        await runtime_io._process_gui_message(
+            app, Mock(), {"type": "hello", "label": "   "}, writer
+        )
+
+        assert app._gui_clients[writer] == runtime_io.DEFAULT_CLIENT_LABEL
+
+    @pytest.mark.asyncio
+    async def test_list_clients_returns_current_labels(self):
+        w1, w2 = Mock(), Mock()
+        app = _make_app(gui_clients={w1: "jarvis-app", w2: "TUI"})
+        writer = Mock()
+
+        with patch.object(runtime_io, "_gui_write", new=AsyncMock()) as gw:
+            await runtime_io._process_gui_message(
+                app, Mock(), {"type": "list_clients"}, writer
+            )
+
+        gw.assert_awaited_once_with(
+            writer, {"type": "client_list", "clients": ["jarvis-app", "TUI"]}
+        )
+
+    @pytest.mark.asyncio
+    async def test_unlabeled_client_appears_with_default_label(self):
+        writer = Mock()
+        app = _make_app(gui_clients={writer: runtime_io.DEFAULT_CLIENT_LABEL})
+        reply_writer = Mock()
+
+        with patch.object(runtime_io, "_gui_write", new=AsyncMock()) as gw:
+            await runtime_io._process_gui_message(
+                app, Mock(), {"type": "list_clients"}, reply_writer
+            )
+
+        gw.assert_awaited_once_with(
+            reply_writer, {"type": "client_list", "clients": ["unlabeled"]}
+        )
+
+
+@pytest.mark.unit
+class TestShutdownRequest:
+    @pytest.mark.asyncio
+    async def test_shutdown_request_calls_app_stop(self):
+        app = _make_app()
+        writer = Mock()
+
+        await runtime_io._process_gui_message(
+            app, Mock(), {"type": "shutdown_request"}, writer
+        )
+
+        app.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_request_callable_by_any_client_no_gate(self):
+        """No confirmation-tier gating at the daemon level -- the issue is
+        explicit that this is each client's own responsibility."""
+        app = _make_app()
+        writer = Mock()
+
+        # No confirmation_manager interaction of any kind should occur.
+        await runtime_io._process_gui_message(
+            app, Mock(), {"type": "shutdown_request"}, writer
+        )
+        assert app.stop.called
+
+
+@pytest.mark.unit
+class TestBuildShutdownSnapshot:
+    def test_snapshot_includes_state_goals_session_and_timestamp(self):
+        goal_ctx = {"id": "g1", "description": "do a thing", "status": "active"}
+        app = _make_app(
+            goals=Mock(
+                get_active_goals=Mock(return_value=[Mock(to_context=lambda: goal_ctx)])
+            ),
+            sessions=Mock(current_id="sess-abc"),
+        )
+        app._gui_state = "processing"
+
+        before = time.time()
+        snapshot = runtime_lifecycle.build_shutdown_snapshot(app)
+        after = time.time()
+
+        assert snapshot["state"] == "processing"
+        assert snapshot["goals"] == [goal_ctx]
+        assert snapshot["session_id"] == "sess-abc"
+        assert before <= snapshot["timestamp"] <= after
+
+    def test_snapshot_session_id_is_none_when_sessions_unavailable(self):
+        app = _make_app(sessions=None)
+        snapshot = runtime_lifecycle.build_shutdown_snapshot(app)
+        assert snapshot["session_id"] is None
+
+
+@pytest.mark.unit
+class TestBroadcastShutdownNotice:
+    @pytest.mark.asyncio
+    async def test_broadcasts_daemon_shutdown_with_snapshot_fields(self):
+        writer = Mock()
+        app = _make_app(gui_clients={writer: "jarvis-app"})
+
+        with patch.object(
+            runtime_lifecycle, "broadcast_to_gui_clients", new=AsyncMock()
+        ) as bc:
+            await runtime_lifecycle.broadcast_shutdown_notice(app, Mock())
+
+        bc.assert_awaited_once()
+        sent_app, message = bc.await_args.args
+        assert sent_app is app
+        assert message["type"] == "DAEMON_SHUTDOWN"
+        assert "state" in message and "goals" in message
+        assert "session_id" in message and "timestamp" in message
+
+    @pytest.mark.asyncio
+    async def test_no_broadcast_when_no_clients_connected(self):
+        app = _make_app(gui_clients={})
+
+        with patch.object(
+            runtime_lifecycle, "broadcast_to_gui_clients", new=AsyncMock()
+        ) as bc:
+            await runtime_lifecycle.broadcast_shutdown_notice(app, Mock())
+
+        bc.assert_not_awaited()
+
+
+@pytest.mark.unit
+class TestJoinVoiceThreadIfRunning:
+    def test_joins_a_running_thread(self):
+        started = threading.Event()
+        finished = threading.Event()
+
+        def work():
+            started.set()
+            time.sleep(0.05)
+            finished.set()
+
+        thread = threading.Thread(target=work, daemon=True)
+        thread.start()
+        started.wait(timeout=1.0)
+
+        runtime_lifecycle.join_voice_thread_if_running(thread, timeout=1.0)
+
+        assert finished.is_set()
+        assert not thread.is_alive()
+
+    def test_none_thread_is_a_no_op(self):
+        runtime_lifecycle.join_voice_thread_if_running(None)  # must not raise
+
+    def test_already_finished_thread_is_a_no_op(self):
+        thread = threading.Thread(target=lambda: None)
+        thread.start()
+        thread.join()
+        runtime_lifecycle.join_voice_thread_if_running(thread)  # must not raise

--- a/tests/test_goal_manager_archive.py
+++ b/tests/test_goal_manager_archive.py
@@ -1,0 +1,58 @@
+"""Tests for GoalManager.archive_all() (Project-JARVIS#146).
+
+Real file I/O via tmp_path -- archive_all() must actually persist
+in-flight goals to disk, not just claim to, since the whole point is
+that a daemon shutdown doesn't silently lose them.
+"""
+
+import json
+
+import pytest
+
+from jarvis.dispatch.goal_manager import GoalManager, GoalStatus
+
+
+@pytest.mark.unit
+class TestArchiveAll:
+    def test_archives_goals_of_every_status(self, tmp_path):
+        gm = GoalManager(archive_dir=str(tmp_path))
+        pending = gm.add_goal("pending work")
+        active = gm.add_goal("active work")
+        gm.link_tasks(active.id, [123])
+        deferred = gm.add_goal("deferred work")
+        gm.defer_goal(deferred.id, timer_pid=456)
+        completed = gm.add_goal("done work")
+        gm.complete_goal(completed.id, output="finished")
+
+        archived = gm.archive_all()
+
+        assert {g.id for g in archived} == {
+            pending.id,
+            active.id,
+            deferred.id,
+            completed.id,
+        }
+        assert gm.get_all_goals() == []  # in-memory state cleared
+
+        archive_file = tmp_path / "goal_archive.jsonl"
+        lines = archive_file.read_text().splitlines()
+        assert len(lines) == 4
+        statuses = {json.loads(line)["status"] for line in lines}
+        assert statuses == {"pending", "active", "deferred", "completed"}
+
+    def test_empty_goal_manager_writes_nothing(self, tmp_path):
+        gm = GoalManager(archive_dir=str(tmp_path))
+        assert gm.archive_all() == []
+        assert not (tmp_path / "goal_archive.jsonl").exists()
+
+    def test_archived_goal_preserves_description_and_status(self, tmp_path):
+        gm = GoalManager(archive_dir=str(tmp_path))
+        goal = gm.add_goal("do the thing")
+
+        gm.archive_all()
+
+        entries = gm.load_archive()
+        assert len(entries) == 1
+        assert entries[0]["id"] == goal.id
+        assert entries[0]["description"] == "do the thing"
+        assert entries[0]["status"] == GoalStatus.PENDING.value


### PR DESCRIPTION
## What changed

- `app._gui_clients` becomes `dict[StreamWriter, str]` (writer → label) instead of a bare set, so clients can identify themselves via a new `hello` message; unlabeled clients default to `"unlabeled"`.
- `list_clients` replies with the current labels, callable by any client with no restriction — lets `jarvisos-app`#17 show "who else is connected" before asking the user to confirm a shutdown.
- `shutdown_request` is a one-liner: `app.stop()`, the exact same `request_stop()` a SIGTERM/SIGINT signal handler already calls. No daemon-enforced confirmation gate — the socket's trust boundary is already same-local-user; checking with the user first is each client's own job.
- `Jarvis.run()`'s `finally` block now broadcasts `DAEMON_SHUTDOWN` (current state, active/pending/deferred goals, session id, timestamp) to every GUI client **before** any socket task is cancelled — cancelling the GUI listener clears `_gui_clients` in its own cleanup, so broadcasting after that point would silently reach nobody.
- `GoalManager.archive_all()` persists every in-memory goal regardless of status before shutdown. `dismiss_completed()`/`dismiss_failed()` only ever archived terminal goals, so a PENDING/ACTIVE/DEFERRED goal previously had zero on-disk trace once the process exited.
- The voice-activation thread (`daemon=True`, never joined before) is now joined with a bounded timeout on shutdown instead of just being left to die implicitly with the process.
- Session/contextor writes need no explicit flush — `ContextorAdapter._send()` is already a synchronous round-trip per call, confirmed by reading the code rather than assumed.

## Why this change

Closes #146. There was previously no way for a connected client to see who else is attached to the daemon, or to request a graceful shutdown — the only option was killing the process directly, risking silent loss of in-flight goal state with no notice to other clients.

SIGTERM/SIGINT and `shutdown_request` now converge on the exact same code path (both call `request_stop()`, both hit the same `finally` block in `run()`), so there's one safe save-then-exit sequence, not two parallel ones.

**Explicitly not a security boundary against a compromised daemon** — a cooperative shutdown mechanism for a well-behaved one, per the issue's own framing.

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests

Commands run:

```bash
python3 -m pytest tests/ -q -m unit   # 151 passed, 1 skipped (pre-existing)
python3 -m black --check .
python3 -m isort --check-only .
python3 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude .venv
```

New test files:
- `tests/test_daemon_shutdown.py` — client labeling (`hello`/`list_clients`/default label), `shutdown_request` → `app.stop()`, `build_shutdown_snapshot()` field coverage, `broadcast_shutdown_notice()` targeting (including the no-clients no-op case), and `join_voice_thread_if_running()` against a real background thread (not mocked).
- `tests/test_goal_manager_archive.py` — `archive_all()` against a real `tmp_path` archive file: goals of every status get persisted, an empty manager writes nothing, and archived entries round-trip through `load_archive()` correctly.

## Checklist

- [x] I added or updated tests for behavior changes
- [x] I updated documentation where needed (`docs/architecture.md`, `CLAUDE.md`)
- [x] I did not include secrets or sensitive data
- [x] I verified there are no unrelated changes in this PR

## Risk and rollout notes

The `_gui_clients` set→dict change touches every call site in `io.py`/`lifecycle.py`/`root_handlers.py`/`main.py` — I grepped the full codebase (including tests) afterward to confirm no other code assumed set semantics; a few pre-existing tests construct `_gui_clients=set()`/`{Mock()}` as truthy/falsy stand-ins and still pass unchanged since they never exercise `.add()`/`.pop()`/keyed-assignment. Purely additive to the GUI socket protocol otherwise — no existing message types changed shape.


---
_Generated by [Claude Code](https://claude.ai/code/session_016DDUnayE4qafoQZXUXVFu5)_