### PR TITLE
Re-land: preserve PATH on sidecar spawn (#170) + macOS voice markers (#172)

### DIFF
--- a/jarvis/dispatch/transport.py
+++ b/jarvis/dispatch/transport.py
@@ -14,13 +14,17 @@ async def connect(adapter: Any, logger: Logger) -> None:
     """Connect DispatchAdapter to dispatch serve over stdio MCP."""
     try:
         from mcp import ClientSession, StdioServerParameters
-        from mcp.client.stdio import stdio_client
+        from mcp.client.stdio import get_default_environment, stdio_client
 
         logger.info(f"Dispatch: Spawning '{Config.DISPATCH_BINARY} serve'")
         params = StdioServerParameters(
             command=Config.DISPATCH_BINARY,
             args=["serve"],
-            env={"RUST_LOG": "dispatch=warn"},
+            # Merge onto the SDK's default env (PATH, HOME, ...) rather than
+            # replacing it: a bare env= drops PATH, so the spawned process
+            # resolves binaries against os.defpath only and can't find
+            # ~/.local/bin or Homebrew installs (#170).
+            env={**get_default_environment(), "RUST_LOG": "dispatch=warn"},
         )
         adapter._client = stdio_client(params)
         read, write = await adapter._client.__aenter__()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ dependencies = [
 [project.optional-dependencies]
 # Voice input dependencies (Speech-to-Text)
 voice-input = [
-    "vosk>=0.3.45",
+    "vosk>=0.3.45; sys_platform != 'darwin'",
+    "vosk>=0.3.44; sys_platform == 'darwin'",
     "sounddevice>=0.5.2",
     "numpy>=2.2.0",
 ]
@@ -60,7 +61,8 @@ voice-output = [
 
 # Complete voice support (includes both input and output)
 voice = [
-    "vosk>=0.3.45",
+    "vosk>=0.3.45; sys_platform != 'darwin'",
+    "vosk>=0.3.44; sys_platform == 'darwin'",
     "piper-tts>=1.3.0",
     "sounddevice>=0.5.2",
     "onnxruntime>=1.22.0",
@@ -73,7 +75,7 @@ voice = [
 # it needs both the mic path and the TTS reference signal.
 voice-aec = [
     "project-jarvis[voice]",
-    "aec-audio-processing>=1.0.1",
+    "aec-audio-processing>=1.0.1; sys_platform == 'win32' or sys_platform == 'linux'",
 ]
 
 # Interactive terminal UI (OpenClaw-style chat with session sidebar).

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,8 @@ httpx>=0.28.1
 pathspec>=0.12.1
 
 # Voice input dependencies (optional - install with jarvis-ai[voice-input])
-vosk>=0.3.45
+vosk>=0.3.45; sys_platform != 'darwin'
+vosk>=0.3.44; sys_platform == 'darwin'
 sounddevice>=0.5.2
 numpy>=2.2.0
 


### PR DESCRIPTION
⚠️ **Re-lands two fixes dropped from the #167 merge.** #167 merged with only the spec commit — the two fix commits I'd pushed to the same branch never reached main (a proxy-to-GitHub propagation lag left PR #167's head at the spec commit at merge time). Both are re-applied cleanly onto the post-#167 main.

Two commits:

## `258d4d4` — preserve PATH on sidecar spawn — closes #170
`StdioServerParameters(env={"RUST_LOG": …})` **replaces** the mcp SDK's default environment, dropping `PATH` so the child resolves binaries against `os.defpath` only — breaks `~/.local/bin` and Homebrew installs on every OS. Now merges onto `get_default_environment()`.

## `245a251` — platform-mark voice extras so macOS installs — closes #172
`vosk>=0.3.45` has no macOS wheel (0.3.44 is the newest darwin build) → `pip install .[voice]`/`[all]` fails to resolve on macOS. Split the pin with environment markers; gate `aec-audio-processing` (Win/Linux wheels only) off macOS. Mirrored in `requirements.txt`.

## Verification
`pyproject.toml` parses, markers validate via `packaging`, `transport.py` lint clean, CI selection **207 passed**.

> **Please confirm before merging that this PR's head shows `245a251`** — that's the guard against the recurring drop. Closes #170, #172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017UmsHxJK4oRYKcHHrny3g4)_