### PR TITLE
legal: GPLv2 precedent + community ratification for fee changes and revocations

### DIFF
--- a/legal/SCCL-v1.md
+++ b/legal/SCCL-v1.md
@@ -14,7 +14,9 @@ This License also exists because **unpaid maintainers are a security vulnerabili
 
 This License offers commercial entities an alternative to the GNU Affero General Public License, Version 3 ("AGPLv3"), under which the Software is also made available. Entities that do not wish to comply with AGPLv3's source disclosure requirements may instead operate under this License, subject to the conditions herein.
 
-The defining feature of this License is **Board-governed commercial access**: the Organization's Governing Board retains unilateral authority to grant, condition, and revoke commercial licenses, ensuring that every commercial use of the Software remains aligned with the Project's values, ethics, and ecosystem.
+**Precedent.** The foundational precedent for this License is Linux's GPLv2: the principle that whoever builds on community-authored software owes the community visibility into what they built, not just permission to use it. GPLv2 enforces that principle at the point of distribution. AGPLv3 — this Project's default license — closes the network-service loophole GPLv2 leaves open, extending the same obligation to software offered only as a hosted service. This License extends the principle one step further, for one specific case: hyperscale commercial operators (the scale of a Microsoft, Google, or Amazon, not a solo developer or small business) who want to avoid AGPLv3's source-disclosure obligations. Historical precedent — Elasticsearch, MongoDB, and Redis each relicensing under SSPL or comparable terms after cloud providers repackaged their work as competing managed services without contributing back — is exactly the dynamic this License is designed to prevent for this Project. The mechanism differs from Elastic's and MongoDB's: instead of a blanket relicense that also burdens small users, this License offers commercial entities of any size a choice — comply with AGPLv3, or pay into and contribute back to the commons under the terms below. Entities that never trigger this License (individuals, small businesses, anyone complying with AGPLv3) are entirely unaffected by it.
+
+The defining feature of this License is **Board-governed commercial access**: the Organization's Governing Board retains authority to grant, condition, and revoke commercial licenses — subject to the community ratification checks in Articles 4 and 6 below — ensuring that every commercial use of the Software remains aligned with the Project's values, ethics, and ecosystem, and that decisions of consequence rest with the community that built the Software, not with any single licensee or corporation.
 
 ---
 
@@ -134,6 +136,14 @@ The Board shall communicate the applicable Revenue Basis to the Licensee in writ
 
 **4.2 Fee Calculation.** The Annual License Fee is calculated in accordance with the Fee Formula set out in Appendix A to this License, using the Revenue Basis determined by the Board for the Licensee (Definition 1.12). The Organization may update the Fee Formula with ninety (90) days' written notice, provided that no increase shall take effect mid-term of any paid year. Changes to the Licensee's Revenue Basis take effect at the next annual renewal.
 
+**4.2.1 Community Ratification of Fee Formula Changes.** A change to the Fee Formula's constants or ranges (K₁, K₂, the inflation buffer, or the fund allocation percentages in Article 4.7) is a decision reserved for the community, not the Board alone, from Governance Stage 3 onward:
+
+  (a) At **Stage 3**, the Board must publish the proposed change and its rationale at least ninety (90) days before it would take effect. If, within that notice period, **fifteen percent (15%)** of Active Contributors petition against the change (Organization Charter B.9.3), the change is stayed and must be put to a ratification poll of Active Contributors; a **simple majority** against blocks the change from taking effect.
+
+  (b) At **Stage 4**, every Fee Formula change requires ratification by the Governance Pool under the standard binding-vote mechanism (Organization Charter B.9.4) before it may take effect; the Board's role is to propose and administer, not to unilaterally decide.
+
+  (c) At **Stages 1–2**, the Board's authority under this Article is unencumbered, consistent with Organization Charter B.9.1–B.9.2.
+
 **4.3 Payment Process.** The Organization shall issue an invoice or fee statement no fewer than thirty (30) days before each payment is due. Payment terms and accepted methods are as specified in the invoice.
 
 **4.4 Self-Reporting.** The Licensee shall provide to the Organization, on an annual basis, an honest declaration of the figures required to calculate the Fee (including the applicable Revenue Basis figure, ecosystem inclusion factors, and any other data the Board reasonably requires), signed by an authorized officer of the Licensee.
@@ -231,6 +241,16 @@ The Board shall communicate the applicable Revenue Basis to the Licensee in writ
   (d) Failure to comply by the end of the Transition Period exposes the Licensee to enforcement under AGPLv3 and applicable copyright law, including claims for damages for the period of unauthorized commercial use.
 
 **6.7 No Retroactive Fee Refund.** Revocation does not entitle the Licensee to a refund of any fees paid.
+
+**6.8 Contested Revocation Review.** A revocation decision under this Article is a Board determination in the first instance, but is not the Board's alone to finalize once contested:
+
+  (a) A Licensee that disputes a revocation decision, or any **fifteen percent (15%)** of Active Contributors who believe a revocation (or a Board decision *not* to revoke) is inconsistent with Article 3 or the published Decision Principles Document (Organization Charter B.4.1), may petition for Contested Revocation Review within the Cure Period or within thirty (30) days of the Revocation Notice, whichever is later.
+
+  (b) A properly filed petition stays the revocation (if any) pending review, except where the Board has invoked immediate revocation under Article 6.4(b) or 6.4(c) for a documented pattern of bad-faith cure exploitation — in which case the stay does not apply but the review proceeds.
+
+  (c) From **Governance Stage 3** onward, Contested Revocation Review is decided by a binding vote of Active Contributors (simple majority, minimum ten percent (10%) participation, mirroring the mechanics of Organization Charter B.9.4); at **Stages 1–2**, the Board reviews the petition itself and must publish a written response addressing the specific inconsistency alleged, per Charter B.4.2.
+
+  (d) The outcome of a Contested Revocation Review is binding on the Board and is recorded in the public license registry (Article 6.5(c)) alongside the original decision.
 
 ---
 

--- a/legal/SCCL-v1.md
+++ b/legal/SCCL-v1.md
@@ -282,7 +282,9 @@ The Board shall communicate the applicable Revenue Basis to the Licensee in writ
 
 **8.2 Limitation of Liability.** TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THE ORGANIZATION OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR IN CONNECTION WITH THIS LICENSE OR THE SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. THE ORGANIZATION'S AGGREGATE LIABILITY SHALL NOT EXCEED THE TOTAL FEES PAID BY THE LICENSEE IN THE TWELVE (12) MONTHS PRECEDING THE CLAIM.
 
