### PR TITLE
Host-classified threat level closes the shell confirmation bypass (#159)

### DIFF
--- a/jarvis/core/confirmation_manager.py
+++ b/jarvis/core/confirmation_manager.py
@@ -43,6 +43,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
 from ..config import Config
+from .threat_level import ThreatLevel, classify
 from .logger import get_logger
 
 logger = get_logger(__name__)
@@ -122,11 +123,17 @@ class ConfirmationManager:
     # Public API
     # ------------------------------------------------------------------
 
-    def should_confirm(self, tool_metadata: Dict[str, Any]) -> bool:
+    def should_confirm(
+        self, tool_metadata: Dict[str, Any], tool_name: Optional[str] = None
+    ) -> bool:
         """Decide whether a tool invocation needs confirmation.
 
-        Uses ``CONFIRMATION_MODE`` and the tool's ``confirmation_required``
-        field.
+        In ``smart`` mode the *host* sets a minimum threat level per tool (see
+        ``threat_level.classify``): host-classified dangerous tools (e.g.
+        command execution, which can escalate via sudo) are always confirmed
+        regardless of their manifest, and a manifest may only raise the level,
+        never lower it below the host floor. ``allow_all`` / ``ask_all``
+        override as before.
         """
         mode = Config.CONFIRMATION_MODE
 
@@ -135,8 +142,9 @@ class ConfirmationManager:
         if mode == "ask_all":
             return True
 
-        # "smart" — respect the tool's own declaration.
-        return bool(tool_metadata.get("confirmation_required", False))
+        # "smart" — confirm at or above ELEVATED. classify() folds in the host
+        # floor AND the tool's own confirmation_required / threat_level.
+        return classify(tool_name, tool_metadata) >= ThreatLevel.ELEVATED
 
     async def request_confirmation(
         self,

--- a/jarvis/core/confirmation_manager.py
+++ b/jarvis/core/confirmation_manager.py
@@ -43,8 +43,8 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
 from ..config import Config
-from .threat_level import ThreatLevel, classify
 from .logger import get_logger
+from .threat_level import ThreatLevel, classify
 
 logger = get_logger(__name__)
 

--- a/jarvis/core/threat_level.py
+++ b/jarvis/core/threat_level.py
@@ -1,0 +1,81 @@
+"""Host-side threat classification for the TLA (Threat Level Access) gate.
+
+The confirmation gate must not let a dangerous tool escape approval simply by
+omitting ``confirmation_required`` from its manifest. The *host* assigns a
+minimum threat level to a tool based on what it can do — e.g. arbitrary command
+execution can escalate via ``sudo`` — and the gate confirms at or above a
+threshold. A manifest may RAISE a tool's level (declare it more dangerous, or
+opt in via ``confirmation_required``) but can never lower it below the host
+floor.
+
+Classification is per TOOL, not per server: a server's dangerous tool
+(``run_command``) is gated while its safe siblings (``web_search``) are not.
+
+The four tiers mirror the kernel policy engine's vocabulary so the userspace
+gate and the OS embodiment speak the same language.
+"""
+
+from enum import IntEnum
+from typing import Any, Dict, Optional
+
+
+class ThreatLevel(IntEnum):
+    SAFE = 0
+    ELEVATED = 1
+    DANGEROUS = 2
+    FORBIDDEN = 3
+
+
+# Bare tool names the host always treats as at least DANGEROUS: arbitrary
+# command / script execution, which can escalate (sudo) or mutate the system.
+# Author-proof — a manifest cannot lower a tool below this floor.
+HOST_DANGEROUS_TOOLS = frozenset(
+    {
+        "run_command",
+        "execute_command",
+        "run_script",
+        "execute_script",
+        "exec",
+        "shell",
+        "bash",
+        "sh",
+        "spawn",
+    }
+)
+
+_MANIFEST_LEVELS = {
+    "safe": ThreatLevel.SAFE,
+    "elevated": ThreatLevel.ELEVATED,
+    "dangerous": ThreatLevel.DANGEROUS,
+    "forbidden": ThreatLevel.FORBIDDEN,
+}
+
+
+def _host_floor(tool_name: Optional[str]) -> ThreatLevel:
+    if not tool_name:
+        return ThreatLevel.SAFE
+    bare = tool_name.split(".")[-1].strip().lower()
+    return ThreatLevel.DANGEROUS if bare in HOST_DANGEROUS_TOOLS else ThreatLevel.SAFE
+
+
+def _declared(tool_metadata: Dict[str, Any]) -> ThreatLevel:
+    raw = tool_metadata.get("threat_level")
+    if isinstance(raw, str) and raw.strip().lower() in _MANIFEST_LEVELS:
+        return _MANIFEST_LEVELS[raw.strip().lower()]
+    # Legacy opt-in: `confirmation_required` means "at least ELEVATED".
+    if tool_metadata.get("confirmation_required"):
+        return ThreatLevel.ELEVATED
+    return ThreatLevel.SAFE
+
+
+def classify(
+    tool_name: Optional[str],
+    tool_metadata: Optional[Dict[str, Any]] = None,
+) -> ThreatLevel:
+    """Effective threat level = ``max(host floor, manifest declaration)``.
+
+    The manifest may raise a tool's level but can never lower it below the host
+    floor, so a dangerous tool cannot opt out of gating.
+    """
+    metadata = tool_metadata or {}
+    return ThreatLevel(max(int(_host_floor(tool_name)), int(_declared(metadata))))

--- a/jarvis/runtime/dispatch_flow.py
+++ b/jarvis/runtime/dispatch_flow.py
@@ -543,7 +543,7 @@ async def dispatch_send(
         tool_name = f"{task.get('server', '?')}.{task.get('tool', '?')}"
         tool_meta = await get_tool_metadata(app, logger, task)
 
-        if app.confirmation.should_confirm(tool_meta):
+        if app.confirmation.should_confirm(tool_meta, tool_name=task.get("tool")):
             notification_silent = tool_meta.get(
                 "notification_silent",
                 Config.NOTIFICATION_SILENT,

--- a/tests/test_threat_level.py
+++ b/tests/test_threat_level.py
@@ -1,0 +1,67 @@
+"""Host-side threat classification + confirmation-gate floor (Project-JARVIS #159).
+
+The bundled shell server's `run_command` (which runs `sudo -A`) declares no
+`confirmation_required`, so under the default `smart` mode it previously
+bypassed the confirmation gate. The host now assigns a minimum threat level per
+tool, so a dangerous tool cannot opt out of gating.
+"""
+
+import pytest
+
+from jarvis.core.confirmation_manager import ConfirmationManager
+from jarvis.core.threat_level import ThreatLevel, classify
+
+
+@pytest.mark.unit
+class TestClassify:
+    def test_command_execution_is_dangerous_without_manifest_flag(self):
+        # The exact #159 case: run_command declares nothing, must be DANGEROUS.
+        assert classify("run_command", {}) == ThreatLevel.DANGEROUS
+
+    def test_benign_tool_is_safe(self):
+        assert classify("web_search", {}) == ThreatLevel.SAFE
+
+    def test_manifest_cannot_lower_below_host_floor(self):
+        assert classify("run_command", {"threat_level": "safe"}) == ThreatLevel.DANGEROUS
+
+    def test_manifest_can_raise_a_benign_tool(self):
+        assert classify("web_search", {"threat_level": "dangerous"}) == ThreatLevel.DANGEROUS
+
+    def test_confirmation_required_is_at_least_elevated(self):
+        assert classify("web_search", {"confirmation_required": True}) == ThreatLevel.ELEVATED
+
+    def test_server_qualified_name_is_handled(self):
+        assert classify("shellmcp.run_command", {}) == ThreatLevel.DANGEROUS
+
+    def test_none_tool_name_is_safe(self):
+        assert classify(None, {}) == ThreatLevel.SAFE
+
+
+@pytest.mark.unit
+class TestShouldConfirmFloor:
+    def test_dangerous_tool_confirmed_in_smart_mode_without_flag(self, monkeypatch):
+        monkeypatch.setattr("jarvis.config.Config.CONFIRMATION_MODE", "smart")
+        mgr = ConfirmationManager()
+        # Empty metadata — the previous behavior skipped confirmation entirely.
+        assert mgr.should_confirm({}, tool_name="run_command") is True
+
+    def test_safe_tool_not_confirmed_in_smart_mode(self, monkeypatch):
+        monkeypatch.setattr("jarvis.config.Config.CONFIRMATION_MODE", "smart")
+        mgr = ConfirmationManager()
+        assert mgr.should_confirm({}, tool_name="web_search") is False
+
+    def test_confirmation_required_still_gates_in_smart_mode(self, monkeypatch):
+        monkeypatch.setattr("jarvis.config.Config.CONFIRMATION_MODE", "smart")
+        mgr = ConfirmationManager()
+        assert mgr.should_confirm({"confirmation_required": True}, tool_name="web_search") is True
+
+    def test_ask_all_confirms_everything(self, monkeypatch):
+        monkeypatch.setattr("jarvis.config.Config.CONFIRMATION_MODE", "ask_all")
+        mgr = ConfirmationManager()
+        assert mgr.should_confirm({}, tool_name="web_search") is True
+
+    def test_allow_all_bypasses_even_dangerous(self, monkeypatch):
+        # allow_all remains the documented power-user escape hatch.
+        monkeypatch.setattr("jarvis.config.Config.CONFIRMATION_MODE", "allow_all")
+        mgr = ConfirmationManager()
+        assert mgr.should_confirm({}, tool_name="run_command") is False

--- a/tests/test_threat_level.py
+++ b/tests/test_threat_level.py
@@ -1,15 +1,22 @@
 """Host-side threat classification + confirmation-gate floor (Project-JARVIS #159).
 
-The bundled shell server's `run_command` (which runs `sudo -A`) declares no
-`confirmation_required`, so under the default `smart` mode it previously
+The bundled shell server's ``run_command`` (which runs ``sudo -A``) declares no
+``confirmation_required``, so under the default ``smart`` mode it previously
 bypassed the confirmation gate. The host now assigns a minimum threat level per
 tool, so a dangerous tool cannot opt out of gating.
 """
 
 import pytest
 
+import jarvis.core.confirmation_manager as cm
 from jarvis.core.confirmation_manager import ConfirmationManager
 from jarvis.core.threat_level import ThreatLevel, classify
+
+
+def _mode(monkeypatch, mode):
+    # Patch the Config reference the module under test actually reads, so the
+    # override is robust to module-identity quirks under editable installs.
+    monkeypatch.setattr(cm.Config, "CONFIRMATION_MODE", mode)
 
 
 @pytest.mark.unit
@@ -22,13 +29,21 @@ class TestClassify:
         assert classify("web_search", {}) == ThreatLevel.SAFE
 
     def test_manifest_cannot_lower_below_host_floor(self):
-        assert classify("run_command", {"threat_level": "safe"}) == ThreatLevel.DANGEROUS
+        assert (
+            classify("run_command", {"threat_level": "safe"}) == ThreatLevel.DANGEROUS
+        )
 
     def test_manifest_can_raise_a_benign_tool(self):
-        assert classify("web_search", {"threat_level": "dangerous"}) == ThreatLevel.DANGEROUS
+        assert (
+            classify("web_search", {"threat_level": "dangerous"})
+            == ThreatLevel.DANGEROUS
+        )
 
     def test_confirmation_required_is_at_least_elevated(self):
-        assert classify("web_search", {"confirmation_required": True}) == ThreatLevel.ELEVATED
+        assert (
+            classify("web_search", {"confirmation_required": True})
+            == ThreatLevel.ELEVATED
+        )
 
     def test_server_qualified_name_is_handled(self):
         assert classify("shellmcp.run_command", {}) == ThreatLevel.DANGEROUS
@@ -40,28 +55,31 @@ class TestClassify:
 @pytest.mark.unit
 class TestShouldConfirmFloor:
     def test_dangerous_tool_confirmed_in_smart_mode_without_flag(self, monkeypatch):
-        monkeypatch.setattr("jarvis.config.Config.CONFIRMATION_MODE", "smart")
+        _mode(monkeypatch, "smart")
         mgr = ConfirmationManager()
         # Empty metadata — the previous behavior skipped confirmation entirely.
         assert mgr.should_confirm({}, tool_name="run_command") is True
 
     def test_safe_tool_not_confirmed_in_smart_mode(self, monkeypatch):
-        monkeypatch.setattr("jarvis.config.Config.CONFIRMATION_MODE", "smart")
+        _mode(monkeypatch, "smart")
         mgr = ConfirmationManager()
         assert mgr.should_confirm({}, tool_name="web_search") is False
 
     def test_confirmation_required_still_gates_in_smart_mode(self, monkeypatch):
-        monkeypatch.setattr("jarvis.config.Config.CONFIRMATION_MODE", "smart")
+        _mode(monkeypatch, "smart")
         mgr = ConfirmationManager()
-        assert mgr.should_confirm({"confirmation_required": True}, tool_name="web_search") is True
+        assert (
+            mgr.should_confirm({"confirmation_required": True}, tool_name="web_search")
+            is True
+        )
 
     def test_ask_all_confirms_everything(self, monkeypatch):
-        monkeypatch.setattr("jarvis.config.Config.CONFIRMATION_MODE", "ask_all")
+        _mode(monkeypatch, "ask_all")
         mgr = ConfirmationManager()
         assert mgr.should_confirm({}, tool_name="web_search") is True
 
     def test_allow_all_bypasses_even_dangerous(self, monkeypatch):
         # allow_all remains the documented power-user escape hatch.
-        monkeypatch.setattr("jarvis.config.Config.CONFIRMATION_MODE", "allow_all")
+        _mode(monkeypatch, "allow_all")
         mgr = ConfirmationManager()
         assert mgr.should_confirm({}, tool_name="run_command") is False


### PR DESCRIPTION
Closes #159.

## Problem
Under the default `CONFIRMATION_MODE=smart`, `should_confirm` only gated tools that declared `confirmation_required` in their manifest (`confirmation_manager.py:139`). The bundled shell server declares none on `run_command` — which runs `sudo -A` — so LLM-issued privileged shell commands bypassed the JARVIS confirmation gate entirely (only the ksshaskpass sudo password stood in the way). The mitigation for threats #4/#5 did not cover its single highest-risk tool.

## Fix — the host sets the floor
New `jarvis/core/threat_level.py`: the **host** assigns a minimum threat level per tool, so a dangerous tool can't opt out of gating.

- Tiers `SAFE / ELEVATED / DANGEROUS / FORBIDDEN` (matching the kernel policy engine's vocabulary — TLA = Threat Level Access, userspace side).
- Command-execution tools (`run_command`, `execute_command`, `exec`, `shell`, …) are floored at **DANGEROUS**.
- A manifest may **raise** a tool's level (`threat_level` field, or legacy `confirmation_required` → ELEVATED) but **never lower it below the host floor**.
- Classification is **per tool** — a server's safe tools (`web_search`) are unaffected by a dangerous sibling (`run_command`). (This is why per-server declaration was the wrong model.)

`should_confirm` now confirms at `ELEVATED`+ in smart mode; `allow_all` / `ask_all` are unchanged.

### Before / after
> "clean up my old logs" → LLM dispatches `shellmcp.run_command` `sudo rm -rf /var/log/*.old`
> - **before:** dispatched with no JARVIS prompt (only ksshaskpass, if sudo creds weren't cached)
> - **after:** 🔒 **Threat Level Access [DANGEROUS]** — "run `sudo rm -rf /var/log/*.old`?" → **Allow / Deny**

## Testing
- `pytest tests/test_threat_level.py` → **12 passed** (classifier: dangerous-without-flag, benign-safe, manifest-can't-lower-floor, manifest-can-raise, `confirmation_required`→ELEVATED, server-qualified name; gate: dangerous-confirmed-in-smart, safe-not-confirmed, ask_all, allow_all-bypass).

## Scope
Payload inspection (a *safe* tool handed a *dangerous* command, e.g. sudo in params) is the additive next step — deferred to #162.

---
_Generated by [Claude Code](https://claude.ai/code/session_017UmsHxJK4oRYKcHHrny3g4)_