### PR TITLE
Harness parity: key-less providers, lmstudio type, embed(), stream_chat()

### DIFF
--- a/jarvis/cli.py
+++ b/jarvis/cli.py
@@ -368,7 +368,9 @@ def _cmd_providers() -> None:
         ptype = flags.get("type", "")
         model = flags.get("model", "")
         if not ptype or not model:
-            print("Usage: jarvis providers add --type <ollama|api> --model <model>")
+            print(
+                "Usage: jarvis providers add --type <ollama|api|lmstudio> --model <model>"
+            )
             print(
                 "  Optional: --name <label> --url <url> --key <api_key> --temperature <0.0-2.0>"
             )
@@ -484,6 +486,9 @@ def show_usage() -> None:
     print("  jarvis providers                                    # List providers")
     print("  jarvis providers add --type ollama --model <model>  # Add Ollama")
     print("  jarvis providers add --type api --model <m> --url <u> --key <k>")
+    print(
+        "  jarvis providers add --type lmstudio --model <m>    # Add LM Studio (no key needed)"
+    )
     print("  jarvis providers remove <name>                      # Remove provider")
     print("  jarvis providers move <name> <position>             # Reorder priority")
     print("  jarvis providers edit <name> --model <model>        # Update a field")

--- a/jarvis/contextor/embeddings.py
+++ b/jarvis/contextor/embeddings.py
@@ -11,12 +11,11 @@ Why Ollama embeddings?
 - nomic-embed-text is small (~270MB) and produces 768-dim vectors
 """
 
-import subprocess
-import time
 from typing import List
 
 from ..config import Config
 from ..core.logger import get_logger
+from ..llm.ollama_utils import try_start_ollama as _try_start_ollama_base
 
 logger = get_logger(__name__)
 
@@ -25,45 +24,8 @@ DEFAULT_EMBED_MODEL = "nomic-embed-text"
 _CONNECT_KEYWORDS = ("connect", "connection", "refused", "unreachable", "timeout")
 
 
-def _is_ollama_up(base_url: str) -> bool:
-    import urllib.request
-
-    try:
-        urllib.request.urlopen(f"{base_url}/api/tags", timeout=2)
-        return True
-    except Exception:
-        return False
-
-
 def _try_start_ollama(base_url: str) -> bool:
-    """Start Ollama via platform service manager or direct spawn."""
-    from ..platform import current as platform
-
-    if platform.try_start_service("ollama", base_url):
-        logger.info("Embeddings: Ollama started via system service manager")
-        return True
-
-    try:
-        subprocess.Popen(
-            ["ollama", "serve"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-    except FileNotFoundError:
-        logger.warning("Embeddings: ollama binary not found; cannot auto-start")
-        return False
-    except Exception as exc:
-        logger.warning(f"Embeddings: Failed to spawn ollama serve: {exc}")
-        return False
-
-    for _ in range(5):
-        time.sleep(1)
-        if _is_ollama_up(base_url):
-            logger.info("Embeddings: Ollama started via direct spawn")
-            return True
-
-    logger.warning("Embeddings: Ollama auto-start attempted but did not become ready")
-    return False
+    return _try_start_ollama_base(base_url, log_prefix="Embeddings")
 
 
 class OllamaEmbeddings:

--- a/jarvis/core/component_factory.py
+++ b/jarvis/core/component_factory.py
@@ -59,8 +59,11 @@ class ComponentFactory:
                         kwargs["think"] = spec["think"]
                     elif llm_think is not None:
                         kwargs["think"] = llm_think
-                elif ptype == "api":
-                    kwargs["api_url"] = spec.get("url", "")
+                elif ptype in ("api", "lmstudio"):
+                    default_url = (
+                        "http://localhost:1234/v1" if ptype == "lmstudio" else ""
+                    )
+                    kwargs["api_url"] = spec.get("url") or default_url
                     kwargs["api_key"] = spec.get("api_key", "")
                     if spec.get("headers"):
                         kwargs["headers"] = spec["headers"]

--- a/jarvis/core/providers.py
+++ b/jarvis/core/providers.py
@@ -55,11 +55,16 @@ def add_provider(
 ) -> Tuple[str, int]:
     """Add a provider. Returns (name, position) or raises ValueError."""
     ptype = ptype.lower()
-    if ptype not in ("ollama", "api"):
-        raise ValueError(f"Unknown provider type '{ptype}'. Use 'ollama' or 'api'.")
+    if ptype not in ("ollama", "api", "lmstudio"):
+        raise ValueError(
+            f"Unknown provider type '{ptype}'. Use 'ollama', 'api', or 'lmstudio'."
+        )
 
-    if ptype == "api" and (not url or not api_key):
-        raise ValueError("API providers require url and api_key.")
+    if ptype == "lmstudio" and not url:
+        url = "http://localhost:1234/v1"
+
+    if ptype in ("api", "lmstudio") and not url:
+        raise ValueError("API/LM Studio providers require a url.")
 
     data = load_providers()
     existing_names = [p.get("name") for p in data.get("providers", [])]

--- a/jarvis/llm/base.py
+++ b/jarvis/llm/base.py
@@ -6,7 +6,7 @@ The rest of JARVIS only depends on this interface.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, List
+from typing import Dict, Iterator, List
 
 
 class BaseLLMProvider(ABC):
@@ -24,6 +24,22 @@ class BaseLLMProvider(ABC):
     @abstractmethod
     def is_available(self) -> bool:
         """Return True if the provider backend is reachable."""
+
+    def stream_chat(self, messages: List[Dict[str, str]]) -> Iterator[str]:
+        """Yield the response incrementally, as it is generated.
+
+        Purely additive: providers that don't override this fall back to
+        yielding the full ``chat()`` result as a single chunk, so existing
+        behavior for any caller that doesn't opt into streaming is
+        unchanged.
+
+        Note: nothing in the current ROOT/DISPATCH action-parsing path
+        consumes this yet — that path expects a complete, parseable JSON
+        object from the LLM, which requires incremental JSON parsing to
+        stream safely. Wiring this into `jarvis ask`/the TUI is tracked as
+        separate follow-up work, not implied by this method existing.
+        """
+        yield self.chat(messages)
 
     def embed(self, texts: List[str]) -> List[List[float]]:
         """Generate embedding vectors for a batch of texts.