-**8.3 Governing Law and Jurisdiction.** This License shall be governed by and construed in accordance with the laws of **[JURISDICTION TO BE SPECIFIED]**. Any disputes shall be subject to the exclusive jurisdiction of the courts of **[JURISDICTION]**.
+**8.3 Governing Law and Jurisdiction.** This License shall be governed by and construed in accordance with the laws of the **State of Washington, USA**. Any disputes shall be subject to the exclusive jurisdiction of the state and federal courts located in Washington State.
+
+  *Drafting note:* Washington is proposed here — not finalized — because the Project's founding institution (Washington State University, Everett) and founders are based there, making it the most natural state of incorporation for the Organization's 501(c)(3) (Charter B.1.3). This is a placeholder position pending confirmation by actual legal counsel at incorporation (per Issue #83's outstanding checklist item), not a final legal determination. If the Organization ultimately incorporates elsewhere, this Article and Charter B.1.3 must be updated together.
 
 **8.4 Entire Agreement.** This License, together with its Appendices and the documents incorporated by reference ([Organization Charter](organization-charter.md), [CLA](cla.md), [C-Points Methodology](c-points.md)), constitutes the entire agreement between the parties regarding commercial use of the Software and supersedes all prior negotiations, representations, or agreements.
 

--- a/legal/SCCL-v1.md
+++ b/legal/SCCL-v1.md
@@ -1,0 +1,385 @@
+# Sovereign Commons Commercial License (SCCL)
+
+## Version 1.0 — DRAFT
+
+> **Status:** This license is a working draft and has not been reviewed by legal counsel. It is published for transparency, community feedback, and iteration. Do not rely on this document as a binding legal instrument until it is finalized.
+
+---
+
+## Preamble
+
+This license exists because the commons should not be exploited without accountability. Free and open-source software is built by communities, for communities. When commercial entities benefit from that labor, the Organization that stewards the software retains the right to demand alignment with the values that built it.
+
+This License also exists because **unpaid maintainers are a security vulnerability.** Critical open-source infrastructure — software that underpins the internet, financial systems, and national security — is routinely maintained by unpaid volunteers working alone, without resources for security audits, code review, or sustainable development practices. The 2024 XZ Utils backdoor (CVE-2024-3094) demonstrated the consequences: a state-level actor spent years social-engineering a burned-out solo maintainer into handing over commit access, nearly compromising SSH authentication on every Linux server worldwide. The attack did not exploit a technical weakness — it exploited the fact that a critical piece of global infrastructure had no funding, no support structure, and a single point of human failure. This License addresses that structural weakness by making contributor compensation mandatory, not optional. Funded maintainers are resilient maintainers. A sustainable commons is a secure commons.
+
+This License offers commercial entities an alternative to the GNU Affero General Public License, Version 3 ("AGPLv3"), under which the Software is also made available. Entities that do not wish to comply with AGPLv3's source disclosure requirements may instead operate under this License, subject to the conditions herein.
+
+The defining feature of this License is **Board-governed commercial access**: the Organization's Governing Board retains unilateral authority to grant, condition, and revoke commercial licenses, ensuring that every commercial use of the Software remains aligned with the Project's values, ethics, and ecosystem.
+
+---
+
+## Article 1 — Definitions
+
+**1.1 "Organization"** means the legal entity (foundation, non-profit, LLC, or equivalent) that owns or stewards the Software and its ecosystem. The Organization acts as Licensor under this Agreement.
+
+**1.2 "Governing Board"** (or "Board") means the decision-making body of the Organization, responsible for issuing, conditioning, and revoking commercial licenses under this Agreement. The Board's composition and procedures are defined in the [Organization Charter](organization-charter.md).
+
+**1.3 "Licensee"** means the legal entity (company, organization, or individual acting in a commercial capacity) entering into this Agreement with the Organization.
+
+**1.4 "Software"** means the original work of authorship made available under this License, including all source code, object code, documentation, and associated files, as identified at the time of licensing.
+
+**1.5 "Derivative Work"** means any work that is based on, incorporates, modifies, or is derived from the Software, whether in whole or in part.
+
+**1.6 "Contribution"** means any modification, improvement, addition, or Derivative Work submitted by the Licensee for inclusion in the Software.
+
+**1.7 "Ecosystem Alignment"** means the Licensee's ongoing adherence to the behavioral and ethical standards set out in Article 3 of this License.
+
+**1.8 "Annual License Fee"** means the fee payable by the Licensee each year, calculated in accordance with the Fee Formula (Appendix A).
+
+**1.9 "Effective Date"** means the date on which the Licensee executes this Agreement or first exercises rights granted hereunder, whichever is earlier.
+
+**1.10 "Cure Period"** means the period granted to a Licensee to remedy a breach or misalignment before further action is taken, as determined by the Board in accordance with Article 6.3.
+
+**1.11 "Licensee Relationship Index"** means the Board's internal, qualitative assessment of a Licensee's cumulative conduct, compliance history, and relationship with the Organization and its ecosystem. The Index is maintained by the Board as a governance instrument and may inform the Board's exercise of discretion under this License, including but not limited to licensing decisions, Cure Period duration, Revenue Basis, and reinstatement applications.
+
+**1.12 "Revenue Basis"** means the financial figure used to calculate the Annual License Fee under Appendix A. The Revenue Basis is determined by the Board for each Licensee based on the Licensee's Relationship Index, and falls within the following spectrum, ordered by severity of the Board's stance:
+
+  (a) **Profit on the Software** — net profit attributable to products or services incorporating the Software, after directly attributable expenses (most lenient);
+
+  (b) **Profit on the Company** — the Licensee's total net income across all business lines;
+
+  (c) **Profit on the Ecosystem** — combined net income of the Licensee and all affiliated entities (subsidiaries, parent companies, and entities under common control);
+
+  (d) **Revenue on the Software** — gross revenue attributable to products or services incorporating the Software;
+
+  (e) **Revenue on the Company** — the Licensee's total annual gross revenue across all business lines;
+
+  (f) **Revenue on the Ecosystem** — combined total gross revenue of the Licensee and all affiliated entities (most restrictive).
+
+**Note:** The tiers above are ordered by the severity of the Board's intent, not by guaranteed monetary value. In practice, a narrower-scope revenue figure (e.g., Revenue on the Software) may be smaller than a broader-scope profit figure (e.g., Profit on the Ecosystem) depending on the Licensee's business structure. The Board should consider the actual financial impact when selecting a tier, ensuring the chosen basis reflects the appropriate level of accountability rather than simply maximizing the fee.
+
+"Affiliated entities" means any entity that directly or indirectly controls, is controlled by, or is under common control with the Licensee, where "control" means ownership of more than fifty percent (50%) of the voting securities or equivalent ownership interest.
+
+The Board shall communicate the applicable Revenue Basis to the Licensee in writing at the time of license issuance and at each annual renewal.
+
+---
+
+## Article 2 — Grant of Commercial License
+
+**2.1 Activation Threshold.** This License may not be issued to any Licensee until the Project has at least **fifteen (15) Active Contributors** (as defined in the [Organization Charter](organization-charter.md), Section B.2.2, excluding corporate contributions per B.2.3), of which no single legal entity (including its subsidiaries and affiliates) accounts for more than **twenty-five percent (25%)** of total contributions measured by commit authorship over the preceding twelve (12) months. This threshold is verified by the Board at the time of license issuance.
+
+**2.2 Board Approval.** Commercial licenses are granted at the sole discretion of the Governing Board. The Board may accept, reject, or condition any application for a commercial license, and is not required to provide reasons for rejection.
+
+**2.3 Grant.** Subject to the Licensee's continuous compliance with all terms of this License, the Organization hereby grants the Licensee a limited, non-exclusive, non-transferable, non-sublicensable license to:
+
+  (a) Use, copy, and internally deploy the Software for commercial purposes;
+
+  (b) Incorporate the Software into proprietary products and services without the source disclosure obligations imposed by AGPLv3;
+
+  (c) Distribute the Software as part of a commercial product or service, provided all conditions of this License are met.
+
+**2.4 Limitations.** This License does not grant the Licensee the right to:
+
+  (a) Sublicense or transfer rights to third parties;
+
+  (b) Remove, alter, or obscure any copyright, attribution, or licensing notices in the Software;
+
+  (c) Use the Software in any application explicitly prohibited under Article 3.4;
+
+  (d) Claim ownership of the Software or misrepresent its origin.
+
+**2.5 Relationship to AGPLv3.** This License is an alternative to AGPLv3, not a supplement to it. The Licensee operates under either AGPLv3 or this License, not both simultaneously. Upon termination of this License for any reason, the Licensee must either comply with AGPLv3 or cease use of the Software in accordance with Article 7.
+
+---
+
+## Article 3 — Ecosystem Alignment Obligations
+
+**3.1 Code of Conduct.** The Licensee must adhere to the Project's published Code of Conduct at all times during the term of this License. The current Code of Conduct is published at [Project URL] and may be updated by the Organization with thirty (30) days' written notice to the Licensee.
+
+**3.2 Cooperative Conduct.** The Licensee shall:
+
+  (a) Cooperate in good faith with the Organization and its contributors on matters affecting the Software, including security disclosures, compatibility, and integration concerns;
+
+  (b) Respond to reasonable communications from the Organization within fifteen (15) business days;
+
+  (c) Maintain accurate, current contact information registered with the Organization for governance and compliance purposes;
+
+  (d) Publicly attribute the Software in any product or service incorporating it, using the form: *"Built with [Software Name] — [Project URL]"*, or an equivalent form approved in writing by the Organization.
+
+**3.3 Non-Aggression.** The Licensee shall not:
+
+  (a) Initiate or financially support patent, copyright, or trade secret litigation against the Organization, any contributor to the Software, or any other Licensee under this License, where such litigation relates to the Software;
+
+  (b) Engage in competitive actions specifically designed to harm the Project, including but not limited to: funding hostile forks, filing malicious DMCA notices, or coordinating efforts to undermine the Project's community or reputation;
+
+  (c) Misrepresent the nature, origin, or capabilities of the Software in public communications, marketing, or regulatory filings.
+
+**3.4 Prohibited Uses.** Regardless of all other terms, the Licensee shall not deploy or incorporate the Software in systems or applications primarily designed to:
+
+  (a) Conduct mass surveillance of individuals without their explicit, informed consent;
+
+  (b) Develop or operate autonomous weapons systems;
+
+  (c) Engage in the unlawful collection, aggregation, or sale of personal data;
+
+  (d) Suppress, censor, or manipulate political speech or democratic processes;
+
+  (e) Discriminate against individuals on the basis of protected characteristics in violation of applicable law.
+
+---
+
+## Article 4 — Annual License Fee
+
+**4.1 Fee Obligation.** The Licensee shall pay the Annual License Fee to the Organization on or before the anniversary of the Effective Date each year.
+
+**4.2 Fee Calculation.** The Annual License Fee is calculated in accordance with the Fee Formula set out in Appendix A to this License, using the Revenue Basis determined by the Board for the Licensee (Definition 1.12). The Organization may update the Fee Formula with ninety (90) days' written notice, provided that no increase shall take effect mid-term of any paid year. Changes to the Licensee's Revenue Basis take effect at the next annual renewal.
+
+**4.3 Payment Process.** The Organization shall issue an invoice or fee statement no fewer than thirty (30) days before each payment is due. Payment terms and accepted methods are as specified in the invoice.
+
+**4.4 Self-Reporting.** The Licensee shall provide to the Organization, on an annual basis, an honest declaration of the figures required to calculate the Fee (including the applicable Revenue Basis figure, ecosystem inclusion factors, and any other data the Board reasonably requires), signed by an authorized officer of the Licensee.
+
+**4.5 Audit Right.** The Organization reserves the right to audit the Licensee's records relevant to Fee calculation, upon thirty (30) days' written notice, no more than once per year. The cost of the audit is borne by the Organization unless the audit reveals an underpayment exceeding the **Audit Tolerance Threshold**, in which case the Licensee bears the audit cost. The Audit Tolerance Threshold is set by the Board within a range of **ten percent (10%) to fifteen percent (15%)**, and may be adjusted per Licensee based on the Licensee's Relationship Index and prior reporting accuracy.
+
+**4.6 Non-Payment.** Failure to pay the Annual License Fee by the due date constitutes a breach. The Organization shall provide written notice of non-payment, after which the Licensee has thirty (30) days to cure. Failure to cure results in automatic suspension of this License pending payment. Suspension exceeding sixty (60) days results in termination under Article 7.
+
+**4.7 Fund Allocation.** All fees collected under this License shall be allocated transparently in accordance with the compensation structure defined in the Organization's charter. The recommended allocation is:
+
+  (a) **50–55%** to the contributor base compensation pool — distributed monthly to contributors proportionally by C-points (see Appendix D);
+
+  (b) **5%** to the contributor incentive pool — Board-directed monthly bounties allocated across subsystems and tasks to steer community effort toward strategic priorities (see Appendix D);
+
+  (c) **15–20%** to project infrastructure (hosting, CI/CD, security audits, tooling);
+
+  (d) **10–15%** to a reserve fund (legal defense, sustainability buffer);
+
+  (e) **5–10%** to an emergency fund (incident response, operational contingencies);
+
+  (f) **Up to 5%** to Organization operations and administration, including Board member compensation (see Organization Charter B.5.5).
+
+  The total contributor allocation ((a) + (b)) is 55–60% of fees collected. The exact percentages are set by the Governing Board and published publicly. Adjustments require thirty (30) days' advance notice.
+
+---
+
+## Article 5 — Contribution Back Requirement
+
+**5.1 Mandatory Contribution.** Any Contribution developed by or on behalf of the Licensee — including modifications, patches, improvements, or Derivative Works — must be submitted to the Organization within ninety (90) days of internal deployment or use, whichever is earlier.
+
+**5.2 Submission Method.** Contributions shall be submitted in accordance with the Project's [Contributor License Agreement (CLA)](cla.md) for commercial licensees, or via Developer Certificate of Origin (DCO) where specified by the Organization. The applicable method and terms are published at [CLA/DCO URL].
+
+**5.3 Organization's Rights Over Contributions.** The Organization may, at its sole discretion:
+
+  (a) Merge the Contribution into the publicly available Software;
+
+  (b) Hold the Contribution privately without public disclosure;
+
+  (c) Decline the Contribution, in which case the Licensee retains ownership of the Contribution but remains bound by the contribution obligations of this Article for future Contributions.
+
+**5.4 No Forced Disclosure of Business Logic.** The Contribution obligation applies to changes made to the Software itself, not to the Licensee's proprietary business logic, data, or configurations that are separate from and do not modify the Software's codebase.
+
+---
+
+## Article 6 — License Revocation
+
+**6.1 Board Authority.** The Governing Board retains unilateral authority to revoke any commercial license granted under this Agreement. Revocation is a measure of last resort, exercised when a Licensee has materially violated the terms or spirit of this License and lesser remedies have proven insufficient.
+
+**6.2 Grounds for Revocation.** The Board may initiate revocation proceedings on the basis of any of the following:
+
+  (a) Material breach of Ecosystem Alignment obligations (Article 3) that has not been cured within the applicable Cure Period;
+
+  (b) Persistent pattern of conduct materially harmful to the Project, its contributors, or its users;
+
+  (c) Conduct constituting a Prohibited Use under Article 3.4;
+
+  (d) Material misrepresentation in Fee self-reporting under Article 4.4;
+
+  (e) Bad-faith conduct in any dispute with the Organization or its contributors.
+
+**6.3 Due Process.**
+
+  (a) Before revoking a license, the Board shall notify the Licensee in writing of the specific grounds for the proposed revocation, including documentary evidence where available.
+
+  (b) The Board shall grant the Licensee a Cure Period whose duration is determined by the Board at its discretion, taking into account the severity of the breach, the Licensee's Relationship Index, and any prior compliance history. The Cure Period shall be no fewer than **fifteen (15) days**.
+
+  (c) The Licensee shall be permitted to submit a written response to the Board within the Cure Period.
+
+  (d) If the Licensee remedies the conduct to the satisfaction of the Board within the Cure Period, the revocation proceedings are dismissed and the Licensee enters a **twelve (12) month Probationary Period**.
+
+**6.4 Probation and Escalation.**
+
+  (a) During a Probationary Period, if the Board identifies a new breach (same or different grounds), the Board may set a shorter Cure Period, subject to the fifteen (15) day minimum.
+
+  (b) If the Licensee requires a third cure within any rolling **twenty-four (24) month** window, the Board may revoke the license immediately with no Cure Period.
+
+  (c) Where the Board determines that a Licensee has engaged in a pattern of repeated violations followed by tactical remediation designed to exploit the Cure Period, the Board may waive the Cure Period entirely.
+
+**6.5 Revocation Decision.**
+
+  (a) If the Cure Period expires without satisfactory remedy, or if the Board exercises immediate revocation under Article 6.4(b) or 6.4(c), the Board shall issue a formal Revocation Notice to the Licensee within fifteen (15) business days of the decision.
+
+  (b) The Revocation Notice shall state the grounds, summarize the evidence, and reference the Licensee's response (if any).
+
+  (c) All revocation decisions and their stated grounds shall be published in the Organization's public license registry for transparency and accountability.
+
+**6.6 Effect of Revocation.** Upon receipt of a Revocation Notice:
+
+  (a) This License is terminated effective ninety (90) days from the date of the Revocation Notice (the "Transition Period");
+
+  (b) During the Transition Period, the Licensee may continue operating under this License on existing deployments only, with no new deployments;
+
+  (c) Before the Transition Period expires, the Licensee must either: (i) come into full compliance with AGPLv3; or (ii) remove the Software from all its systems;
+
+  (d) Failure to comply by the end of the Transition Period exposes the Licensee to enforcement under AGPLv3 and applicable copyright law, including claims for damages for the period of unauthorized commercial use.
+
+**6.7 No Retroactive Fee Refund.** Revocation does not entitle the Licensee to a refund of any fees paid.
+
+---
+
+## Article 7 — Termination
+
+**7.1 Termination for Breach.** This License terminates automatically upon:
+
+  (a) Failure to cure non-payment within the period specified in Article 4.6;
+
+  (b) Material breach of any term of this License not cured within the Cure Period set by the Board in accordance with Article 6.3;
+
+  (c) A revocation decision by the Board under Article 6.
+
+**7.2 Effect of Termination.** Upon termination:
+
+  (a) All rights granted under this License immediately cease (subject to the Transition Period in Article 6.6 where applicable);
+
+  (b) The Licensee must, within ninety (90) days: comply with AGPLv3 for any continued use, or remove all copies of the Software from its systems;
+
+  (c) Obligations that by their nature survive termination (including Article 5 for Contributions already developed, Article 6.7, and this Article 7.2) shall survive.
+
+**7.3 Reinstatement.** A terminated Licensee may apply for a new license at the Board's sole discretion. The Board may consider the Licensee's Relationship Index, prior compliance history, and the circumstances of termination in evaluating any reinstatement application.
+
+---
+
+## Article 8 — General Provisions
+
+**8.1 No Warranty.** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+
+**8.2 Limitation of Liability.** TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THE ORGANIZATION OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR IN CONNECTION WITH THIS LICENSE OR THE SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. THE ORGANIZATION'S AGGREGATE LIABILITY SHALL NOT EXCEED THE TOTAL FEES PAID BY THE LICENSEE IN THE TWELVE (12) MONTHS PRECEDING THE CLAIM.
+
+**8.3 Governing Law and Jurisdiction.** This License shall be governed by and construed in accordance with the laws of **[JURISDICTION TO BE SPECIFIED]**. Any disputes shall be subject to the exclusive jurisdiction of the courts of **[JURISDICTION]**.
+
+**8.4 Entire Agreement.** This License, together with its Appendices and the documents incorporated by reference ([Organization Charter](organization-charter.md), [CLA](cla.md), [C-Points Methodology](c-points.md)), constitutes the entire agreement between the parties regarding commercial use of the Software and supersedes all prior negotiations, representations, or agreements.
+
+**8.5 Severability.** If any provision of this License is found invalid or unenforceable, it shall be modified to the minimum extent necessary to make it enforceable. The remaining provisions shall continue in full force.
+
+**8.6 No Waiver.** Failure by the Organization to enforce any provision of this License shall not constitute a waiver of the right to enforce it in the future.
+
+**8.7 Amendments.** The Organization may publish revised versions of this License. Licensees operating under a specific version are not automatically subject to a new version; continued use after the transition date specified in any revision notice constitutes acceptance.
+
+**8.8 Notices.** All notices under this License shall be in writing and delivered to the registered contact addresses of each party.
+
+---
+
+## Appendix A — Fee Formula
+
+### A.1 Formula
+
+```
+Annual Fee = revenue_basis × K₁ × (1 + K₂ × inclusion_index) × inflation_factor
+```
+
+### A.2 Variables
+
+| Variable | Definition |
+|----------|-----------|
+| `revenue_basis` | The financial figure determined by the Board per Licensee based on the Licensee's Relationship Index (see Definition 1.12). Six tiers from Profit on the Software (most lenient) to Revenue on the Ecosystem (most restrictive). |
+| `K₁` | Rate constant — the base percentage of revenue basis charged as a license fee. |
+| `K₂` | Ecosystem lock-in penalty multiplier — scales the surcharge applied to closed-ecosystem business models. |
+| `inclusion_index` | A score from 0.0 (fully open) to 1.0 (fully locked-in), assessed annually by the Board using the methodology in A.4. |
+| `inflation_factor` | Annual CPI adjustment. Calculated as `1 + CPI_change + buffer`, where `buffer` is a fixed percentage above inflation to account for project growth costs. |
+
+### A.3 Constants and Guidance
+
+#### K₁ — Rate Constant
+
+K₁ represents the percentage of the Licensee's revenue basis paid as a base license fee. The Board sets K₁ at the time of license activation (Article 2.1) and may adjust it with ninety (90) days' written notice (Article 4.2). Adjustments take effect at the Licensee's next annual renewal, not mid-term — no Licensee will face an increased fee during a year they have already paid for.
+
+**Reasonable range:** 1–5%. Software royalties in comparable open-core and dual-licensing arrangements typically fall in this range. A K₁ of 2% on a $10M revenue basis yields a $200,000 annual fee before ecosystem adjustments.
+
+**Board guidance for setting K₁:**
+- Project maturity: early-stage projects may set K₁ at the lower end to encourage commercial adoption.
+- Licensee size: the Board may apply tiered K₁ values by revenue bracket (e.g., lower rate for companies under $1M ARR).
+- Market context: the Board should reference comparable dual-license and open-core arrangements in the software industry when setting K₁.
+
+#### K₂ — Ecosystem Lock-In Penalty Multiplier
+
+K₂ controls how much additional fee a Licensee pays for operating a walled-garden business model that restricts users from switching away. It amplifies the `inclusion_index` score.
+
+**Interpretation:**
+- `K₂ = 0`: No ecosystem penalty — the fee is the base rate regardless of lock-in.
+- `K₂ = 1.0`: A Licensee with `inclusion_index = 1.0` (fully locked-in) pays **double** the base rate.
+- `K₂ = 0.5`: A fully locked-in Licensee pays 1.5× the base rate.
+
+**Reasonable range:** 0.5–1.5. The Board sets K₂ alongside K₁. Higher values create stronger incentives for interoperability and data portability.
+
+#### Inflation Factor
+
+The inflation factor is recalculated annually by the Board and applied to the following year's fee.
+
+```
+inflation_factor = 1 + CPI_change + buffer
+```
+
+- **CPI index**: The Board selects a widely recognized national or regional consumer price index relevant to the jurisdiction where the Organization is incorporated (see Article 8.3). The same index is used consistently year over year; changes require a Charter amendment.
+- **Buffer above CPI**: A fixed percentage above CPI, in the range of **2–5%**, to account for project infrastructure growth, maintainer compensation, and reserve fund requirements. The buffer is set in the Charter (Appendix B) and is subject to the Charter amendment process.
+- **Floor**: `inflation_factor` shall not be less than 1.0 — the fee may not decrease due to deflation.
+
+### A.4 Inclusion Index Assessment Methodology
+
+The Board assesses a Licensee's `inclusion_index` annually using the following scoring criteria. Each criterion is scored 0.0–1.0; the inclusion index is the weighted average.
+
+| Criterion | Weight | 0.0 (fully open) | 1.0 (fully closed) |
+|-----------|--------|-------------------|---------------------|
+| **Data portability** | 25% | Users can export all their data in standard formats at any time. | No export capability; data is locked to the platform. |
+| **API openness** | 20% | Public API with standard protocols; third-party integrations fully supported. | Proprietary APIs; third-party integrations blocked or heavily restricted. |
+| **Interoperability** | 20% | Product interoperates with competing products and open standards. | Product deliberately prevents interoperability with alternatives. |
+| **Switching cost** | 20% | No contractual lock-in; users can migrate to alternatives with minimal friction. | Long-term contracts, migration fees, or technical barriers that prevent switching. |
+| **Platform dependency** | 15% | No dependency on Licensee-controlled infrastructure for core functionality. | Core functionality requires Licensee-controlled proprietary infrastructure. |
+
+**Assessment process:**
+1. The Licensee submits a self-assessment alongside the annual revenue declaration (Article 4.4).
+2. The Board reviews the self-assessment and may request supporting evidence.
+3. The Board issues a final score. Disputes regarding the score may be raised with the Board in writing; the Board shall respond within thirty (30) days.
+
+**Example scores:**
+- A fully open-source product with standard APIs and free data export: `inclusion_index ≈ 0.05`
+- A SaaS product with export features but proprietary APIs: `inclusion_index ≈ 0.40`
+- A walled-garden platform with no export, proprietary APIs, and vendor lock-in contracts: `inclusion_index ≈ 0.90`
+
+### A.5 Dynamic Nature of the Fee
+
+The Annual License Fee is **hyper-dynamic by design**. Multiple variables in the formula — including the Revenue Basis, inclusion index, and applicable constants — are subject to Board discretion and may change between annual terms based on the Licensee's conduct, Relationship Index, and ecosystem alignment.
+
+The Licensee acknowledges that the Fee is not a fixed or purely formulaic calculation, but a Board-governed assessment informed by the formula above and the Licensee's overall relationship with the Organization.
+
+### A.6 Negotiation
+
+If the Licensee considers the Fee proposed by the Board to be unreasonable or misaligned with the Licensee's actual use of the Software, the Licensee may request a negotiation with the Board before the annual payment is due. The Board shall consider such requests in good faith but is not obligated to adjust the Fee. If no agreement is reached, the Licensee may:
+
+  (a) Pay the Fee as proposed by the Board to maintain the commercial license;
+
+  (b) Decline the Fee and transition to AGPLv3 compliance in accordance with Article 2.5; or
+
+  (c) Cease use of the Software in accordance with Article 7.
+
+---
+
+## Companion Documents
+
+The following documents are part of this License and incorporated by reference:
+
+| Document | Description |
+|---|---|
+| [Organization Charter](organization-charter.md) | Governance structure, Board composition, membership, staged governance (B.1–B.9) |
+| [Contributor License Agreement](cla.md) | IP license grant, scope of Article 5 contributions, representations and warranties, per-entity signing process |
+| [C-Points Methodology](c-points.md) | Variables and weights (8 dimensions), calculation mechanics (rolling 24-month, daily recalculation), anti-gaming measures, tooling |
+
+---
+
+*End of Sovereign Commons Commercial License v1.0 — DRAFT*

--- a/legal/adversarial-scenarios.md
+++ b/legal/adversarial-scenarios.md
@@ -1,0 +1,86 @@
+# Adversarial Scenario Analysis — SCCL v1 / Organization Charter
+
+**Version:** 1.0-draft
+**Status:** Working analysis, part of Issue #83's outstanding checklist ("the license structure holds up under adversarial scenarios"). This document is a structured first pass by the Organization's founders and is **not a substitute for review by legal counsel** — it exists so counsel has a starting map of known stress points rather than a blank page.
+
+---
+
+## Purpose
+
+For each scenario: what an adversary tries, what in the current SCCL/Charter mechanics stops or slows it, and what residual risk remains (if any) that this document does not claim to have solved.
+
+---
+
+## Scenario 1 — Hostile Licensee
+
+**1.1 Licensee disputes every Board decision to stall and exhaust the Organization.**
+
+A Licensee facing revocation files a Contested Revocation Review petition (SCCL Article 6.8) purely to buy time, regardless of merit.
+
+- *Holds:* The stay under 6.8(b) does not apply where the Board has invoked immediate revocation for documented bad-faith cure exploitation (6.4(b)/(c)) — a genuinely hostile Licensee with a real compliance history triggers that carve-out. At Stages 1–2, review is Board-run, not community-run, so there's no larger process to stall.
+- *Residual risk:* At Stage 3+, a single contested review is a binding contributor vote (Charter B.6.3(c)) — cheap for a well-resourced Licensee to force, expensive in community attention each time. Nothing currently rate-limits how often the *same* Licensee can trigger review petitions. **Not fixed here** — worth a future amendment capping petition frequency per Licensee per rolling period.
+
+**1.2 Licensee manipulates Revenue Basis reporting (SCCL 4.4) to underpay.**
+
+- *Holds:* Audit Right (4.5) lets the Organization inspect records; underpayment beyond the Audit Tolerance Threshold shifts audit cost to the Licensee and feeds the Relationship Index (1.11), which can escalate future Revenue Basis tier severity (1.12) and shorten future Cure Periods (6.3(b)).
+- *Residual risk:* Audit is capped at once per year (4.5) and requires 30 days' notice — a sophisticated Licensee has a known audit window to normalize books around. The "Affiliated Entities" test (1.12 note) requires >50% common control; a Licensee could structure revenue through a minority-owned (e.g., 49%) shell to argue it falls outside "Revenue on the Ecosystem" scope even while functionally controlling it. **Not fixed here** — the >50% bright-line control test is precise but gameable; a facts-and-circumstances "de facto control" backstop (similar to Charter B.2.8(f)'s approach for Employer Groups) would close this but isn't drafted yet.
+
+**1.3 Licensee litigates instead of complying (Non-Aggression, SCCL 3.3).**
+
+- *Holds:* Initiating IP litigation against the Organization or its contributors is itself a Non-Aggression breach (3.3(a)) and grounds for revocation (6.2(a)) — the Licensee cannot sue its way out of the License without triggering the License's own termination.
+- *Residual risk:* None identified beyond ordinary litigation cost/time risk inherent to any license enforcement — this is a legal-counsel question (enforceability of non-aggression clauses varies by jurisdiction, hence 8.3's importance), not a drafting gap.
+
+---
+
+## Scenario 2 — Board / Governance Capture
+
+**2.1 A single employer accumulates Governance Pool dominance through years of ordinary hiring.**
+
+- *Holds:* Employer Concentration Limit (Charter B.2.8), active from Stage 4 onward, caps any Employer Group at 20% of the Pool and 1 Board seat, enforced by exclusion (not down-weighting) at each monthly recalculation. Affiliation Disclosure (c-points.md §1a) plus the Integrity Multiplier (§3.6) penalize concealment.
+- *Residual risk:* B.2.8 only activates at Stage 4. Between the 500-Active-Contributor eligibility trigger and actual Stage 4 activation, the project sits at Stage 3, where Pool composition is advisory only (B.9.3) — so a concentrated employer bloc has no *binding* power yet, but could use its Stage-3 advisory weight to campaign against Stage 4 activation itself (Rolling Vote, B.9.4) indefinitely, since a Negative tally blocks Stage 4 regardless of contributor count (B.9.4(g)). **This is a real, not-fully-closed risk**: a large employer could rationally prefer to keep the project at Stage 3 (Board-controlled, its employees hold advisory influence and up to 1 elected seat) rather than let Stage 4 activate and trigger B.2.8's cap against it. Founders retain full Board authority through Stage 3, which limits the practical damage, but this is the mechanism worth flagging most prominently to legal counsel and to future Board members.
+
+**2.2 Coordinated bloc removes a Board member via the Continuous Confidence Vote (Charter B.3.3) at low turnout.**
+
+- *Holds:* Requires >50% of non-neutral votes AND ≥10% Pool participation — a small bloc cannot act alone without the rest of the Pool actively countering with "keep" votes.
+- *Residual risk:* The 10% participation floor is low by design (to keep the mechanism usable at scale), which means a coordinated bloc of roughly 10–15% of the Pool, voting uniformly while the remaining ~85–90% stays passive (the normal state for most large communities), can clear the bar. This is a known trade-off in "health bar" style continuous-confidence systems generally, not unique to this draft. **Not fixed here** — a possible future mitigation is a minimum "keep" floor (e.g., replacement blocked if keep votes alone exceed some absolute threshold) rather than only a replace/non-neutral ratio; flagged for Board consideration, not drafted.
+
+**2.3 Founder dies/retires before Stage 3, seat falls to a thin, capturable Pool.**
+
+- *Holds:* Now addressed by Charter B.3.6 — Designated Successor holds the seat through a 12-month bridge, cannot be Licensee-affiliated (immutable), and the seat does not auto-convert into an immature Pool.
+- *Residual risk:* Relies on the Founder actually filing a Designated Successor in advance. If neither Founder ever files one, B.3.6(d) falls back to Emergency Succession (B.7.2) — "5 most recent Active Contributors by contribution date," which has no Employer Group diversity requirement of its own. **Partial gap** — B.7.2 could be strengthened to require those 5 not share an Employer Group, matching B.2.8's logic; not drafted here since it's Stage-1/2-era (pre-Pool, pre-B.2.8 activation) and the founders filing a Designated Successor is the primary intended mitigation.
+
+---
+
+## Scenario 3 — Fee Formula Edge Cases
+
+**3.1 Board sets K₁/K₂ punitively high to force a Licensee out entirely.**
+
+- *Holds:* From Stage 3 onward, Fee Formula changes require community ratification (Charter B.6.4) — the Board cannot unilaterally weaponize the formula against a disfavored Licensee once past the earliest stage. A Licensee can also always exit to AGPLv3 compliance instead of paying (SCCL 2.5, 4.2's negotiation clause A.6).
+- *Residual risk:* At Stages 1–2, this ratification requirement doesn't apply yet (B.6.4 activates at Stage 3) — so a punitive fee is theoretically possible pre-Stage-3, though there are by definition few or no commercial Licensees yet at that stage for it to matter (Article 2.1's 15-Active-Contributor activation threshold gates when licenses can even issue). Low practical risk given the ordering of thresholds, but worth legal counsel's eyes.
+
+**3.2 Licensee structures around the Revenue Basis tiers.**
+
+- Covered under 1.2 above (Affiliated Entities >50% control test).
+
+**3.3 Inflation factor exploited during high-inflation periods to justify runaway fee growth.**
+
+- *Holds:* A.3's floor (`inflation_factor` never below 1.0) prevents deflation abuse; the buffer is capped in the Charter (2–5%) and requires a Charter amendment to change, not a unilateral Board act.
+- *Residual risk:* None identified beyond the CPI-index selection itself being a one-time Board choice (A.3) that could favor an index understating true cost growth — a legal/economic counsel question, not a structural loophole.
+
+---
+
+## Summary of Unresolved Residual Risks
+
+| # | Risk | Severity | Status |
+|---|------|----------|--------|
+| 1 | No rate limit on repeated Contested Revocation Review petitions by the same Licensee (1.1) | Low–Medium | Not fixed |
+| 2 | Affiliated-Entities >50% control test is a bright line, gameable via minority-stake structuring (1.2, 3.2) | Medium | Not fixed |
+| 3 | Employer bloc may rationally oppose Stage 4 activation to avoid B.2.8's cap (2.1) | **High** | Not fixed — most significant open item |
+| 4 | Continuous Confidence Vote's 10% participation floor allows small coordinated blocs to act at low turnout (2.2) | Medium | Not fixed |
+| 5 | Emergency Succession (B.7.2) has no Employer Group diversity requirement if no Designated Successor is filed (2.3) | Low–Medium | Partial (mitigated by encouraging Designated Successor filing) |
+
+None of these risks are fabricated to look resolved — they are named here specifically because SCCL/Charter drafting alone cannot close them with confidence; they need either further design iteration, or a judgment call from actual legal/governance counsel about acceptable risk tolerance, before Issue #83 can honestly close its "adversarial scenarios" checklist item.
+
+---
+
+*This document is maintained alongside SCCL-v1.md and organization-charter.md. Findings here should inform, not substitute for, the legal counsel review required to close Issue #83.*

--- a/legal/c-points.md
+++ b/legal/c-points.md
@@ -17,10 +17,21 @@ C-points are **not currency** and carry no direct monetary value. They determine
 
 ## 1. Variables and Weights
 
+### 1a. Affiliation Disclosure (required, gates Pool/Board eligibility)
+
+Every Contributor must disclose, and keep current, their present employer(s), contracting engagements, and any other relationship a reasonable person would consider a material financial tie — updated within **thirty (30) days** of any change. This is not a scored dimension; it is a compliance gate. Its purpose is to make the Employer Concentration Limit (Organization Charter §B.2.8) enforceable — that Section is a structural cap, not a trust-based rule, and a structural cap only works if affiliation is known.
+
+- A Contributor with no disclosure on file, or a stale one (unconfirmed for 12+ months), is ineligible for Governance Pool ranking and Board candidacy until it is filed or reconfirmed. Their C-points continue to accrue for compensation purposes (§6) regardless — this gate affects governance eligibility only, never pay.
+- Disclosure is self-reported but subject to Board audit (§3.5) and public challenge; a Contributor may dispute another's disclosed (or apparently undisclosed) affiliation through the same channel used for C-point disputes.
+- The current disclosure record (employer/affiliation only, not compensation figures) is visible to the Board and to Organization tooling enforcing B.2.8; it is not published to the general public, to avoid inviting targeted harassment of individual contributors.
+
+### 1b. Dimensions and Weights
+
 The C-point score for a contributor over a rolling 24-month window is calculated as:
 
 ```
-C = Σ (dimension_score × weight)
+C_raw = Σ (dimension_score × weight)
+C_final = C_raw × Integrity_Multiplier   (see §3.6)
 ```
 
 | # | Dimension | Weight | Description |
@@ -88,6 +99,19 @@ Contributions authored by automated systems, bots, or CI pipelines are ineligibl
 
 The Board may audit any contributor's C-point breakdown and disqualify contributions that appear to be the result of gaming or coordinated inflation. Disputes are resolved under the Charter dispute resolution process.
 
+### 3.6 Integrity Multiplier
+
+`Integrity_Multiplier` starts at **1.0** for every Contributor and applies to their total score (`C_final = C_raw × Integrity_Multiplier`) — it affects both Governance Pool rank and compensation-pool share, since both are computed from `C_final`. It is reduced, proportionate to severity and never below **0.0**, on any of the following findings by the Board (subject to the same dispute/appeal process as any C-point determination):
+
+| Finding | Typical range |
+|---|---|
+| Confirmed gaming or coordinated inflation (§3.5) | 0.25–0.75, scaled to the share of score affected |
+| Undisclosed or stale affiliation (§1a), first instance | 0.75–0.9, for the period of non-disclosure only |
+| Undisclosed affiliation, willful or repeated | 0.0–0.5, and referred to Charter B.4.3 for Pool/Board disqualification |
+| Code of Conduct violation resulting in formal Board sanction | Set case-by-case by the Board, published with rationale per B.4.1 |
+
+A reduced multiplier applies only to the window it covers — it is not a permanent mark. A Contributor may appeal a multiplier determination through the same channel as any other C-point dispute (§3.5), and the Board must publish its reasoning per Charter B.4.1/B.4.2 (consistency across similar cases).
+
 ---
 
 ## 4. Edge Cases
@@ -116,7 +140,7 @@ The canonical score is stored in the Organization's registry (not derived from G
 
 ## 6. Governance Pool Membership
 
-The **Governance Pool** consists of the top 1000 contributors by C-point score in the rolling 24-month window. Membership is recalculated monthly.
+The **Governance Pool** consists of the top 1000 contributors by `C_final` score in the rolling 24-month window, subject to the **Employer Concentration Limit** (Organization Charter §B.2.8): no single Employer Group (§1a) may exceed 20% of the 1000 seats, and eligibility additionally requires a current Affiliation Disclosure (§1a). Membership is recalculated monthly.
 
 Governance Pool members receive:
 - A weighted vote on Charter amendments and major project decisions (Charter §B.3).

--- a/legal/c-points.md
+++ b/legal/c-points.md
@@ -149,6 +149,244 @@ Governance Pool members receive:
 
 A contributor who leaves the top 1000 loses Governance Pool membership at the next monthly recalculation. There is no grandfather provision.
 
+
+---
+
+
+## 7. Monthly Compensation Calculation
+
+### 7.1 Two-Pool Structure
+
+Contributor compensation (SCCL Article 4.7) is split into two pools, both funded annually and paid out monthly:
+
+| Pool | Source | Distribution mechanism |
+|---|---|---|
+| **Base pool** (50–55% of annual fees) | Organic C-points activity | Proportional to each contributor's monthly C-points |
+| **Incentive pool** (5% of annual fees) | Board-directed bounties | Allocated across subsystems/tasks; distributed to contributors who worked in those areas |
+
+Both pools are divided by 12 to produce a monthly budget. No annual surplus rolls over — unspent incentive budget in a given month returns to the reserve fund.
+
+### 7.2 Base Pool Distribution
+
+Each month:
+
+```
+monthly_base_budget  = (annual_fees × base_pool_%) / 12
+contributor_share    = contributor_monthly_cpoints / total_monthly_cpoints_all_contributors
+contributor_payout   = contributor_share × monthly_base_budget
+```
+
+No subsystem weighting is applied to the base pool. Contributors working on less-trafficked subsystems naturally receive a larger per-contributor share because fewer people compete for the same activity.
+
+### 7.3 Incentive Pool Distribution
+
+Each month, the Board may publish a revised **monthly incentive allocation** — the percentage of the monthly incentive budget directed to each subsystem or task category. These percentages reflect strategic priorities (e.g., security-critical work, underserved subsystems, documentation gaps). If the Board does not publish a new allocation for a given month, the most recent allocation remains in effect.
+
+Example annual incentive allocation:
+
+| Subsystem / Task | Incentive share |
+|---|---|
+| Security and vulnerability work | 35% |
+| Core dispatch engine | 25% |
+| Documentation | 20% |
+| TUI | 10% |
+| Voice / STT | 10% |
+
+Each month, a contributor who worked in an incentivized area receives an additional payout proportional to their C-points within that area relative to all contributors in that area that month:
+
+```
+monthly_incentive_budget        = (annual_fees × 5%) / 12
+subsystem_incentive_budget      = monthly_incentive_budget × subsystem_share
+contributor_subsystem_cpoints   = contributor's C-points earned in that subsystem this month
+total_subsystem_cpoints         = all contributors' C-points in that subsystem this month
+contributor_incentive_payout    = (contributor_subsystem_cpoints / total_subsystem_cpoints)
+                                  × subsystem_incentive_budget
+```
+
+A contributor's total monthly compensation is their base payout plus the sum of any incentive payouts across subsystems they contributed to.
+
+**Conflict of interest:** Board members may not vote on the incentive allocation for any subsystem in which they rank in the top ten contributors by C-points over the preceding 24 months. Recusal is logged and published in the annual governance report (Charter §B.9.3).
+
+### 7.4 Board Member Compensation
+
+Board members are compensated from the operations slice (SCCL Article 4.7(f)), not from the contributor pools. Board compensation is set at **0.0001–0.001% of annual SCCL fees per Board member**, as determined by the Board and published in the annual financial report (Charter §B.5.5).
+
+Board members who are also Active Contributors continue to earn contributor compensation through the base and incentive pools on equal footing with all other contributors. Their Board compensation is additive and separate.
+
+### 7.5 Activation
+
+The monthly compensation model activates at **Governance Stage 3** (Charter §B.9.3), when the project has 30+ Active Contributors and at least one active SCCL commercial license generating revenue. At Stages 1–2, there is no SCCL revenue to distribute. Stage 3 serves as the beta period for testing the compensation mechanics, refining the incentive allocation process, and establishing operational infrastructure (payment methods, tax compliance, contributor identity verification) before Stage 4 scales it to the full Governance Pool.
+
+### 7.6 Example — Full Moneyfall
+
+This example traces **$1,000,000** in annual SCCL license fees from collection to individual contributor payouts.
+
+---
+
+#### Step 1 — Annual fund allocation (SCCL Article 4.7)
+
+| Category | % | Annual | Monthly (÷12) |
+|---|---|---|---|
+| **(a) Contributor base pool** | **52%** | **$520,000** | **$43,333** |
+| **(b) Contributor incentive pool** | **5%** | **$50,000** | **$4,167** |
+| (c) Infrastructure | 18% | $180,000 | — |
+| (d) Reserve fund | 12% | $120,000 | — |
+| (e) Emergency fund | 8% | $80,000 | — |
+| (f) Operations (incl. Board comp.) | 5% | $50,000 | — |
+| **Total** | **100%** | **$1,000,000** | |
+
+Total contributor allocation: (a) + (b) = **57%** = **$570,000/year** = **$47,500/month**.
+
+---
+
+#### Step 2 — Board sets monthly incentive allocation
+
+The Board publishes the incentive allocation for March (if unchanged from the previous month, the previous allocation carries over):
+
+| Subsystem | Incentive share | Monthly incentive budget |
+|---|---|---|
+| Security / auth | 35% | $1,458 |
+| Core dispatch engine | 25% | $1,042 |
+| Documentation | 20% | $833 |
+| TUI | 10% | $417 |
+| Voice / STT | 10% | $417 |
+| **Total** | **100%** | **$4,167** |
+
+---
+
+#### Step 3 — Contributors earn C-points in March
+
+Three contributors are active. Their raw activity in March:
+
+| Contributor | PRs merged | Reviews | Security patches | Doc PRs | Subsystems touched |
+|---|---|---|---|---|---|
+| Alice | 8 | 12 | 2 | 0 | dispatch, security |
+| Bob | 5 | 6 | 0 | 3 | TUI, docs |
+| You | 4 | 10 | 1 | 2 | security, docs, TUI |
+
+---
+
+#### Step 4 — Calculate monthly C-points per contributor
+
+Using the 8-dimension formula (§1), each dimension normalized against the 95th-percentile contributor over the rolling 24-month window. For this example, assume the 95th-percentile ceilings are:
+
+| Dimension | 95th-pctl ceiling (24-month) | Weight |
+|---|---|---|
+| Merged volume | 50 PRs | 20% |
+| Code scope | 8,000 complexity-adjusted LOC | 20% |
+| Review labor | 40 substantive reviews | 15% |
+| Security work | 10 security patches | 15% |
+| Maintenance | 20 triage actions | 10% |
+| Documentation | 15 doc PRs | 10% |
+| Mentorship | 30 mentoring interactions | 5% |
+| Leadership | 10 events | 5% |
+
+**Alice's March C-points** (showing only non-zero dimensions for brevity):
+
+| Dimension | Raw value | Normalized (÷ ceiling × 100) | × Weight | Points |
+|---|---|---|---|---|
+| Merged volume | 8 PRs | (8/50) × 100 = 16.0 | × 0.20 | 3.20 |
+| Code scope | 2,400 LOC | (2400/8000) × 100 = 30.0 | × 0.20 | 6.00 |
+| Review labor | 12 reviews | (12/40) × 100 = 30.0 | × 0.15 | 4.50 |
+| Security work | 2 patches | (2/10) × 100 = 20.0 | × 0.15 | 3.00 |
+| **Alice total** | | | | **16.70** |
+
+**Bob's March C-points:**
+
+| Dimension | Raw value | Normalized | × Weight | Points |
+|---|---|---|---|---|
+| Merged volume | 5 PRs | 10.0 | × 0.20 | 2.00 |
+| Code scope | 1,200 LOC | 15.0 | × 0.20 | 3.00 |
+| Review labor | 6 reviews | 15.0 | × 0.15 | 2.25 |
+| Documentation | 3 doc PRs | 20.0 | × 0.10 | 2.00 |
+| **Bob total** | | | | **9.25** |
+
+**Your March C-points:**
+
+| Dimension | Raw value | Normalized | × Weight | Points |
+|---|---|---|---|---|
+| Merged volume | 4 PRs | 8.0 | × 0.20 | 1.60 |
+| Code scope | 1,800 LOC | 22.5 | × 0.20 | 4.50 |
+| Review labor | 10 reviews | 25.0 | × 0.15 | 3.75 |
+| Security work | 1 patch | 10.0 | × 0.15 | 1.50 |
+| Documentation | 2 doc PRs | 13.3 | × 0.10 | 1.33 |
+| **Your total** | | | | **12.68** |
+
+**Total monthly C-points (all contributors):** 16.70 + 9.25 + 12.68 = **38.63**
+
+---
+
+#### Step 5 — Base pool payout (March)
+
+Monthly base budget: **$43,333**
+
+| Contributor | C-points | Share (÷ 38.63) | Base payout |
+|---|---|---|---|
+| Alice | 16.70 | 43.2% | $18,733 |
+| Bob | 9.25 | 23.9% | $10,373 |
+| You | 12.68 | 32.8% | $14,227 |
+| **Total** | **38.63** | **100%** | **$43,333** |
+
+---
+
+#### Step 6 — Incentive pool payout (March)
+
+Each contributor's C-points are broken down by subsystem to determine incentive eligibility.
+
+**Security incentive ($1,458):** Alice (2 patches) and You (1 patch) worked on security.
+
+| Contributor | Security C-points | Share | Payout |
+|---|---|---|---|
+| Alice | 3.00 | 66.7% | $972 |
+| You | 1.50 | 33.3% | $486 |
+
+**Dispatch incentive ($1,042):** Only Alice worked on dispatch.
+
+| Contributor | Dispatch C-points | Share | Payout |
+|---|---|---|---|
+| Alice | 6.00 | 100% | $1,042 |
+
+**Documentation incentive ($833):** Bob and You wrote docs.
+
+| Contributor | Docs C-points | Share | Payout |
+|---|---|---|---|
+| Bob | 2.00 | 60.0% | $500 |
+| You | 1.33 | 40.0% | $333 |
+
+**TUI incentive ($417):** Bob worked on TUI.
+
+| Contributor | TUI C-points | Share | Payout |
+|---|---|---|---|
+| Bob | 3.00 | 100% | $417 |
+
+**Voice/STT incentive ($417):** No contributors worked here this month. Unspent — returns to the reserve fund.
+
+---
+
+#### Step 7 — Total March compensation per contributor
+
+| Contributor | Base payout | + Security | + Dispatch | + Docs | + TUI | **Total** |
+|---|---|---|---|---|---|---|
+| Alice | $18,733 | $972 | $1,042 | — | — | **$20,747** |
+| Bob | $10,373 | — | — | $500 | $417 | **$11,290** |
+| You | $14,227 | $486 | — | $333 | — | **$15,046** |
+| **Monthly total** | **$43,333** | **$1,458** | **$1,042** | **$833** | **$417** | **$47,083** |
+
+Unspent incentive (Voice/STT): $417 → reserve fund.
+
+---
+
+#### Step 8 — Board member compensation (separate)
+
+From the operations slice ($50,000/year = $4,167/month), Board members receive 0.0001–0.001% of annual SCCL fees. At 0.0005% for a Board of 5:
+
+```
+per_board_member = $1,000,000 × 0.000005 = $5.00/year
+```
+
+This is intentionally nominal at low revenue. At $100M in annual fees, the same rate yields $500/year per Board member. Board members who are also Active Contributors continue earning contributor compensation through the base and incentive pools on equal footing.
+
+
 ---
 
 *This methodology document is maintained by the Organization Board. Amendment proposals should be submitted as pull requests to this file with a corresponding Charter amendment reference.*

--- a/legal/organization-charter.md
+++ b/legal/organization-charter.md
@@ -30,11 +30,25 @@
 
 **B.2.7 No Corporate Membership Tiers.** The Organization does not sell board seats, governance influence, or voting rights. Commercial licensees fund the ecosystem through the Annual License Fee (SCCL Article 4); this entitles them to use the Software commercially — not to govern it.
 
+**B.2.8 Employer Concentration Limit.** B.2.3–B.2.4 exclude corporate-obligated contributions from governance status, but do not by themselves stop a single employer's genuinely-individual contributors from coming to dominate the Governance Pool by ordinary hiring and encouragement over years — the same dynamic that has concentrated maintainership of other major open-source projects in a handful of employers despite nominal individual meritocracy. This Section is the structural backstop; B.2.3–B.2.4 remain in force as the intent-based rule.
+
+  (a) **Scope.** This Section applies from the moment Governance Stage 4 activates and continuously thereafter. It does not apply at Stages 1–3, where the Board (not the Pool) holds decision authority and Pool composition carries no binding power.
+
+  (b) **Employer Group.** Means: (i) an Affiliated Entities group as defined in SCCL Definition 1.12's note (common control >50%); plus (ii) any entity a Contributor discloses as a current employer, contractor engagement, or material financial relationship under C-Points Methodology §1a.
+
+  (c) **Pool cap.** No single Employer Group may constitute more than **twenty percent (20%)** of the Governance Pool at any time. If a monthly recalculation (C-Points Methodology §6) would put an Employer Group over this cap, the lowest-C-points members of that Employer Group are excluded from the Pool — not merely down-weighted — until the cap is satisfied; the next-highest-ranked contributors from other Employer Groups backfill the freed seats. Exclusion under this paragraph affects governance rights only; it has no effect on the excluded contributor's C-points or compensation-pool eligibility (SCCL Article 4.7 / B.5).
+
+  (d) **Board cap.** No more than **one (1)** Board seat — excluding the Independent Seat, which is separately restricted under B.3.1(c) — may be held at any time by individuals sharing an Employer Group. If an election would otherwise seat a second member from the same Employer Group, the seat instead goes to the next-highest-voted candidate from a different Employer Group; if none exists, the seat remains vacant until a qualifying candidate is elected.
+
+  (e) **Undisclosed affiliation.** A Contributor who fails to disclose a material affiliation, or a change of affiliation, within the window required by C-Points Methodology §1a is, upon discovery, retroactively excluded from the Pool for the period of non-disclosure and subject to the Integrity Multiplier penalty (C-Points Methodology §3.6). Willful or repeated non-disclosure is grounds for Pool and Board disqualification under B.4.3.
+
+  (f) **No proxy voting workaround.** "Sharing an Employer Group" is determined by disclosed and reasonably discoverable affiliation, not by formal coordination — the Board (at Stages 1–3) or a Pool-initiated review (at Stage 4, per B.6.3's mechanics) may determine that two or more Contributors constitute a single Employer Group for purposes of this Section where the evidence shows de facto common employer direction, even absent a formal control relationship under SCCL 1.12.
+
 ### B.3 — Governing Board
 
 **B.3.1 Composition.** The Board shall consist of **five (5) to nine (9) members**, with the exact number set by Board resolution. The Board is composed as follows:
 
-  (a) **Founder Seats (up to 2)** — Appointed by the founding members of the Organization. Founder seats convert to Pool-Elected seats when the founder steps down, is removed by Pool vote, or after a maximum of **ten (10) years** from the Organization's incorporation, whichever comes first.
+  (a) **Founder Seats (up to 2)** — Appointed by the founding members of the Organization. Founder seats convert to Pool-Elected seats when the founder steps down, is removed by Pool vote, or after a maximum of **ten (10) years** from the Organization's incorporation, whichever comes first. **Death or incapacity of a Founder is governed by B.3.6, not by this paragraph** — the seat does not convert immediately in that case.
 
   (b) **Pool-Elected Seats** — Elected by the Governance Pool at Stage 4. At Stage 3, at least one seat must be filled by Active Contributor election. At Stage 4, all seats (except the Independent Seat) are Pool-Elected.
 
@@ -72,6 +86,18 @@
 
 **B.3.5 Vacancy.** If a seat is vacated by resignation, the Governance Pool fills it through a **fourteen (14) day** nomination and election (ranked choice, no self-nomination). If the Pool cannot fill the seat within thirty (30) days, Emergency Succession (B.7.2) applies.
 
+**B.3.6 Founder Succession on Death or Incapacity.** This section exists so that a Founder's death or sudden incapacity cannot hand a Founder Seat to whatever the Governance Pool happens to look like at that moment — which, before Stage 3–4 maturity, may be thin, new, or unrepresentative.
+
+  (a) **Designated Successor.** Each Founder may, at any time, file with the Organization a signed, revocable **Designated Successor** — one named individual who will hold the Founder's seat in trust if the Founder dies or becomes permanently incapacitated. A Founder may change or revoke their Designated Successor at any time; only the most recently filed designation is effective.
+
+  (b) **Eligibility restriction (immutable).** A Designated Successor must not be, at the time of designation or at the time of the triggering event, an employee, contractor, officer, or board member of any commercial Licensee, nor of any entity with a pending or reasonably anticipated commercial license application. This restriction cannot be waived by the Founder, the Board, or any amendment short of the process in B.4.6.
+
+  (c) **Bridge Period.** Upon a Founder's death or permanent incapacity (determined by the remaining Board members in good faith, or by the Founder's own advance written declaration), the Designated Successor — if named, available, and still eligible under (b) — assumes the Founder Seat for a **Bridge Period of twelve (12) months**, with full Founder Seat authority and subject to the same conflict-of-interest and recusal rules (B.4.3) as any Board member.
+
+  (d) **No Designated Successor.** If no Designated Successor is named, available, or eligible, the seat is filled for the Bridge Period through Emergency Succession (B.7.2), applied regardless of whether the Board is actually below quorum.
+
+  (e) **End of Bridge Period.** At the end of the Bridge Period, the seat converts to Pool-Elected under B.3.1(a) if the project has reached the 15-Active-Contributor threshold (B.2.1); otherwise it remains held under (c) or (d) — re-extended in twelve (12) month increments — until that threshold is met.
+
 ### B.4 — Constraints on Board Power
 
 **B.4.1 Published Principles.** The Board must publish and maintain a **Decision Principles Document** that articulates the criteria used for discretionary decisions (licensing approvals, Revenue Basis selection, cure period duration, Relationship Index assessment). Decisions must be consistent with these published principles. This obligation applies at all Governance Stages.
@@ -102,7 +128,11 @@
 
   (h) B.6.3 — Contested Revocation Review (compliance disputes are not the Board's to finalize unilaterally once contested, from Stage 3 onward);
 
-  (i) B.6.4 — Fee Formula Ratification (Fee Formula changes are not the Board's to finalize unilaterally once contested, from Stage 3 onward).
+  (i) B.6.4 — Fee Formula Ratification (Fee Formula changes are not the Board's to finalize unilaterally once contested, from Stage 3 onward);
+
+  (j) B.2.8 — Employer Concentration Limit (no single employer may dominate the Governance Pool or Board once Stage 4 activates);
+
+  (k) B.3.6(b) — Designated Successor eligibility restriction (a Founder's emergency successor can never be affiliated with a commercial licensee).
 
 ### B.5 — Financial Governance
 
@@ -222,7 +252,7 @@ The Organization's governance evolves through four stages. Stage advancement fro
 
   *Governance — The Governance Pool as Legislature:*
 
-  - The **Governance Pool** (B.2.6) — the top 1000 Active Contributors by C-points (B.2.5) — becomes the legislative body of the Organization.
+  - The **Governance Pool** (B.2.6) — the top 1000 Active Contributors by C-points (B.2.5), subject to the Employer Concentration Limit (B.2.8) — becomes the legislative body of the Organization.
   - The Board's role transitions to **executive and operational**: managing day-to-day operations, licensee relationships, fee collection, compliance enforcement, financial administration, and serving as the public face of the Organization.
   - **Pool members may initiate binding votes** on any matter within the Organization's scope, including licensing policy, fee principles, ecosystem direction, Code of Conduct changes, and fund allocation within the ranges of SCCL Article 4.7.
   - The Board may also initiate votes, on equal footing with any Pool member.

--- a/legal/organization-charter.md
+++ b/legal/organization-charter.md
@@ -98,7 +98,11 @@
 
   (f) B.9 — Governance Stage advancement triggers (Board cannot prevent stage progression);
 
-  (g) B.9.4(e) — Stage 4 irreversibility (once ratified, contributor governance is permanent).
+  (g) B.9.4(e) — Stage 4 irreversibility (once ratified, contributor governance is permanent);
+
+  (h) B.6.3 — Contested Revocation Review (compliance disputes are not the Board's to finalize unilaterally once contested, from Stage 3 onward);
+
+  (i) B.6.4 — Fee Formula Ratification (Fee Formula changes are not the Board's to finalize unilaterally once contested, from Stage 3 onward).
 
 ### B.5 — Financial Governance
 
@@ -127,6 +131,10 @@
   (d) Upon written request from a Licensee, provide that Licensee with a summary of its own Index standing and the factors contributing to it.
 
 **B.6.2 License Registry.** The Organization shall maintain a public registry of: (a) all active commercial licenses (Licensee name and effective date); (b) all revocation decisions (grounds and summary, per SCCL Article 6.5c); (c) all terminations. The registry does not disclose fee amounts or Relationship Index scores.
+
+**B.6.3 Contested Revocation Review.** Implements SCCL Article 6.8. A revocation decision (or a Board decision not to revoke) may be escalated to the community rather than left to the Board's sole judgment. From Stage 3 onward, a properly filed petition (fifteen percent (15%) of Active Contributors, or the affected Licensee itself) triggers a binding vote of Active Contributors under the mechanics of B.9.4, superseding the Board's determination. At Stages 1–2, the Board reviews the petition directly and must publish a written response under B.4.2. The Board may not decline to run a properly filed petition.
+
+**B.6.4 Fee Formula Ratification.** Implements SCCL Article 4.2.1. Changes to the Fee Formula's constants (K₁, K₂, inflation buffer) or the fund allocation ranges (SCCL Article 4.7) are not solely a Board prerogative once the Project reaches Stage 3: a timely petition of fifteen percent (15%) of Active Contributors stays the change pending a ratification poll (simple majority against blocks it); at Stage 4, ratification via the standard Pool binding vote (B.9.4) is required for every such change, not only contested ones.
 
 ### B.7 — Succession and Continuity
 

--- a/legal/organization-charter.md
+++ b/legal/organization-charter.md
@@ -1,0 +1,233 @@
+# Organization Charter
+
+> **Part of the [Sovereign Commons Commercial License (SCCL) v1.0](SCCL-v1.md)**
+>
+> **Status:** Working draft. Subject to legal review and community feedback.
+
+---
+
+### B.1 — Purpose and Identity
+
+**B.1.1** The Organization exists to steward the Software and its ecosystem for the benefit of contributors and users, not corporations or investors. It is a **non-profit foundation** structured to resist capture by any single entity, corporate or individual.
+
+**B.1.2** The Organization's governance evolves with its community. In its early stages, the Board governs with full authority — because a nascent project cannot afford governance paralysis. As the community grows, contributors earn progressively more governance power, until the Board serves at the community's pleasure. This progression is formalized in B.9 (Governance Stages).
+
+**B.1.3** The Organization shall be incorporated as a **501(c)(3) public charity** or equivalent non-profit legal structure in the applicable jurisdiction. The 501(c)(3) structure ensures: (a) donations are tax-deductible for individual supporters; (b) the Organization cannot primarily serve corporate interests; (c) no individual or entity may profit from the Organization's dissolution.
+
+### B.2 — Membership
+
+**B.2.1 Contributors.** Any individual who has authored at least one merged contribution to the Software (as evidenced by the project's version control history and signed off via DCO) is a Contributor. Contributors are the primary stakeholders of the Organization.
+
+**B.2.2 Active Contributors.** A Contributor is "Active" if they have authored at least one merged contribution within the preceding twenty-four (24) months. Only Active Contributors may exercise governance rights available at the current Governance Stage.
+
+**B.2.3 Corporate Contribution Exclusion.** Contributions submitted on behalf of a commercial licensee — including those fulfilling the contribution-back obligation under SCCL Article 5, signed under the CLA, or authored in the scope of employment with a licensee — do **not** count toward an individual's Active Contributor status for governance purposes. Such contributions satisfy the licensee's contractual obligations but confer no governance rights.
+
+**B.2.4 Individual Contributions by Licensee Employees.** An individual employed by a commercial licensee may qualify as an Active Contributor if and only if: (a) the contribution is signed off via DCO (not CLA); (b) the contribution is made outside the scope of their employment; and (c) the contribution is not fulfilling any part of their employer's SCCL Article 5 obligations. The individual's governance rights are personal and may not be directed or influenced by their employer.
+
+**B.2.5 Contribution Points (C-Points).** Each Active Contributor accumulates **Contribution Points (C-points)** — a weighted composite score reflecting the quality, scope, and nature of their contributions. C-points are used to rank contributors for Governance Pool membership (B.2.6) and other governance purposes. The methodology for calculating C-points — including the variables considered and their respective weights — is defined in the [C-Points Methodology](c-points.md). C-points are recalculated continuously as contributions are merged.
+
+**B.2.6 Governance Pool.** At Governance Stage 4, the governance body consists of the **Governance Pool**: the top **one thousand (1000)** Active Contributors, ranked by C-points (B.2.5), excluding corporate contributions per B.2.3. Only members of the Governance Pool may initiate votes, cast votes, and nominate or stand as candidates for Board seats at Stage 4. The Pool is recalculated continuously as C-points change and Active status changes. At Stages 1–3, all Active Contributors hold whatever governance rights the current stage provides (the 1000-member cap applies only at Stage 4).
+
+**B.2.7 No Corporate Membership Tiers.** The Organization does not sell board seats, governance influence, or voting rights. Commercial licensees fund the ecosystem through the Annual License Fee (SCCL Article 4); this entitles them to use the Software commercially — not to govern it.
+
+### B.3 — Governing Board
+
+**B.3.1 Composition.** The Board shall consist of **five (5) to nine (9) members**, with the exact number set by Board resolution. The Board is composed as follows:
+
+  (a) **Founder Seats (up to 2)** — Appointed by the founding members of the Organization. Founder seats convert to Pool-Elected seats when the founder steps down, is removed by Pool vote, or after a maximum of **ten (10) years** from the Organization's incorporation, whichever comes first.
+
+  (b) **Pool-Elected Seats** — Elected by the Governance Pool at Stage 4. At Stage 3, at least one seat must be filled by Active Contributor election. At Stage 4, all seats (except the Independent Seat) are Pool-Elected.
+
+  (c) **Independent Seat (1)** — An external advisor with relevant expertise (legal, financial, nonprofit governance) appointed by the Board. Must have no employment or financial relationship with any commercial licensee.
+
+**B.3.2 Rolling Tenure.** Board members serve **indefinitely** — there are no fixed terms, scheduled elections, re-election cycles, or lifetime caps. A Board member's tenure continues until:
+
+  (a) They voluntarily step down; or
+
+  (b) They are replaced through the Continuous Confidence Vote (B.3.3).
+
+  A Board member who has been replaced may be nominated and elected to the Board again in the future — there is no restriction on re-election. Board members retain their standing in the Governance Pool based on their C-points (B.2.5); serving on the Board does not diminish their Pool rank.
+
+**B.3.3 Continuous Confidence Vote.** At Stage 4, each Board member has an **auto-generated, always-open confidence vote** maintained by the Organization. This vote exists from the moment a member joins the Board and remains open for the duration of their tenure. It functions as a **health bar** — Board members start at full confidence and remain until the community actively erodes it. The mechanics are:
+
+  (a) **Auto-seed**: When a Board member takes their seat, every current Governance Pool member is automatically set to **"keep"** for that member. New members joining the Pool after that point also default to "keep" for all sitting Board members. The Board member begins at full health.
+
+  (b) **Three states**: Every Pool member holds one of three positions for each Board member, changeable at any time:
+
+  - **"Keep"** (default) — supports the Board member's continued service;
+  - **"Neutral"** — withdraws active support without calling for replacement. Counted toward participation but does not count toward the keep/replace ratio;
+  - **"Replace"** — calls for the Board member's removal. Must include a **nominee** from the Governance Pool, identified by handle or email. **Self-nomination is not permitted.**
+
+  (c) **Activation threshold**: A Board member is replaced when **more than fifty percent (50%)** of non-neutral cast votes are "replace" AND at least **ten percent (10%)** of the Governance Pool has cast a vote (of any kind, including neutral). Neutral votes raise participation without tipping the balance — as neutrals accumulate, fewer active "replace" votes are needed to cross the 50% line among non-neutral votes.
+
+  (d) **Replacement selection**: When the activation threshold is met, the nominee with the most "replace" votes naming them as replacement fills the seat. In the event of a tie, a **seven (7) day** ranked-choice runoff election is held among the tied candidates.
+
+  (e) **Post-replacement reset**: After a replacement occurs, the new Board member's confidence vote resets — all Pool members are auto-seeded to "keep" for the new member (full health). The replaced member returns to the Governance Pool as a regular member and may be nominated for any future Board vacancy.
+
+  (f) **Lapsed members**: If a Pool member loses their Active status (no merged contribution in the preceding 24 months), their vote is removed from the tally entirely. If they later regain Pool membership, they are re-seeded to "keep" for all sitting Board members.
+
+  (g) **Transparency**: The live tally for each Board member — percentage of "keep," "neutral," and "replace," along with the current participation rate — is **publicly visible** to all Pool members at all times.
+
+**B.3.4 Chair.** At Stages 1–3, the Board elects a Chair from among its members. At Stage 4, the Chair is selected via the same continuous confidence mechanism — Pool members may additionally indicate their preferred Chair among current Board members, and the Board member with the highest Chair preference among Pool voters serves as Chair.
+
+**B.3.5 Vacancy.** If a seat is vacated by resignation, the Governance Pool fills it through a **fourteen (14) day** nomination and election (ranked choice, no self-nomination). If the Pool cannot fill the seat within thirty (30) days, Emergency Succession (B.7.2) applies.
+
+### B.4 — Constraints on Board Power
+
+**B.4.1 Published Principles.** The Board must publish and maintain a **Decision Principles Document** that articulates the criteria used for discretionary decisions (licensing approvals, Revenue Basis selection, cure period duration, Relationship Index assessment). Decisions must be consistent with these published principles. This obligation applies at all Governance Stages.
+
+**B.4.2 Consistency Requirement.** Similar cases must be treated similarly. If a Licensee can demonstrate that its situation is materially indistinguishable from a prior case that was decided differently, it may appeal to the Board citing the inconsistency. Selective enforcement is a Charter violation.
+
+**B.4.3 Conflict of Interest.** A Board member must recuse themselves from any decision involving a Licensee that employs them, contracts with them, or in which they hold a financial interest. Failure to recuse is grounds for recall (at stages where recall is active). No Board member may simultaneously hold a governance role in a commercial licensee.
+
+**B.4.4 Board Accountability.** At Stage 4, every Board member is subject to the Continuous Confidence Vote (B.3.3). This always-open mechanism is the primary instrument of Board accountability — no separate recall or election process is needed. There is no lifetime cap on Board service; members who have been replaced may be re-elected to any future vacancy.
+
+**B.4.5 Charter Amendment.** At Stages 1–3, the Charter may be amended by a **unanimous Board vote**. At Stage 4, amendment requires a vote of **two-thirds (⅔) of the Board** AND **a simple majority of Active Contributors** voting in a ratification poll conducted over no fewer than fourteen (14) days. Neither the Board alone nor Contributors alone may unilaterally change this Charter at Stage 4.
+
+**B.4.6 Immutable Provisions.** The following provisions may not be amended or removed at ANY Governance Stage, by any process short of dissolution and reconstitution:
+
+  (a) B.2.3 — Corporate Contribution Exclusion (corporate work ≠ governance rights);
+
+  (b) B.2.7 — No corporate membership tiers (money cannot buy governance);
+
+  (c) B.3.3 — Continuous Confidence Vote (Board members are always accountable to the Pool);
+
+  (d) B.5.1 — Contributor compensation minimum (50% of fees);
+
+  (e) B.7.3 — Dissolution asset protection (no distribution to licensees or Board);
+
+  (f) B.9 — Governance Stage advancement triggers (Board cannot prevent stage progression);
+
+  (g) B.9.4(e) — Stage 4 irreversibility (once ratified, contributor governance is permanent).
+
+### B.5 — Financial Governance
+
+**B.5.1 Contributor Compensation Floor.** No less than **fifty percent (50%)** of all fees collected under the SCCL shall be allocated to contributor compensation. This floor is immutable under B.4.6(d).
+
+**B.5.2 Allocation Ranges.** Subject to the floor in B.5.1, the Board sets annual allocation percentages within the ranges specified in SCCL Article 4.7. Adjustments require thirty (30) days' advance notice and a published rationale.
+
+**B.5.3 Compensation Methodology.** The Board shall publish the methodology used to determine individual contributor compensation. The methodology may consider: volume of contributions, maintenance burden assumed, security-critical work, review labor, mentorship, and community leadership. The specific formula or rubric is set by the Board and published annually.
+
+**B.5.4 Transparency.** The Organization shall publish an annual financial report within ninety (90) days of each fiscal year end, including: (a) total fees collected, by licensee (anonymized if the Licensee requests confidentiality, but aggregate amounts must be disclosed); (b) allocation by category; (c) individual compensation amounts (with contributor consent) or anonymized distribution statistics; (d) reserve fund balance; (e) Board member compensation (if any — see B.5.5).
+
+**B.5.5 Board Compensation.** Board members may receive reasonable compensation for their service, not to exceed the median contributor compensation in any given year. Board compensation is disclosed publicly in the annual financial report.
+
+**B.5.6 Independent Audit.** The Organization shall engage an independent auditor to review its financial statements at least once every **three (3) years**, or annually once total fees collected exceed **$1,000,000** per year. Audit results are published.
+
+### B.6 — Licensee Relations
+
+**B.6.1 Relationship Index Procedures.** The Licensee Relationship Index (SCCL Definition 1.11) is maintained by the Board as an internal governance tool. The Board shall:
+
+  (a) Document the factors considered in assessing the Index (compliance history, reporting accuracy, cure periods used, cooperative conduct, ecosystem contribution);
+
+  (b) Review each Licensee's Index at least annually;
+
+  (c) Not disclose a Licensee's Index score to other Licensees or the public;
+
+  (d) Upon written request from a Licensee, provide that Licensee with a summary of its own Index standing and the factors contributing to it.
+
+**B.6.2 License Registry.** The Organization shall maintain a public registry of: (a) all active commercial licenses (Licensee name and effective date); (b) all revocation decisions (grounds and summary, per SCCL Article 6.5c); (c) all terminations. The registry does not disclose fee amounts or Relationship Index scores.
+
+### B.7 — Succession and Continuity
+
+**B.7.1 No Single Point of Failure.** The Organization must ensure that no single individual's departure — whether sudden or planned — can paralyze governance. The rolling tenure model (B.3.2), Continuous Confidence Vote (B.3.3), vacancy procedures (B.3.5), and emergency succession (B.7.2) provide structural continuity.
+
+**B.7.2 Emergency Succession.** If the Board falls below quorum (defined as a simple majority of filled seats) and cannot fill vacancies through normal procedures, the **five (5) most recent Active Contributors by contribution date** shall convene within fourteen (14) days to appoint interim Board members until a proper election can be held.
+
+**B.7.3 Dissolution.** If the Organization dissolves, all assets (after settling liabilities) shall be transferred to a 501(c)(3) organization with a compatible mission, as selected by a majority vote of Active Contributors. The Software remains available under AGPLv3 regardless of the Organization's status. Under no circumstances may assets be distributed to any commercial licensee, Board member, or their affiliates.
+
+### B.8 — Activation Threshold
+
+**B.8.1** Per SCCL Article 2.1, no commercial license may be issued until the Project has at least **fifteen (15) Active Contributors** (as defined in B.2.2, excluding corporate contributions per B.2.3), of which no single legal entity (including subsidiaries and affiliates) accounts for more than **twenty-five percent (25%)** of total C-points (B.2.5) over the preceding twelve (12) months.
+
+**B.8.2** The Board verifies the threshold at the time of each license issuance.
+
+### B.9 — Governance Stages
+
+The Organization's governance evolves through four stages. Stage advancement from Stage 1 through Stage 3 is triggered by **objective, measurable criteria** and is **automatic** — the Board cannot prevent or delay stage progression when the criteria are met. Stage 4 requires a **community vote** (see B.9.4). Stage regression may occur between Stages 1–3 if the criteria for the current stage are no longer met for twelve (12) consecutive months. **Stage 4 is permanent and irreversible.**
+
+**B.9.1 Stage 1 — Founding (Autocratic)**
+
+  *Trigger:* Default state from incorporation.
+
+  *Governance:*
+  - The Board governs with full authority.
+  - No contributor elections, no recall, no community veto.
+  - The Board makes all decisions regarding licensing, fees, and ecosystem management.
+  - Immutable provisions (B.4.6) still apply. Published Principles (B.4.1) still apply.
+  - No commercial licenses may be issued (activation threshold not met).
+
+  *Exits when:* The project reaches **15 Active Contributors** (per B.2.2, excluding corporate contributions).
+
+**B.9.2 Stage 2 — Growth (Consultative)**
+
+  *Trigger:* 15+ Active Contributors.
+
+  *Governance:*
+  - The Board retains full decision-making authority.
+  - The Board must **publish all licensing decisions** and their rationale.
+  - The Board must conduct a **quarterly community consultation** — a public forum where Active Contributors may comment on licensee relationships, fee decisions, and ecosystem direction. The Board must publish written responses to community input within thirty (30) days.
+  - Community input is **advisory and non-binding** — the Board decides.
+  - SCCL commercial licenses may now be issued (activation threshold met).
+
+  *Exits when:* The project reaches **30 Active Contributors** AND at least **one (1) active SCCL commercial license** has been issued.
+
+**B.9.3 Stage 3 — Traction (Participatory)**
+
+  *Trigger:* 30+ Active Contributors AND 1+ active commercial licensee.
+
+  *Governance:*
+  - **Contributor-Elected Board seats activated.** At least one (1) seat on the Board must be filled by contributor election. Additional Contributor-Elected seats are added as the Board grows (maintaining a path toward majority).
+  - The Board must **formally consider and respond to** community positions on licensee relationships. If a majority of Active Contributors express a position on a licensing decision (via public poll or petition), the Board must address it in writing with specific reasons if it disagrees.
+  - Active Contributors may **petition the Board** on any matter with fifteen percent (15%) of Active Contributors signing. The Board must respond within thirty (30) days.
+  - The Board must publish an **annual governance report** reviewing its own performance, decisions made, and community feedback received.
+
+  *Exits when:* The project reaches **500 Active Contributors** AND at least **three (3) active SCCL commercial licensees**, triggering Stage 4 eligibility (see B.9.4).
+
+**B.9.4 Stage 4 — Maturity (Contributor-Governed)**
+
+  Stage 4 represents a fundamental and **permanent** shift in governance: the Board transitions from decision-maker to executive, and the contributor community becomes the legislative body. There is no turning back from Stage 4.
+
+  *Eligibility Trigger:* 500+ Active Contributors AND 3+ active commercial licensees.
+
+  *Activation Process — Rolling Vote:*
+
+  (a) When the eligibility criteria are met, the Board must publicly announce Stage 4 eligibility within **thirty (30) days** and open the **Stage 4 Rolling Vote**. If the Board fails to announce, any Active Contributor may initiate the process directly by publishing the eligibility verification and opening the vote.
+
+  (b) The Rolling Vote is **permanent and continuous** — it does not close. Once opened, it remains open for as long as the project is at Stage 3. Active Contributors may cast, change, or withdraw their vote at any time.
+
+  (c) Only votes from current **Active Contributors** (per B.2.2) are counted in the tally. If a Contributor's Active status lapses (no merged contribution in the preceding 24 months), their vote is automatically removed from the tally. If they later regain Active status through a new contribution, they may vote again.
+
+  (d) The live tally is classified continuously as follows:
+
+  - **Positive**: More than 52.5% of cast votes are in favor, AND votes have been cast by at least **fifteen percent (15%)** of current Active Contributors.
+  - **Negative**: More than 52.5% of cast votes are against, AND votes have been cast by at least **fifteen percent (15%)** of current Active Contributors.
+  - **Neutral**: Fewer than 15% of Active Contributors have cast votes, OR the tally falls within **five (5) percentage points of 50%** (i.e., 47.5%–52.5%).
+
+  (e) **Positive tally** — Stage 4 activates immediately, regardless of contributor count. The community has chosen self-governance.
+
+  (f) **Neutral tally at 1000+ Active Contributors** — Stage 4 activates automatically. At this scale, the absence of opposition is treated as consent.
+
+  (g) **Negative tally** — The project remains at Stage 3 regardless of contributor count. The community's explicit rejection is respected — even at 1000+ contributors, Stage 4 does **not** auto-activate while the tally is Negative. Stage 4 can only activate when the live tally shifts to Positive or when it becomes Neutral at 1000+ contributors.
+
+  (h) Once Stage 4 is activated — whether by Positive tally or Neutral auto-transition — **it cannot be reversed** by any mechanism. The community's self-governance is permanent.
+
+  *Governance — The Governance Pool as Legislature:*
+
+  - The **Governance Pool** (B.2.6) — the top 1000 Active Contributors by C-points (B.2.5) — becomes the legislative body of the Organization.
+  - The Board's role transitions to **executive and operational**: managing day-to-day operations, licensee relationships, fee collection, compliance enforcement, financial administration, and serving as the public face of the Organization.
+  - **Pool members may initiate binding votes** on any matter within the Organization's scope, including licensing policy, fee principles, ecosystem direction, Code of Conduct changes, and fund allocation within the ranges of SCCL Article 4.7.
+  - The Board may also initiate votes, on equal footing with any Pool member.
+  - Binding votes require a **simple majority** of participating Pool members, with a minimum participation threshold of **ten percent (10%)** of the Governance Pool to ensure legitimacy.
+  - **Board Final Say (Veto).** The Board retains a veto on community resolutions. To exercise a veto, the Board must publish a **detailed written justification** within fifteen (15) days of the vote result. A vetoed resolution may be overridden by a **two-thirds (⅔) supermajority** of the Governance Pool in a subsequent override vote. If the override passes, the Board must implement the resolution.
+  - **Dual-approval Charter amendments** (B.4.5) — Board ⅔ + Pool majority required.
+
+  *Governance — Board at Stage 4:*
+
+  - **All Board seats are Pool-Elected** (except the Independent Seat per B.3.1c). Founder Seats have expired or converted (per B.3.1a). The Board may not self-appoint members.
+  - Board members serve **indefinitely** on a rolling basis (B.3.2) — no terms, no scheduled elections, no lifetime caps. They serve until replaced by the Continuous Confidence Vote (B.3.3) or voluntary resignation. Board members retain their Governance Pool standing.
+  - Every Board member is subject to an **always-open Continuous Confidence Vote** (B.3.3) — Pool members start at "keep" and may shift to "neutral" or "replace" at any time. Replaced members return to the Pool and may be re-elected.
+  - The Governance Pool selects the **Chair** directly (B.3.4).
+  - Emergency Succession (B.7.2) remains available as a last resort if the Board falls below quorum.
+
+**B.9.5 Stage Verification.** The Board must verify and publicly declare the current Governance Stage annually. Any Active Contributor may challenge the declared stage by demonstrating that the objective criteria for a different stage are met. Disputes are resolved by an independent count of Active Contributors as recorded in the project's version control history.

--- a/legal/organization-charter.md
+++ b/legal/organization-charter.md
@@ -98,6 +98,20 @@
 
   (e) **End of Bridge Period.** At the end of the Bridge Period, the seat converts to Pool-Elected under B.3.1(a) if the project has reached the 15-Active-Contributor threshold (B.2.1); otherwise it remains held under (c) or (d) — re-extended in twelve (12) month increments — until that threshold is met.
 
+**B.3.7 Ordinary Board Meetings, Quorum, and Minutes.** B.3.3–B.3.6 govern elections, confidence votes, and succession. This section governs the Board's routine, day-to-day decision-making — licensing approvals, Relationship Index reviews, cure-period determinations, and other business that is not an election, a Charter amendment, or a matter reserved to the community under B.6.3/B.6.4.
+
+  (a) **Cadence.** The Board shall meet no less than **once per calendar quarter**, and additionally whenever the Chair or any two (2) Board members call a meeting. At Stage 2+, at least one quarterly meeting per year must be the public consultation session required by B.9.2.
+
+  (b) **Quorum.** A quorum for any Board meeting or vote is a **simple majority of filled seats** (matching the quorum definition already used for Emergency Succession, B.7.2). No Board decision is valid without quorum present or voting.
+
+  (c) **Voting.** Absent a more specific rule elsewhere in this Charter or the SCCL (e.g., Charter amendments under B.4.5, Fee Formula ratification under B.6.4), routine Board decisions are decided by **simple majority of Board members present and voting**. The Chair votes as an ordinary member and does not hold a tiebreaking vote; a tied routine vote fails to pass.
+
+  (d) **Minutes.** The Board shall keep written minutes of every meeting, recording: date, attendees, decisions made, the vote on each decision (including abstentions and recusals under B.4.3), and a summary of the reasoning for any decision governed by the Decision Principles Document (B.4.1). Minutes must be published to Active Contributors within **fourteen (14) days** of the meeting.
+
+  (e) **Confidential exception.** Minutes may redact specific figures or facts that would violate a Licensee's confidentiality (e.g., unpublished fee amounts under SCCL Article 4.7, a Licensee's Relationship Index score per B.6.1(c)) — but the redaction itself, and the general nature of the item discussed, must be noted rather than omitted silently.
+
+  (f) **Emergency exception.** A decision made outside a scheduled meeting under exigent circumstances (e.g., invoking immediate revocation under SCCL Article 6.4(b)/(c)) must be ratified by the full Board and documented in the minutes of the next meeting, no later than **thirty (30) days** after the fact.
+
 ### B.4 — Constraints on Board Power
 
 **B.4.1 Published Principles.** The Board must publish and maintain a **Decision Principles Document** that articulates the criteria used for discretionary decisions (licensing approvals, Revenue Basis selection, cure period duration, Relationship Index assessment). Decisions must be consistent with these published principles. This obligation applies at all Governance Stages.
@@ -159,6 +173,10 @@
   (c) Not disclose a Licensee's Index score to other Licensees or the public;
 
   (d) Upon written request from a Licensee, provide that Licensee with a summary of its own Index standing and the factors contributing to it.
+
+  (e) **Access control.** The Index for each Licensee may be viewed or edited only by sitting Board members and any staff/officer explicitly delegated Index-maintenance duties by Board resolution. A Board member who is recused from a Licensee's matters under B.4.3 also loses Index access for that Licensee for the duration of the recusal. Every view and edit is logged (accessor identity, timestamp, and — for edits — the prior and new value) in an append-only audit log retained for no less than **seven (7) years**.
+
+  (f) **Audit log oversight.** The independent auditor engaged under B.5.6 shall review the Index access log as part of its periodic review and report any irregular access pattern (e.g., access by a person without delegated duties, edits without a corresponding B.6.1(b) annual review) to the full Board.
 
 **B.6.2 License Registry.** The Organization shall maintain a public registry of: (a) all active commercial licenses (Licensee name and effective date); (b) all revocation decisions (grounds and summary, per SCCL Article 6.5c); (c) all terminations. The registry does not disclose fee amounts or Relationship Index scores.
 


### PR DESCRIPTION
## Summary
- Builds on the SCCL v1 / Organization Charter draft from #104 (still open — this branch carries that draft's file content forward onto current main so the diff below is scoped to the actual change).
- Preamble now names Linux's GPLv2 explicitly as the license's foundational precedent, explains why AGPLv3+SCCL extends it one step further for hyperscale operators, and cites the Elastic/MongoDB/Redis SSPL history as the dynamic this License exists to avoid repeating for this Project.
- New SCCL Article 4.2.1 + Charter B.6.4: Fee Formula changes (K1, K2, inflation buffer, allocation ranges) require community ratification from Governance Stage 3 onward — a petition from 15% of Active Contributors stays a Board-proposed change pending a ratification vote; at Stage 4 every such change requires Pool ratification, not just contested ones.
- New SCCL Article 6.8 + Charter B.6.3: revocation decisions (and contested non-revocations) can be escalated by petition to a binding contributor vote from Stage 3 onward, instead of being the Board's to finalize alone.
- Both new checks are added to the Charter's immutable-provisions list (B.4.6(h)/(i)) so a future Board can't strip them via amendment.

## Why
Addresses #83 (legal-framework sustainability) and #86 (governance documentation) directly: the open question in both was whether decisions of consequence rest with the Board alone or with the community. This lands a hybrid model — Board keeps day-to-day authority, but the two decision classes most likely to be leveraged against the community (how much a commercial entity pays, whether it gets cut off) get binding community ratification once the project is past the earliest bootstrap stage.

## Test plan
- [ ] Legal counsel review (per #83's outstanding checklist item — unchanged by this PR)
- [ ] Maintainer read-through for internal consistency with the rest of #104's draft
- [ ] Confirm jurisdiction (Article 8.3, still a placeholder) doesn't conflict with the new ratification mechanics

Refs #83, #86, #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)