### PR TITLE
Post-review remediation: sudo fix (#158), TLA naming, boundary enforcement (#165)

### DIFF
--- a/docs/SECURITY-ARCHITECTURE.md
+++ b/docs/SECURITY-ARCHITECTURE.md
@@ -24,25 +24,27 @@ OS embodiment, not the core.
 | 1 | Malicious MCP Servers | registry vetting + `dmcp` manifest-hash verify + agent source-confinement | **implemented** (official tier not yet populated) |
 | 2 | Prompt Injection | dispatch 128-bit boundary nonce + `input_guard` on direct input | **partial** — dispatch tags output; the daemon does not yet verify the tag |
 | 3 | Misleading MCP Server Usage | official-tier review of tool descriptions + structured schema | **partial** |
-| 4 | Unauthorized Sudo via MCP | userspace Tool-Level-Action confirmation gate | **implemented**, with the `shellmcp` gap (#159) |
+| 4 | Unauthorized Sudo via MCP | userspace Threat-Level-Access confirmation gate | **implemented**, with the `shellmcp` gap (#159) |
 | 5 | Sudo Capability Exploitation | same confirmation gate, goal-scoped | **implemented**, same gap |
 | 6 | Bloated Context | daemon two-tier context + dispatch rolling window + contextor pruning | **partial** — constraint preservation not implemented |
 | — | Kernel 4-tier policy engine (`/dev/jarvis`) | linux-jarvisos + daemon `KernelClient` | **OS-side** — not consulted from the daemon today |
 
 ### On the "TLA" acronym (important for the paper)
 
-The confirmation gate in this repo is **"TLA = Tool-Level Action" confirmation**
+**TLA = Threat Level Access.** It is a **userspace**, non-blocking,
+human-in-the-loop confirmation gate on the dispatch path
 (`docs/tla-confirmation-design.md`, `jarvis/core/confirmation_manager.py`,
-`jarvis/runtime/dispatch_flow.py`): a **userspace**, non-blocking,
-human-in-the-loop gate on the dispatch path — the LLM is deliberately kept out
-of the confirmation loop so it cannot misrepresent an action. The website and
-earlier drafts expand TLA as **"Threat Level Access"** and describe it as
-**OS-enforced**; that phrasing does not match the code. The enforcement of
-record is the **userspace Tool-Level-Action gate**. The kernel `/dev/jarvis`
-policy engine is part of the OS embodiment and is **not** consulted from the
-daemon today — `KernelClient.policy_check` and `get_api_key` have no callers in
-the execution path. For publication: pick one expansion of "TLA," and use
-"userspace confirmation gate," not "OS-enforced," for the current core behavior.
+`jarvis/runtime/dispatch_flow.py`) — the LLM is deliberately kept out of the
+confirmation loop so it cannot misrepresent an action. Every privileged tool
+call is evaluated against a host-assigned threat level and escalation requires
+explicit out-of-band user approval.
+
+Enforcement is **in userspace** (the JARVIS daemon), so do **not** describe the
+current core behavior as "OS-enforced." The kernel `/dev/jarvis` policy engine
+is part of the OS embodiment and is **not** consulted from the daemon today —
+`KernelClient.policy_check` and `get_api_key` have no callers in the execution
+path. (Earlier drafts expanded TLA as "Tool-Level Action"; "Threat Level
+Access" is now the canonical expansion.)
 
 ---
 

--- a/docs/tla-confirmation-design.md
+++ b/docs/tla-confirmation-design.md
@@ -1,4 +1,4 @@
-# Tool-Level Action (TLA) Confirmation System
+# Threat Level Access (TLA) Confirmation System
 
 ## Overview
 

--- a/jarvis/.env.example
+++ b/jarvis/.env.example
@@ -185,7 +185,7 @@ ALLOW_EMBEDDING_SEARCH=true
 CONTEXTOR_BINARY=contextor
 
 # ===========================================
-# Tool-Level Confirmation
+# Threat Level Access (TLA) Confirmation
 # ===========================================
 # Confirmation mode for tool execution:
 # - "allow_all": never ask (power users / trusted environments)

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -217,7 +217,7 @@ class Config:
         os.path.join(JARVIS_DATA_DIR, "jarvis.sock"),
     )
 
-    # Tool-Level Action (TLA) Confirmation
+    # Threat Level Access (TLA) Confirmation
     # - "allow_all": never ask, run everything (power users / trusted environments)
     # - "smart":     only ask when tool has confirmation_required=true (default)
     # - "ask_all":   ask for every tool call, regardless of metadata

--- a/jarvis/core/confirmation_manager.py
+++ b/jarvis/core/confirmation_manager.py
@@ -1,5 +1,5 @@
 """
-Confirmation Manager — Tool-Level Action (TLA) confirmation gate.
+Confirmation Manager — Threat Level Access (TLA) confirmation gate.
 
 MCP server developers declare ``confirmation_required: true`` on tools that
 need user approval before execution.  The ConfirmationManager reads that

--- a/jarvis/core/sudo_manager.py
+++ b/jarvis/core/sudo_manager.py
@@ -1,0 +1,112 @@
+"""System-side sudo toggle for the JARVIS user (Project-JARVIS #158).
+
+``enable_sudo`` / ``disable_sudo`` install or remove a sudoers drop-in that
+grants the invoking user sudo; ``is_sudo_enabled`` reports whether that drop-in
+is present so ``jarvis sudo`` can reconcile the real system state against the
+``JARVIS_SUDO_ENABLED`` config preference.
+
+The drop-in is **password-required** on purpose. ``shellmcp`` escalates via
+``sudo -A`` + ksshaskpass, and the GUI password prompt is the security boundary
+the architecture depends on — a ``NOPASSWD`` rule would remove it. This toggle
+makes the grant explicit and jarvis-managed; it never weakens the prompt.
+
+Writing to ``/etc/sudoers.d`` is guarded: root is required, the candidate file
+is validated with ``visudo -c`` before it is installed, and the swap is atomic
+(temp file + ``os.replace``, mode ``0440``). A malformed sudoers file can lock a
+user out of sudo entirely, so validation is not optional.
+"""
+
+import getpass
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+SUDOERS_DROPIN = Path("/etc/sudoers.d/jarvis")
+
+
+def _target_user() -> str:
+    # Under `sudo jarvis sudo enable` the process runs as root; act on the
+    # original user, recorded by sudo in SUDO_USER, not on root.
+    return os.environ.get("SUDO_USER") or getpass.getuser()
+
+
+def _validate_sudoers(path: Path) -> bool:
+    visudo = shutil.which("visudo") or "/usr/sbin/visudo"
+    try:
+        result = subprocess.run(
+            [visudo, "-c", "-f", str(path)],
+            capture_output=True,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+def _install_dropin(content: str) -> bool:
+    directory = SUDOERS_DROPIN.parent
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        # A dotted name so sudo's `#includedir` skips this file while it exists
+        # (sudo ignores drop-ins containing a `.`), keeping the swap atomic.
+        fd, tmp_name = tempfile.mkstemp(prefix=".jarvis.", dir=str(directory))
+    except OSError:
+        return False
+
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, 0o440)
+        if not _validate_sudoers(tmp):
+            return False
+        os.replace(tmp, SUDOERS_DROPIN)
+        return True
+    except OSError:
+        return False
+    finally:
+        # os.replace consumed tmp on success; clean up on every failure path.
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
+def is_sudo_enabled() -> bool:
+    """Return whether the jarvis-managed sudoers drop-in is installed.
+
+    Read-only and root-free — reflects real system state so the CLI can flag
+    when it diverges from the ``JARVIS_SUDO_ENABLED`` preference.
+    """
+    return SUDOERS_DROPIN.exists()
+
+
+def enable_sudo() -> bool:
+    """Install a password-required sudoers drop-in for the invoking user.
+
+    Returns ``False`` without modifying anything when not run as root or when
+    the candidate file fails ``visudo`` validation.
+    """
+    if os.geteuid() != 0:
+        return False
+    return _install_dropin(f"{_target_user()} ALL=(ALL) ALL\n")
+
+
+def disable_sudo() -> bool:
+    """Remove the jarvis-managed sudoers drop-in. Idempotent.
+
+    Returns ``False`` when not run as root; ``True`` when the drop-in is absent
+    or successfully removed.
+    """
+    if os.geteuid() != 0:
+        return False
+    try:
+        SUDOERS_DROPIN.unlink(missing_ok=True)
+        return True
+    except OSError:
+        return False

--- a/tests/test_sudo_manager.py
+++ b/tests/test_sudo_manager.py
@@ -1,0 +1,97 @@
+"""Tests for the sudo toggle (Project-JARVIS #158).
+
+``sudo_manager`` writes to ``/etc/sudoers.d`` in production; every test here
+redirects ``SUDOERS_DROPIN`` to a tmp path and fakes ``geteuid``/validation so
+nothing touches the real system and root is never required.
+"""
+
+import getpass
+import os
+
+import pytest
+
+import jarvis.core.sudo_manager as sm
+
+
+@pytest.mark.unit
+class TestIsSudoEnabled:
+    def test_reflects_dropin_presence(self, monkeypatch, tmp_path):
+        dropin = tmp_path / "jarvis"
+        monkeypatch.setattr(sm, "SUDOERS_DROPIN", dropin)
+        assert sm.is_sudo_enabled() is False
+        dropin.write_text("user ALL=(ALL) ALL\n")
+        assert sm.is_sudo_enabled() is True
+
+
+@pytest.mark.unit
+class TestTargetUser:
+    def test_prefers_sudo_user(self, monkeypatch):
+        monkeypatch.setenv("SUDO_USER", "yakup")
+        assert sm._target_user() == "yakup"
+
+    def test_falls_back_to_current_user(self, monkeypatch):
+        monkeypatch.delenv("SUDO_USER", raising=False)
+        assert sm._target_user() == getpass.getuser()
+
+
+@pytest.mark.unit
+class TestRootGating:
+    def test_enable_is_a_noop_without_root(self, monkeypatch, tmp_path):
+        dropin = tmp_path / "jarvis"
+        monkeypatch.setattr(sm, "SUDOERS_DROPIN", dropin)
+        monkeypatch.setattr(os, "geteuid", lambda: 1000)
+        assert sm.enable_sudo() is False
+        assert not dropin.exists()
+
+    def test_disable_is_a_noop_without_root(self, monkeypatch, tmp_path):
+        dropin = tmp_path / "jarvis"
+        dropin.write_text("x")
+        monkeypatch.setattr(sm, "SUDOERS_DROPIN", dropin)
+        monkeypatch.setattr(os, "geteuid", lambda: 1000)
+        assert sm.disable_sudo() is False
+        assert dropin.exists()
+
+
+@pytest.mark.unit
+class TestInstallAndRemove:
+    def test_enable_installs_validated_dropin(self, monkeypatch, tmp_path):
+        dropin = tmp_path / "sudoers.d" / "jarvis"
+        monkeypatch.setattr(sm, "SUDOERS_DROPIN", dropin)
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+        monkeypatch.setattr(sm, "_validate_sudoers", lambda p: True)
+        monkeypatch.setenv("SUDO_USER", "yakup")
+
+        assert sm.enable_sudo() is True
+        assert dropin.exists()
+        assert "yakup ALL=(ALL) ALL" in dropin.read_text()
+        assert oct(dropin.stat().st_mode & 0o777) == "0o440"
+
+    def test_enable_rejects_invalid_sudoers_and_leaves_no_temp(
+        self, monkeypatch, tmp_path
+    ):
+        dropin = tmp_path / "sudoers.d" / "jarvis"
+        monkeypatch.setattr(sm, "SUDOERS_DROPIN", dropin)
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+        monkeypatch.setattr(sm, "_validate_sudoers", lambda p: False)
+
+        assert sm.enable_sudo() is False
+        assert not dropin.exists()
+        # The rejected candidate must not be left behind in /etc/sudoers.d.
+        assert list((tmp_path / "sudoers.d").iterdir()) == []
+
+    def test_disable_removes_dropin(self, monkeypatch, tmp_path):
+        directory = tmp_path / "sudoers.d"
+        directory.mkdir()
+        dropin = directory / "jarvis"
+        dropin.write_text("yakup ALL=(ALL) ALL\n")
+        monkeypatch.setattr(sm, "SUDOERS_DROPIN", dropin)
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+
+        assert sm.disable_sudo() is True
+        assert not dropin.exists()
+
+    def test_disable_is_idempotent_when_absent(self, monkeypatch, tmp_path):
+        dropin = tmp_path / "sudoers.d" / "jarvis"
+        monkeypatch.setattr(sm, "SUDOERS_DROPIN", dropin)
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+        assert sm.disable_sudo() is True


### PR DESCRIPTION
Post-review remediation for Project-JARVIS. Three items on the one review branch (`claude/org-projects-review-q93mj3`), newest first.

---

## 3. Daemon-side boundary enforcement — closes #165

The Cryptographic Boundary Protocol (Threat #2, Prompt Injection) was only half-built: dispatch wraps tool output in an unforgeable 128-bit-nonce boundary, but nothing on the **consuming** side enforced it — the daemon passed EXIT bodies through as text, and the system prompt never told the LLM that wrapped content is untrusted.

- **System-prompt enforcement** (`config.py`, all four tool-consuming prompts — both ROOT variants + both DISPATCH variants): the LLM is told everything inside a `[hash=H] 200 <H>…</H>` boundary is untrusted external data, never instructions, and to treat `UNVERIFIED` output as suspect.
- **Structural verification** (`jarvis/dispatch/boundary.py`): `verify_boundary()` confirms an EXIT body is wrapped by the nonce dispatch recorded for that PID (trusted structured nonce is authoritative; falls back to the inline prefix hash). Wired into `event_merger` via `verify_and_mark()` — every EXIT/TIMEOUT is verified as ingested; a missing/mismatched tag is logged and the body gets an in-band `UNVERIFIED` marker so ROOT sees it even if it ignores the metadata flag.
- Additive and fail-open: verification never raises and never drops signals. **18 new unit tests** incl. an injection-breakout case and a guard that all four prompts carry the rule.

## 2. Fix `jarvis sudo` crash — closes #158

`jarvis/cli.py` imported `jarvis.core.sudo_manager` (`enable_sudo`, `disable_sudo`, `is_sudo_enabled`), which didn't exist — every `jarvis sudo enable/disable/status` raised `ModuleNotFoundError`. Adds `sudo_manager.py`: a **password-required** sudoers.d drop-in for the invoking user (matches the existing `sudo -A`/ksshaskpass design — a `NOPASSWD` rule would remove the security boundary), root-gated, `visudo -c`-validated, atomic `0440` write. Verified end-to-end against real `visudo`.

## 1. Unify the "TLA" acronym on "Threat Level Access"

Code comments and doc titles expanded TLA two ways; unified on the canonical expansion (also now the accurate description after the `#159` classifier landed). `config.py`, `.env.example`, `confirmation_manager.py`, `docs/tla-confirmation-design.md`, `docs/SECURITY-ARCHITECTURE.md`.

---

## Verification
- `black --check`, `isort --check-only`, `flake8 --select=E9,F63,F7,F82` clean on all touched files.
- CI test selection (`pytest -m "not integration and not manual and not slow"`): **199 passed** (incl. the 18 boundary tests + 9 sudo tests). The 12 `test_integration_llm.py` failures are pre-existing (stale `LLM.__init__` signature) and excluded from CI — not touched here.

> These three landed on one branch because the review assigns a single working branch per repo. Happy to split if you'd rather review them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)