--- a/jarvis/llm/base.py
+++ b/jarvis/llm/base.py
@@ -24,3 +24,12 @@ class BaseLLMProvider(ABC):
     @abstractmethod
     def is_available(self) -> bool:
         """Return True if the provider backend is reachable."""
+
+    def embed(self, texts: List[str]) -> List[List[float]]:
+        """Generate embedding vectors for a batch of texts.
+
+        Not every provider/model supports embeddings — the default
+        raises so callers get a clear, immediate error rather than a
+        confusing failure further down the stack.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support embeddings")

--- a/jarvis/llm/ollama_utils.py
+++ b/jarvis/llm/ollama_utils.py
@@ -1,0 +1,65 @@
+"""Shared helpers for talking to a local/remote Ollama server.
+
+Used by both the chat provider (``jarvis.llm.providers.ollama``) and the
+embeddings provider (``jarvis.contextor.embeddings``) so the reachability
+check and auto-start logic exist in exactly one place instead of two
+near-identical copies.
+"""
+
+import subprocess
+import time
+
+from ..core.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def is_ollama_up(base_url: str) -> bool:
+    """Return True if Ollama responds on base_url/api/tags within 2 s."""
+    import urllib.request
+
+    try:
+        urllib.request.urlopen(f"{base_url}/api/tags", timeout=2)
+        return True
+    except Exception:
+        return False
+
+
+def try_start_ollama(base_url: str, log_prefix: str = "") -> bool:
+    """Start Ollama via platform service manager or direct spawn.
+
+    Returns True if it comes up. ``log_prefix`` is prepended to log lines
+    (e.g. ``"Embeddings"``) so callers keep their existing log identity.
+    """
+    prefix = f"{log_prefix}: " if log_prefix else ""
+    logger.info(f"{prefix}Ollama not reachable — attempting auto-start")
+
+    from ..platform import current as platform
+
+    if platform.try_start_service("ollama", base_url):
+        logger.info(f"{prefix}Ollama started via system service manager")
+        return True
+
+    try:
+        subprocess.Popen(
+            ["ollama", "serve"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        logger.warning(f"{prefix}ollama binary not found; cannot auto-start")
+        return False
+    except Exception as exc:
+        logger.warning(f"{prefix}Failed to spawn ollama serve: {exc}")
+        return False
+
+    for _ in range(5):
+        time.sleep(1)
+        if is_ollama_up(base_url):
+            logger.info(f"{prefix}Ollama started via direct spawn")
+            return True
+
+    logger.warning(
+        f"{prefix}Ollama auto-start attempted but did not become ready in time"
+    )
+    return False

--- a/jarvis/llm/provider_pool.py
+++ b/jarvis/llm/provider_pool.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from ..core.logger import get_logger
 from .base import BaseLLMProvider
@@ -119,6 +119,53 @@ class ProviderPool(BaseLLMProvider):
         raise RuntimeError(
             "All LLM providers are unavailable for embeddings:\n"
             + self._status_lines_text(now)
+        )
+
+    def stream_chat(self, messages: List[Dict[str, str]]) -> Iterator[str]:
+        """Stream with failover — but only before any chunk has been yielded.
+
+        Once a provider has yielded at least one chunk, a mid-stream error
+        cannot be silently retried on another provider without risking
+        duplicated/garbled output, so it propagates instead of failing over.
+        """
+        now = datetime.now()
+        self._restore_cooled_down(now)
+
+        errors: List[tuple[str, str]] = []
+        for entry in self._entries:
+            if entry.status != "active":
+                continue
+            try:
+                gen = entry.provider.stream_chat(messages)
+                first_chunk = next(gen)
+            except StopIteration:
+                self.model = entry.provider.model
+                return
+            except Exception as e:
+                entry.failure_count += 1
+                entry.last_error = str(e)
+                self._classify_and_mark(entry, e, now)
+                errors.append((entry.name, str(e)))
+                if len(self._entries) > 1:
+                    logger.warning(
+                        f"Provider '{entry.name}' failed to start streaming "
+                        f"({entry.status}), trying next"
+                    )
+                continue
+
+            self.model = entry.provider.model
+            if entry.failure_count > 0:
+                logger.info(f"Provider '{entry.name}' recovered")
+                entry.failure_count = 0
+
+            yield first_chunk
+            yield from gen
+            self.last_prompt_tokens = entry.provider.last_prompt_tokens
+            self.last_completion_tokens = entry.provider.last_completion_tokens
+            return
+
+        raise RuntimeError(
+            "All LLM providers are unavailable:\n" + self._status_lines_text(now)
         )
 
     def _status_lines_text(self, now: datetime) -> str:

--- a/jarvis/llm/provider_pool.py
+++ b/jarvis/llm/provider_pool.py
@@ -78,6 +78,50 @@ class ProviderPool(BaseLLMProvider):
                         f"trying next"
                     )
 
+        raise RuntimeError(
+            "All LLM providers are unavailable:\n" + self._status_lines_text(now)
+        )
+
+    def embed(self, texts: List[str]) -> List[List[float]]:
+        now = datetime.now()
+        self._restore_cooled_down(now)
+
+        errors: List[tuple[str, str]] = []
+        unsupported = 0
+        for entry in self._entries:
+            if entry.status != "active":
+                continue
+            try:
+                result = entry.provider.embed(texts)
+                if entry.failure_count > 0:
+                    logger.info(f"Provider '{entry.name}' recovered")
+                    entry.failure_count = 0
+                return result
+            except NotImplementedError:
+                unsupported += 1
+                continue
+            except Exception as e:
+                entry.failure_count += 1
+                entry.last_error = str(e)
+                self._classify_and_mark(entry, e, now)
+                errors.append((entry.name, str(e)))
+                if len(self._entries) > 1:
+                    logger.warning(
+                        f"Provider '{entry.name}' failed embeddings "
+                        f"({entry.status}), trying next"
+                    )
+
+        if unsupported and not errors:
+            raise NotImplementedError(
+                "No active provider in the pool supports embeddings"
+            )
+
+        raise RuntimeError(
+            "All LLM providers are unavailable for embeddings:\n"
+            + self._status_lines_text(now)
+        )
+
+    def _status_lines_text(self, now: datetime) -> str:
         status_lines = []
         for entry in self._entries:
             line = f"  {entry.name}: {entry.status}"
@@ -87,10 +131,7 @@ class ProviderPool(BaseLLMProvider):
             if entry.last_error:
                 line += f" — {entry.last_error}"
             status_lines.append(line)
-
-        raise RuntimeError(
-            "All LLM providers are unavailable:\n" + "\n".join(status_lines)
-        )
+        return "\n".join(status_lines)
 
     def is_available(self) -> bool:
         self._restore_cooled_down(datetime.now())

--- a/jarvis/llm/providers/__init__.py
+++ b/jarvis/llm/providers/__init__.py
@@ -15,7 +15,7 @@ def create_provider(
     """Create an LLM provider instance.
 
     Args:
-        provider: Provider name (``"ollama"`` or ``"api"``).
+        provider: Provider name (``"ollama"``, ``"api"``, or ``"lmstudio"``).
         model: Model name / identifier.
         **kwargs: Provider-specific options (base_url, api_key, etc.).
 
@@ -33,12 +33,14 @@ def create_provider(
 
         return OllamaProvider(model=model, **kwargs)
 
-    if provider == "api":
+    if provider in ("api", "lmstudio"):
         from .api import APIProvider
 
         return APIProvider(model=model, **kwargs)
 
-    raise ValueError(f"Unknown LLM provider: '{provider}'. Available: ollama, api")
+    raise ValueError(
+        f"Unknown LLM provider: '{provider}'. Available: ollama, api, lmstudio"
+    )
 
 
 __all__ = ["BaseLLMProvider", "create_provider"]

--- a/jarvis/llm/providers/api.py
+++ b/jarvis/llm/providers/api.py
@@ -12,7 +12,9 @@ class APIProvider(BaseLLMProvider):
     """Provider for OpenAI-compatible API endpoints.
 
     Works with OpenAI, Claude (via compatibility layer), OpenRouter,
-    and any server that exposes ``/v1/chat/completions``.
+    and any server that exposes ``/v1/chat/completions`` — including
+    key-less local servers such as LM Studio, where ``api_key`` may be
+    omitted entirely.
     """
 
     def __init__(
@@ -24,17 +26,14 @@ class APIProvider(BaseLLMProvider):
     ):
         if not api_url:
             raise ValueError("api_url is required for the API provider")
-        if not api_key:
-            raise ValueError("api_key is required for the API provider")
 
         super().__init__(model)
         self.api_url = api_url.rstrip("/")
         self.api_key = api_key
 
-        self.headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {api_key}",
-        }
+        self.headers = {"Content-Type": "application/json"}
+        if api_key:
+            self.headers["Authorization"] = f"Bearer {api_key}"
         if headers:
             self.headers.update(headers)
 
@@ -106,3 +105,33 @@ class APIProvider(BaseLLMProvider):
         except Exception as e:
             logger.debug(f"API availability check failed: {e}")
             return True
+
+    def embed(self, texts: List[str]) -> List[List[float]]:
+        self._ensure_client()
+
+        payload = {"model": self.model, "input": texts}
+
+        try:
+            with self._httpx.Client(timeout=60.0) as client:
+                response = client.post(
+                    f"{self.api_url}/v1/embeddings",
+                    headers=self.headers,
+                    json=payload,
+                )
+                response.raise_for_status()
+                result = response.json()
+
+                data = result.get("data")
+                if not data:
+                    raise ValueError(f"Unexpected embeddings response format: {result}")
+                return [
+                    item["embedding"]
+                    for item in sorted(data, key=lambda d: d.get("index", 0))
+                ]
+
+        except self._httpx.HTTPError as e:
+            logger.error(f"API embeddings HTTP error: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"API embeddings error: {e}")
+            raise

--- a/jarvis/llm/providers/api.py
+++ b/jarvis/llm/providers/api.py
@@ -1,6 +1,7 @@
 """OpenAI-compatible API LLM provider."""
 
-from typing import Any, Dict, List, Optional
+import json
+from typing import Any, Dict, Iterator, List, Optional
 
 from ...core.logger import get_logger
 from ..base import BaseLLMProvider
@@ -86,6 +87,47 @@ class APIProvider(BaseLLMProvider):
             raise
         except Exception as e:
             logger.error(f"API chat error: {e}")
+            raise
+
+    def stream_chat(self, messages: List[Dict[str, str]]) -> Iterator[str]:
+        """Yield response text incrementally via SSE (`stream: true`)."""
+        self._ensure_client()
+
+        payload = {"model": self.model, "messages": messages, "stream": True}
+
+        try:
+            with self._httpx.Client(timeout=60.0) as client:
+                with client.stream(
+                    "POST",
+                    f"{self.api_url}/v1/chat/completions",
+                    headers=self.headers,
+                    json=payload,
+                ) as response:
+                    response.raise_for_status()
+                    for line in response.iter_lines():
+                        if not line or not line.startswith("data: "):
+                            continue
+                        data = line[len("data: ") :].strip()
+                        if data == "[DONE]":
+                            break
+                        chunk = json.loads(data)
+                        choices = chunk.get("choices") or []
+                        if choices:
+                            content = choices[0].get("delta", {}).get("content")
+                            if content:
+                                yield content
+                        usage = chunk.get("usage")
+                        if usage:
+                            self.last_prompt_tokens = usage.get("prompt_tokens", 0) or 0
+                            self.last_completion_tokens = (
+                                usage.get("completion_tokens", 0) or 0
+                            )
+
+        except self._httpx.HTTPError as e:
+            logger.error(f"API stream chat HTTP error: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"API stream chat error: {e}")
             raise
 
     def is_available(self) -> bool:

--- a/jarvis/llm/providers/ollama.py
+++ b/jarvis/llm/providers/ollama.py
@@ -1,7 +1,7 @@
 """Ollama LLM provider."""
 
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from ...core.logger import get_logger
 from ..base import BaseLLMProvider
@@ -221,6 +221,42 @@ class OllamaProvider(BaseLLMProvider):
         except Exception as e:
             logger.debug(f"Ollama not available: {e}")
             return False
+
+    def stream_chat(self, messages: List[Dict[str, str]]) -> Iterator[str]:
+        """Yield response text incrementally via Ollama's streaming chat.
+
+        Simplifications vs. ``chat()``: does not auto-pull a missing model
+        (the model must already exist) and does not apply the special-token
+        stripping / thinking-field fallback that ``_extract_content`` does
+        for non-streaming responses — content is yielded as the model emits
+        it.
+        """
+        self._maybe_autostart()
+        self._ensure_client()
+
+        options = {}
+        if self.temperature is not None:
+            options["temperature"] = self.temperature
+
+        kwargs: Dict[str, object] = {
+            "model": self.model,
+            "messages": messages,
+            "options": options or None,
+            "stream": True,
+        }
+        if self.strict_json:
+            kwargs["format"] = "json"
+        if self.think is not None:
+            kwargs["think"] = self.think
+
+        for chunk in self._client.chat(**kwargs):
+            msg = chunk["message"]
+            content = msg.get("content") or ""
+            if content:
+                yield content
+            if chunk.get("done"):
+                self.last_prompt_tokens = chunk.get("prompt_eval_count", 0) or 0
+                self.last_completion_tokens = chunk.get("eval_count", 0) or 0
 
     def embed(self, texts: List[str]) -> List[List[float]]:
         self._maybe_autostart()

--- a/jarvis/llm/providers/ollama.py
+++ b/jarvis/llm/providers/ollama.py
@@ -1,12 +1,12 @@
 """Ollama LLM provider."""
 
-import subprocess
 import sys
-import time
 from typing import Any, Dict, List, Optional
 
 from ...core.logger import get_logger
 from ..base import BaseLLMProvider
+from ..ollama_utils import is_ollama_up as _is_ollama_up
+from ..ollama_utils import try_start_ollama as _try_start_ollama
 
 logger = get_logger(__name__)
 
@@ -15,51 +15,6 @@ LLM_TIMEOUT = 60  # seconds — prevents indefinite hangs on cloud API
 _shared_clients: Dict[tuple, Any] = {}
 _last_autostart: Dict[str, float] = {}
 AUTOSTART_COOLDOWN = 60.0
-
-
-def _is_ollama_up(base_url: str) -> bool:
-    """Return True if Ollama responds on base_url/api/tags within 2 s."""
-    import urllib.request
-
-    try:
-        urllib.request.urlopen(f"{base_url}/api/tags", timeout=2)
-        return True
-    except Exception:
-        return False
-
-
-def _try_start_ollama(base_url: str) -> bool:
-    """Start Ollama via platform service manager or direct spawn. Return True if it comes up."""
-    logger.info("Ollama not reachable — attempting auto-start")
-
-    from ...platform import current as platform
-
-    if platform.try_start_service("ollama", base_url):
-        logger.info("Ollama started via system service manager")
-        return True
-
-    # Fall back to direct spawn
-    try:
-        subprocess.Popen(
-            ["ollama", "serve"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-    except FileNotFoundError:
-        logger.warning("ollama binary not found; cannot auto-start")
-        return False
-    except Exception as exc:
-        logger.warning(f"Failed to spawn ollama serve: {exc}")
-        return False
-
-    for _ in range(5):
-        time.sleep(1)
-        if _is_ollama_up(base_url):
-            logger.info("Ollama started via direct spawn")
-            return True
-
-    logger.warning("Ollama auto-start attempted but did not become ready in time")
-    return False
 
 
 def _get_shared_client(host: str, api_key: Optional[str]) -> Any:
@@ -266,6 +221,14 @@ class OllamaProvider(BaseLLMProvider):
         except Exception as e:
             logger.debug(f"Ollama not available: {e}")
             return False
+
+    def embed(self, texts: List[str]) -> List[List[float]]:
+        self._maybe_autostart()
+        self._ensure_client()
+        return [
+            self._client.embeddings(model=self.model, prompt=text)["embedding"]
+            for text in texts
+        ]
 
     # -- Ollama-specific -----------------------------------------------------
 

--- a/tests/test_embeddings_capability.py
+++ b/tests/test_embeddings_capability.py
@@ -1,0 +1,102 @@
+"""Tests for the first-class embed() capability on BaseLLMProvider,
+OllamaProvider, APIProvider, and ProviderPool (#180).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from jarvis.llm.base import BaseLLMProvider
+from jarvis.llm.provider_pool import ProviderEntry, ProviderPool
+from jarvis.llm.providers.api import APIProvider
+from jarvis.llm.providers.ollama import OllamaProvider
+
+
+class _MinimalProvider(BaseLLMProvider):
+    """Bare-bones provider that only implements the abstract methods."""
+
+    def chat(self, messages):
+        return "ok"
+
+    def is_available(self):
+        return True
+
+
+class TestBaseLLMProviderDefault:
+    def test_embed_not_implemented_by_default(self):
+        provider = _MinimalProvider("test-model")
+        with pytest.raises(NotImplementedError, match="does not support embeddings"):
+            provider.embed(["hello"])
+
+
+class TestOllamaProviderEmbed:
+    def test_embed_calls_client_per_text(self, monkeypatch):
+        provider = OllamaProvider("nomic-embed-text")
+        monkeypatch.setattr(provider, "_maybe_autostart", lambda: None)
+        monkeypatch.setattr(provider, "_ensure_client", lambda: None)
+
+        mock_client = MagicMock()
+        mock_client.embeddings.side_effect = [
+            {"embedding": [0.1, 0.2]},
+            {"embedding": [0.3, 0.4]},
+        ]
+        provider._client = mock_client
+
+        result = provider.embed(["a", "b"])
+
+        assert result == [[0.1, 0.2], [0.3, 0.4]]
+        assert mock_client.embeddings.call_count == 2
+        mock_client.embeddings.assert_any_call(model="nomic-embed-text", prompt="a")
+
+
+class TestAPIProviderEmbed:
+    def test_embed_posts_and_sorts_by_index(self, monkeypatch):
+        provider = APIProvider(
+            model="text-embedding-3-small", api_url="http://localhost:8080"
+        )
+        monkeypatch.setattr(provider, "_ensure_client", lambda: None)
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {"embedding": [0.9, 0.9], "index": 1},
+                {"embedding": [0.1, 0.1], "index": 0},
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+
+        mock_client_cm = MagicMock()
+        mock_client_cm.__enter__.return_value.post.return_value = mock_response
+
+        mock_httpx = MagicMock()
+        mock_httpx.Client.return_value = mock_client_cm
+        mock_httpx.HTTPError = Exception
+        provider._httpx = mock_httpx
+
+        result = provider.embed(["a", "b"])
+
+        assert result == [[0.1, 0.1], [0.9, 0.9]]
+
+
+class TestProviderPoolEmbed:
+    def test_falls_through_unsupported_to_supporting_provider(self):
+        chat_only = _MinimalProvider("chat-model")
+        embed_capable = _MinimalProvider("embed-model")
+        embed_capable.embed = lambda texts: [[1.0] for _ in texts]  # type: ignore
+
+        pool = ProviderPool(
+            [
+                ProviderEntry(provider=chat_only, name="chat-only"),
+                ProviderEntry(provider=embed_capable, name="embed-capable"),
+            ]
+        )
+
+        result = pool.embed(["x"])
+        assert result == [[1.0]]
+
+    def test_raises_not_implemented_when_no_provider_supports_it(self):
+        pool = ProviderPool(
+            [ProviderEntry(provider=_MinimalProvider("m"), name="only")]
+        )
+        with pytest.raises(NotImplementedError, match="No active provider"):
+            pool.embed(["x"])

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,85 @@
+"""Tests for provider CRUD (jarvis.core.providers) and provider creation
+(jarvis.llm.providers), covering the key-less API provider fix (#177) and
+the lmstudio provider type (#179).
+"""
+
+import json
+
+import pytest
+
+from jarvis.core import providers as providers_module
+from jarvis.llm.providers import create_provider
+from jarvis.llm.providers.api import APIProvider
+
+
+@pytest.fixture
+def isolated_providers_file(tmp_path, monkeypatch):
+    providers_file = tmp_path / "providers.json"
+    monkeypatch.setattr(providers_module.Config, "PROVIDERS_FILE", str(providers_file))
+    return str(providers_file)
+
+
+class TestAPIProviderKeyless:
+    def test_api_url_still_required(self):
+        with pytest.raises(ValueError, match="api_url is required"):
+            APIProvider(model="gpt-4", api_url="", api_key="")
+
+    def test_api_key_is_optional(self):
+        provider = APIProvider(model="gpt-4", api_url="http://localhost:1234/v1")
+        assert "Authorization" not in provider.headers
+
+    def test_api_key_sets_authorization_header(self):
+        provider = APIProvider(
+            model="gpt-4", api_url="http://localhost:8080", api_key="sk-test"
+        )
+        assert provider.headers["Authorization"] == "Bearer sk-test"
+
+
+class TestCreateProviderLmstudio:
+    def test_lmstudio_dispatches_to_api_provider(self):
+        provider = create_provider(
+            provider="lmstudio",
+            model="local-model",
+            api_url="http://localhost:1234/v1",
+        )
+        assert isinstance(provider, APIProvider)
+
+    def test_unknown_provider_lists_lmstudio(self):
+        with pytest.raises(ValueError, match="lmstudio"):
+            create_provider(provider="bogus", model="x")
+
+
+class TestAddProviderLmstudio:
+    def test_lmstudio_defaults_url(self, isolated_providers_file):
+        name, _ = providers_module.add_provider(ptype="lmstudio", model="local-model")
+        with open(isolated_providers_file) as f:
+            data = json.load(f)
+        entry = next(p for p in data["providers"] if p["name"] == name)
+        assert entry["url"] == "http://localhost:1234/v1"
+        assert "api_key" not in entry
+
+    def test_lmstudio_explicit_url_respected(self, isolated_providers_file):
+        name, _ = providers_module.add_provider(
+            ptype="lmstudio", model="local-model", url="http://192.168.1.5:1234/v1"
+        )
+        with open(isolated_providers_file) as f:
+            data = json.load(f)
+        entry = next(p for p in data["providers"] if p["name"] == name)
+        assert entry["url"] == "http://192.168.1.5:1234/v1"
+
+    def test_api_type_no_longer_requires_key(self, isolated_providers_file):
+        name, _ = providers_module.add_provider(
+            ptype="api", model="local-model", url="http://localhost:8080/v1"
+        )
+        with open(isolated_providers_file) as f:
+            data = json.load(f)
+        entry = next(p for p in data["providers"] if p["name"] == name)
+        assert "api_key" not in entry
+
+    def test_api_type_still_requires_url(self, isolated_providers_file):
+        with pytest.raises(ValueError, match="require a url"):
+            providers_module.add_provider(ptype="api", model="local-model")
+
+    def test_unknown_type_rejected(self, isolated_providers_file):
+        with pytest.raises(ValueError, match="lmstudio"):
+            providers_module.add_provider(ptype="bogus", model="local-model")

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,147 @@
+"""Tests for stream_chat() on BaseLLMProvider, OllamaProvider, APIProvider,
+and ProviderPool (#178).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from jarvis.llm.base import BaseLLMProvider
+from jarvis.llm.provider_pool import ProviderEntry, ProviderPool
+from jarvis.llm.providers.api import APIProvider
+from jarvis.llm.providers.ollama import OllamaProvider
+
+
+class _MinimalProvider(BaseLLMProvider):
+    def chat(self, messages):
+        return "buffered full response"
+
+    def is_available(self):
+        return True
+
+
+class TestBaseLLMProviderDefaultStreaming:
+    def test_falls_back_to_single_chunk(self):
+        provider = _MinimalProvider("test-model")
+        chunks = list(provider.stream_chat([{"role": "user", "content": "hi"}]))
+        assert chunks == ["buffered full response"]
+
+
+class TestOllamaProviderStreaming:
+    def test_yields_content_deltas_and_captures_usage(self, monkeypatch):
+        provider = OllamaProvider("qwen3:4b")
+        monkeypatch.setattr(provider, "_maybe_autostart", lambda: None)
+        monkeypatch.setattr(provider, "_ensure_client", lambda: None)
+
+        mock_client = MagicMock()
+        mock_client.chat.return_value = iter(
+            [
+                {"message": {"content": "Hel"}, "done": False},
+                {"message": {"content": "lo"}, "done": False},
+                {
+                    "message": {"content": ""},
+                    "done": True,
+                    "prompt_eval_count": 10,
+                    "eval_count": 2,
+                },
+            ]
+        )
+        provider._client = mock_client
+
+        chunks = list(provider.stream_chat([{"role": "user", "content": "hi"}]))
+
+        assert chunks == ["Hel", "lo"]
+        assert provider.last_prompt_tokens == 10
+        assert provider.last_completion_tokens == 2
+        assert mock_client.chat.call_args.kwargs["stream"] is True
+
+
+class TestAPIProviderStreaming:
+    def test_parses_sse_deltas(self, monkeypatch):
+        provider = APIProvider(model="gpt-4", api_url="http://localhost:8080")
+        monkeypatch.setattr(provider, "_ensure_client", lambda: None)
+
+        sse_lines = [
+            'data: {"choices": [{"delta": {"content": "Hel"}}]}',
+            'data: {"choices": [{"delta": {"content": "lo"}}]}',
+            'data: {"choices": [{"delta": {}}], "usage": '
+            '{"prompt_tokens": 5, "completion_tokens": 2}}',
+            "data: [DONE]",
+        ]
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.iter_lines.return_value = iter(sse_lines)
+
+        mock_stream_cm = MagicMock()
+        mock_stream_cm.__enter__.return_value = mock_response
+
+        mock_client_cm = MagicMock()
+        mock_client_cm.__enter__.return_value.stream.return_value = mock_stream_cm
+
+        mock_httpx = MagicMock()
+        mock_httpx.Client.return_value = mock_client_cm
+        mock_httpx.HTTPError = Exception
+        provider._httpx = mock_httpx
+
+        chunks = list(provider.stream_chat([{"role": "user", "content": "hi"}]))
+
+        assert chunks == ["Hel", "lo"]
+        assert provider.last_prompt_tokens == 5
+        assert provider.last_completion_tokens == 2
+
+
+class TestProviderPoolStreaming:
+    def test_streams_from_first_active_provider(self):
+        provider = _MinimalProvider("m")
+        provider.stream_chat = lambda messages: iter(["a", "b", "c"])  # type: ignore
+        pool = ProviderPool([ProviderEntry(provider=provider, name="only")])
+
+        assert list(pool.stream_chat([{"role": "user", "content": "hi"}])) == [
+            "a",
+            "b",
+            "c",
+        ]
+
+    def test_fails_over_before_any_chunk_yielded(self):
+        def broken_stream(messages):
+            raise RuntimeError("connection refused")
+            yield  # pragma: no cover - never reached, makes this a generator
+
+        broken = _MinimalProvider("broken")
+        broken.stream_chat = broken_stream  # type: ignore
+
+        healthy = _MinimalProvider("healthy")
+        healthy.stream_chat = lambda messages: iter(["ok"])  # type: ignore
+
+        pool = ProviderPool(
+            [
+                ProviderEntry(provider=broken, name="broken"),
+                ProviderEntry(provider=healthy, name="healthy"),
+            ]
+        )
+
+        assert list(pool.stream_chat([{"role": "user", "content": "hi"}])) == ["ok"]
+
+    def test_mid_stream_error_propagates_without_failover(self):
+        def flaky_stream(messages):
+            yield "partial"
+            raise RuntimeError("dropped connection")
+
+        flaky = _MinimalProvider("flaky")
+        flaky.stream_chat = flaky_stream  # type: ignore
+
+        healthy = _MinimalProvider("healthy")
+        healthy.stream_chat = lambda messages: iter(["should not reach"])  # type: ignore
+
+        pool = ProviderPool(
+            [
+                ProviderEntry(provider=flaky, name="flaky"),
+                ProviderEntry(provider=healthy, name="healthy"),
+            ]
+        )
+
+        gen = pool.stream_chat([{"role": "user", "content": "hi"}])
+        assert next(gen) == "partial"
+        with pytest.raises(RuntimeError, match="dropped connection"):
+            next(gen)


### PR DESCRIPTION
## Summary
- Closes #177: `APIProvider` no longer requires `api_key` — unblocks key-less local backends (LM Studio).
- Closes #179: adds `lmstudio` provider type, defaulting `api_url` to `http://localhost:1234/v1`.
- Closes #180: adds first-class `embed()` to `BaseLLMProvider`/`OllamaProvider`/`APIProvider`/`ProviderPool`; `contextor/embeddings.py` now reuses the shared Ollama auto-start helper (`jarvis/llm/ollama_utils.py`) instead of duplicating it.
- Closes #178: adds `stream_chat()` to the same set of classes — real SSE/Ollama-stream implementations, pool-level failover that only retries before any chunk has been yielded. Not wired into `jarvis ask`/TUI yet — that needs incremental JSON parsing on the ROOT/DISPATCH action-parsing path, called out as separate follow-up in the docstring.

Does not touch #181 (OpenAI-compatible HTTP server) — that one has an explicit security-posture tension with `SECURITY-ARCHITECTURE.md`'s "no TCP listener" claim and needs confirmation before any code gets written.

## Test plan
- [x] `tests/test_providers.py` (new) — api_key-optional + lmstudio defaults
- [x] `tests/test_embeddings_capability.py` (new) — embed() on all 4 classes
- [x] `tests/test_streaming.py` (new) — stream_chat() on all 4 classes, including pool failover-before-first-chunk and mid-stream-error-propagates cases
- [x] Full existing suite run — 12 pre-existing failures confirmed unrelated (same failures present on `main` before this branch), everything else passes
- [x] `black`/`isort` clean, `flake8 --select=E9,F63,F7,F82` (actual CI lint scope) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)