### PR TITLE
Opt-in OpenAI-compatible HTTP endpoint (security-safeguarded)

### DIFF
--- a/docs/SECURITY-ARCHITECTURE.md
+++ b/docs/SECURITY-ARCHITECTURE.md
@@ -85,10 +85,15 @@ The table below maps their critical CVEs to JARVIS design decisions.
 transmitting the user’s authentication token.  Attacker captured the
 token, reconnected to the legitimate gateway, and achieved full RCE.
 
-**JARVIS:** Has no WebSocket gateway, no auth token, and no TCP port
-listener.  The entire attack surface for this CVE does not exist.
+**JARVIS:** Has no WebSocket gateway and no URL-parameter-driven
+auto-connect-and-exfiltrate mechanism of any kind — the specific pattern
+this CVE exploited does not exist here, regardless of the optional TCP
+listener described under "Exposed Instances" below (that listener requires
+a bearer token per request and is never auto-triggered by a URL parameter
+or untrusted input).
 
-- Status: ✅ Eliminated by design (no network gateway)
+- Status: ✅ Eliminated by design (no WebSocket gateway, no URL-driven
+  auto-connect)
 
 ### CVE-2026-28472 “ClawJacked” — WebSocket Auth Bypass
 
@@ -111,8 +116,22 @@ authentication.
 — and are not reachable from the network.  `jarvis/core/socket_security.py`
 hardens their permissions to `0600` (owner-only) at creation time.
 
-- Status: ✅ Not network-exposed · ⚠️ Same-user local processes can still
-  reach the socket (see § Remaining Attack Surfaces below)
+- Status: ✅ Not network-exposed by default · ⚠️ Same-user local processes
+  can still reach the socket (see § Remaining Attack Surfaces below) ·
+  ⚠️ **Conditional exception:** `jarvis/server/openai_compat.py` adds an
+  **opt-in** OpenAI-compatible TCP listener (`JARVIS_OPENAI_SERVER_ENABLED`,
+  default `false`) so JARVIS can act as a backend for OpenAI-compatible
+  clients. When disabled (the default), this section's "not network-exposed"
+  claim holds exactly as stated above. When explicitly enabled, JARVIS gains
+  a TCP listener with the following mitigations, none of which are optional
+  once the feature is on: bound to loopback only unless a *second* explicit
+  opt-in (`JARVIS_OPENAI_SERVER_ALLOW_NONLOCAL`) is set; a bearer token is
+  required on every request (generated on first use, stored `0600`) — there
+  is no anonymous-access mode, which is the specific gap that made stock
+  Ollama instances discoverable on Shodan in the first place; and the
+  endpoint proxies to LLM inference only (`chat`/`stream_chat`) — it does
+  not go through ROOT/DISPATCH, MCP tool calls, or the TLA confirmation
+  gate, so a client hitting it gets completions, not shell access.
 
 ### Malicious Skill Marketplace
 

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -217,6 +217,26 @@ class Config:
         os.path.join(JARVIS_DATA_DIR, "jarvis.sock"),
     )
 
+    # OpenAI-compatible local HTTP endpoint (opt-in, off by default).
+    # SECURITY-SENSITIVE: this is a TCP listener, unlike every other JARVIS
+    # IPC surface (see core/socket_security.py's docstring). See
+    # jarvis/server/openai_compat.py and docs/SECURITY-ARCHITECTURE.md
+    # before changing any of these defaults.
+    OPENAI_SERVER_ENABLED = (
+        os.getenv("JARVIS_OPENAI_SERVER_ENABLED", "false").lower() == "true"
+    )
+    OPENAI_SERVER_HOST = os.getenv("JARVIS_OPENAI_SERVER_HOST", "127.0.0.1")
+    OPENAI_SERVER_PORT = int(os.getenv("JARVIS_OPENAI_SERVER_PORT", "8317"))
+    # A second, separate opt-in required to bind anything other than
+    # loopback — changing OPENAI_SERVER_HOST alone is not enough.
+    OPENAI_SERVER_ALLOW_NONLOCAL = (
+        os.getenv("JARVIS_OPENAI_SERVER_ALLOW_NONLOCAL", "false").lower() == "true"
+    )
+    OPENAI_SERVER_TOKEN_FILE = os.getenv(
+        "JARVIS_OPENAI_SERVER_TOKEN_FILE",
+        os.path.join(_DEFAULT_CONFIG_DIR, "openai_server_token"),
+    )
+
     # Threat Level Access (TLA) Confirmation
     # - "allow_all": never ask, run everything (power users / trusted environments)
     # - "smart":     only ask when tool has confirmation_required=true (default)

--- a/jarvis/main.py
+++ b/jarvis/main.py
@@ -39,6 +39,7 @@ from .runtime.lifecycle import (
     shutdown,
     start_runtime_services,
     stdin_is_tty,
+    stop_openai_server_if_running,
 )
 from .runtime.llm_bridge import ask_llm as runtime_ask_llm
 from .runtime.llm_bridge import ask_llm_sync as runtime_ask_llm_sync
@@ -136,6 +137,7 @@ class Jarvis:
         output_task = runtime_tasks["output_socket"]
         gui_task = runtime_tasks["gui_socket"]
         voice_thread = runtime_tasks["voice_thread"]
+        openai_server = runtime_tasks["openai_server"]
 
         logger.info("JARVIS: Event loop started")
 
@@ -164,6 +166,7 @@ class Jarvis:
             cancel_task_if_running(output_task)
             cancel_task_if_running(gui_task)
             join_voice_thread_if_running(voice_thread)
+            stop_openai_server_if_running(openai_server)
             if event_tasks:
                 logger.info(
                     f"JARVIS: Waiting for {len(event_tasks)} in-flight goal(s) to finish..."

--- a/jarvis/runtime/lifecycle.py
+++ b/jarvis/runtime/lifecycle.py
@@ -160,11 +160,22 @@ async def start_runtime_services(app: Any, logger: Logger) -> dict[str, Any]:
             has_clients=lambda: bool(app._output_clients) or bool(app._gui_clients),
         )
 
+    # Opt-in, off by default -- see jarvis/server/openai_compat.py's
+    # module docstring for why this is the one deliberate exception to
+    # JARVIS having no TCP listener.
+    openai_server = None
+    if Config.OPENAI_SERVER_ENABLED:
+        from ..server.openai_compat import OpenAICompatServer
+
+        openai_server = OpenAICompatServer(app.llm.provider)
+        openai_server.start()
+
     return {
         "input_socket": input_socket_task,
         "output_socket": output_socket_task,
         "gui_socket": gui_socket_task,
         "voice_thread": voice_thread,
+        "openai_server": openai_server,
     }
 
 
@@ -186,6 +197,12 @@ def join_voice_thread_if_running(
     """
     if thread and thread.is_alive():
         thread.join(timeout=timeout)
+
+
+def stop_openai_server_if_running(server: Optional[Any]) -> None:
+    """Stop the opt-in OpenAI-compat server if it was started."""
+    if server is not None and server.is_running:
+        server.stop()
 
 
 def request_stop(app: Any) -> None:

--- a/jarvis/server/__init__.py
+++ b/jarvis/server/__init__.py
@@ -1,0 +1,5 @@
+"""Optional local server surfaces for JARVIS.
+
+Everything under this package is opt-in and off by default — see
+``openai_compat.py`` for the OpenAI-compatible HTTP endpoint.
+"""

--- a/jarvis/server/openai_compat.py
+++ b/jarvis/server/openai_compat.py
@@ -1,0 +1,271 @@
+"""OpenAI-compatible local HTTP endpoint — opt-in, off by default.
+
+SECURITY CONTEXT (read before touching this file)
+--------------------------------------------------
+``docs/SECURITY-ARCHITECTURE.md`` states, as a security property, that
+JARVIS has "no WebSocket gateway, no auth token, and no TCP port
+listener" and that this eliminates real OpenClaw CVE classes
+(exposed-instance attacks like the ~40k Ollama-style deployments found on
+Shodan). This module is the one deliberate exception to that claim, and
+it exists specifically so JARVIS can act as a drop-in backend for
+OpenAI-compatible clients (aider, continue.dev, etc.) — the same role
+Ollama's ``:11434`` or LM Studio's ``:1234`` play.
+
+Because it reopens network-listener attack surface on purpose, it ships
+with safeguards that are not optional:
+
+1. **Off by default.** Nothing in this module runs unless
+   ``JARVIS_OPENAI_SERVER_ENABLED=true`` is set. ``jarvis run`` never
+   starts it otherwise.
+2. **Loopback-only by default.** Binding anything other than
+   ``127.0.0.1``/``localhost``/``::1`` additionally requires
+   ``JARVIS_OPENAI_SERVER_ALLOW_NONLOCAL=true`` — changing the host
+   alone is not enough.
+3. **Bearer token required on every request.** Generated on first use,
+   stored at ``Config.OPENAI_SERVER_TOKEN_FILE`` with ``0600``
+   permissions (mirrors the socket-hardening approach in
+   ``core/socket_security.py``). There is no anonymous access mode —
+   this is the exact gap that made stock Ollama instances routinely
+   discoverable on Shodan.
+4. **Inference only, no tool execution.** This proxies straight to a
+   ``BaseLLMProvider`` (chat/stream_chat) — it does not go through
+   ROOT/DISPATCH, MCP tool calls, or the TLA confirmation gate. A
+   client hitting this endpoint gets LLM completions, nothing more; it
+   cannot make JARVIS run a shell command.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import os
+import secrets
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Optional
+
+from ..config import Config
+from ..core.logger import get_logger
+from ..llm.base import BaseLLMProvider
+
+logger = get_logger(__name__)
+
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
+
+def _load_or_create_token() -> str:
+    """Return the bearer token, generating and persisting one on first use."""
+    path = Config.OPENAI_SERVER_TOKEN_FILE
+
+    if os.path.isfile(path):
+        with open(path) as f:
+            token = f.read().strip()
+        if token:
+            return token
+
+    token = secrets.token_urlsafe(32)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(token + "\n")
+    try:
+        os.chmod(path, 0o600)
+    except OSError as exc:
+        logger.warning(f"openai_server: could not chmod token file {path}: {exc}")
+
+    return token
+
+
+class _OpenAICompatHandler(BaseHTTPRequestHandler):
+    """Request handler. ``self.server`` carries the provider + token."""
+
+    server: "_OpenAICompatHTTPServer"
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        logger.debug("openai_server: " + format, *args)
+
+    def _check_auth(self) -> bool:
+        expected = f"Bearer {self.server.token}"
+        actual = self.headers.get("Authorization", "")
+        if not hmac.compare_digest(actual, expected):
+            self._send_json(401, {"error": {"message": "Unauthorized"}})
+            return False
+        return True
+
+    def _send_json(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path != "/v1/models":
+            self._send_json(404, {"error": {"message": "not found"}})
+            return
+        if not self._check_auth():
+            return
+
+        provider = self.server.provider
+        self._send_json(
+            200,
+            {
+                "object": "list",
+                "data": [{"id": provider.model, "object": "model"}],
+            },
+        )
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/v1/chat/completions":
+            self._send_json(404, {"error": {"message": "not found"}})
+            return
+        if not self._check_auth():
+            return
+
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(length) if length else b""
+        try:
+            payload = json.loads(raw or b"{}")
+        except json.JSONDecodeError:
+            self._send_json(400, {"error": {"message": "invalid JSON body"}})
+            return
+
+        messages = payload.get("messages", [])
+        if payload.get("stream"):
+            self._handle_stream(messages)
+        else:
+            self._handle_blocking(messages)
+
+    def _handle_blocking(self, messages: list) -> None:
+        provider = self.server.provider
+        try:
+            text = provider.chat(messages)
+        except Exception as e:
+            logger.error(f"openai_server: chat error: {e}")
+            self._send_json(500, {"error": {"message": str(e)}})
+            return
+
+        self._send_json(
+            200,
+            {
+                "id": "chatcmpl-jarvis",
+                "object": "chat.completion",
+                "model": provider.model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": text},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": provider.last_prompt_tokens,
+                    "completion_tokens": provider.last_completion_tokens,
+                },
+            },
+        )
+
+    def _handle_stream(self, messages: list) -> None:
+        provider = self.server.provider
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+
+        try:
+            for chunk in provider.stream_chat(messages):
+                event = {
+                    "id": "chatcmpl-jarvis",
+                    "object": "chat.completion.chunk",
+                    "model": provider.model,
+                    "choices": [{"index": 0, "delta": {"content": chunk}}],
+                }
+                self.wfile.write(f"data: {json.dumps(event)}\n\n".encode())
+                self.wfile.flush()
+        except Exception as e:
+            logger.error(f"openai_server: stream error: {e}")
+
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+
+
+class _OpenAICompatHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(self, address: tuple, provider: BaseLLMProvider, token: str):
+        super().__init__(address, _OpenAICompatHandler)
+        self.provider = provider
+        self.token = token
+
+
+class OpenAICompatServer:
+    """Manages the opt-in OpenAI-compatible endpoint's lifecycle."""
+
+    def __init__(self, provider: BaseLLMProvider):
+        self.provider = provider
+        self._httpd: Optional[_OpenAICompatHTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+
+    @property
+    def is_running(self) -> bool:
+        return self._httpd is not None
+
+    def start(self) -> None:
+        """Start the server if enabled and the bind target is safe.
+
+        No-ops silently if ``OPENAI_SERVER_ENABLED`` is false (the
+        default) — safe to call unconditionally at startup.
+        """
+        if not Config.OPENAI_SERVER_ENABLED:
+            return
+        if self._httpd is not None:
+            return
+
+        host = Config.OPENAI_SERVER_HOST
+        if host not in _LOOPBACK_HOSTS and not Config.OPENAI_SERVER_ALLOW_NONLOCAL:
+            logger.error(
+                f"openai_server: JARVIS_OPENAI_SERVER_HOST={host!r} is not "
+                "loopback and JARVIS_OPENAI_SERVER_ALLOW_NONLOCAL is not set "
+                "— refusing to start. This guard exists because a "
+                "non-loopback bind reopens the network attack surface JARVIS "
+                "is otherwise designed without. See "
+                "docs/SECURITY-ARCHITECTURE.md before overriding it."
+            )
+            return
+
+        token = _load_or_create_token()
+        address = (host, Config.OPENAI_SERVER_PORT)
+
+        try:
+            self._httpd = _OpenAICompatHTTPServer(address, self.provider, token)
+        except OSError as e:
+            logger.error(
+                f"openai_server: failed to bind {host}:{Config.OPENAI_SERVER_PORT}: {e}"
+            )
+            return
+
+        self._thread = threading.Thread(
+            target=self._httpd.serve_forever,
+            daemon=True,
+            name="jarvis-openai-server",
+        )
+        self._thread.start()
+
+        bound_host, bound_port = self._httpd.server_address[:2]
+        logger.warning(
+            f"openai_server: ENABLED on http://{bound_host}:{bound_port} — "
+            f"bearer token required, stored at {Config.OPENAI_SERVER_TOKEN_FILE} "
+            "(0600). This is a deliberate exception to JARVIS's normal "
+            "no-network-listener design — see docs/SECURITY-ARCHITECTURE.md."
+        )
+
+    def stop(self) -> None:
+        if self._httpd is None:
+            return
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._httpd = None
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None

--- a/tests/test_openai_compat_server.py
+++ b/tests/test_openai_compat_server.py
@@ -1,0 +1,165 @@
+"""Tests for the opt-in OpenAI-compatible HTTP server (#181).
+
+Covers: off-by-default, the non-loopback guard, token generation/
+persistence, and a full request round trip (auth required, /v1/models,
+blocking and streaming /v1/chat/completions).
+"""
+
+import http.client
+import json
+import os
+
+import pytest
+
+from jarvis.config import Config
+from jarvis.llm.base import BaseLLMProvider
+from jarvis.server.openai_compat import OpenAICompatServer, _load_or_create_token
+
+
+class _StubProvider(BaseLLMProvider):
+    def chat(self, messages):
+        return "hello from stub"
+
+    def is_available(self):
+        return True
+
+    def stream_chat(self, messages):
+        yield "chunk-a"
+        yield "chunk-b"
+
+
+@pytest.fixture
+def stub_provider():
+    return _StubProvider("stub-model")
+
+
+@pytest.fixture
+def token_file(tmp_path, monkeypatch):
+    path = str(tmp_path / "openai_server_token")
+    monkeypatch.setattr(Config, "OPENAI_SERVER_TOKEN_FILE", path)
+    return path
+
+
+class TestTokenPersistence:
+    def test_creates_and_persists_token(self, token_file):
+        token1 = _load_or_create_token()
+        assert os.path.isfile(token_file)
+        token2 = _load_or_create_token()
+        assert token1 == token2
+
+    def test_token_file_is_owner_only(self, token_file):
+        _load_or_create_token()
+        mode = os.stat(token_file).st_mode & 0o777
+        assert mode == 0o600
+
+
+class TestStartupGuards:
+    def test_disabled_by_default_never_binds(self, stub_provider, monkeypatch):
+        monkeypatch.setattr(Config, "OPENAI_SERVER_ENABLED", False)
+        server = OpenAICompatServer(stub_provider)
+        server.start()
+        assert not server.is_running
+
+    def test_nonloopback_refused_without_second_optin(self, stub_provider, monkeypatch):
+        monkeypatch.setattr(Config, "OPENAI_SERVER_ENABLED", True)
+        monkeypatch.setattr(Config, "OPENAI_SERVER_HOST", "0.0.0.0")
+        monkeypatch.setattr(Config, "OPENAI_SERVER_ALLOW_NONLOCAL", False)
+        server = OpenAICompatServer(stub_provider)
+        server.start()
+        assert not server.is_running
+
+
+@pytest.fixture
+def running_server(stub_provider, token_file, monkeypatch):
+    monkeypatch.setattr(Config, "OPENAI_SERVER_ENABLED", True)
+    monkeypatch.setattr(Config, "OPENAI_SERVER_HOST", "127.0.0.1")
+    monkeypatch.setattr(Config, "OPENAI_SERVER_PORT", 0)  # OS picks a free port
+    monkeypatch.setattr(Config, "OPENAI_SERVER_ALLOW_NONLOCAL", False)
+
+    server = OpenAICompatServer(stub_provider)
+    server.start()
+    assert server.is_running
+    yield server
+    server.stop()
+
+
+def _request(server, method, path, token=None, body=None):
+    host, port = server._httpd.server_address[:2]
+    conn = http.client.HTTPConnection(host, port, timeout=5)
+    headers = {}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    payload = json.dumps(body).encode() if body is not None else None
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+    conn.request(method, path, body=payload, headers=headers)
+    response = conn.getresponse()
+    data = response.read()
+    conn.close()
+    return response.status, data
+
+
+class TestRequestRoundTrip:
+    def test_missing_auth_is_rejected(self, running_server):
+        status, _ = _request(running_server, "GET", "/v1/models")
+        assert status == 401
+
+    def test_wrong_token_is_rejected(self, running_server):
+        status, _ = _request(running_server, "GET", "/v1/models", token="wrong")
+        assert status == 401
+
+    def test_v1_models_lists_current_model(self, running_server):
+        token = running_server._httpd.token
+        status, data = _request(running_server, "GET", "/v1/models", token=token)
+        assert status == 200
+        result = json.loads(data)
+        assert result["data"][0]["id"] == "stub-model"
+
+    def test_blocking_chat_completion(self, running_server):
+        token = running_server._httpd.token
+        status, data = _request(
+            running_server,
+            "POST",
+            "/v1/chat/completions",
+            token=token,
+            body={
+                "model": "stub-model",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+        assert status == 200
+        result = json.loads(data)
+        assert result["choices"][0]["message"]["content"] == "hello from stub"
+
+    def test_streaming_chat_completion(self, running_server):
+        token = running_server._httpd.token
+        host, port = running_server._httpd.server_address[:2]
+        conn = http.client.HTTPConnection(host, port, timeout=5)
+        conn.request(
+            "POST",
+            "/v1/chat/completions",
+            body=json.dumps(
+                {
+                    "model": "stub-model",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                }
+            ).encode(),
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+        )
+        response = conn.getresponse()
+        assert response.status == 200
+        raw = response.read().decode()
+        conn.close()
+
+        assert "chunk-a" in raw
+        assert "chunk-b" in raw
+        assert raw.strip().endswith("data: [DONE]")
+
+    def test_unknown_path_is_404(self, running_server):
+        token = running_server._httpd.token
+        status, _ = _request(running_server, "GET", "/v1/unknown", token=token)
+        assert status == 404


### PR DESCRIPTION
## Summary
- Closes #181: adds `jarvis/server/openai_compat.py` — `/v1/models` + `/v1/chat/completions` (blocking and SSE-streaming), backed directly by the existing `BaseLLMProvider`/`ProviderPool.chat()`/`stream_chat()` (from the already-merged #183).
- Deliberate, narrow exception to JARVIS's no-TCP-listener design, shipped with the three safeguards agreed on before any code was written:
  - **Off by default** (`JARVIS_OPENAI_SERVER_ENABLED=false`) — nothing imports/binds/threads unless explicitly enabled.
  - **Loopback-only** unless a *second* explicit opt-in (`JARVIS_OPENAI_SERVER_ALLOW_NONLOCAL=true`).
  - **Bearer token required on every request**, generated on first use, persisted at `0600` — no anonymous-access mode, closing the exact gap that made stock Ollama instances discoverable on Shodan.
  - **Inference only** — proxies to `chat()`/`stream_chat()`, never touches ROOT/DISPATCH, MCP tool calls, or the TLA confirmation gate.
- `docs/SECURITY-ARCHITECTURE.md` updated in this same PR so its "no TCP port listener" claim is now accurate (conditional on the feature being off) instead of stale.
- Wired into `jarvis run` via `start_runtime_services()`/`shutdown()` in `runtime/lifecycle.py`, symmetric with the existing socket/voice-thread lifecycle.

## Test plan
- [x] `tests/test_openai_compat_server.py` (new): token generation/persistence + 0600 permissions, disabled-by-default never binds, non-loopback-without-second-optin refused, full request round trip against a real bound socket (missing/wrong auth → 401, `/v1/models`, blocking and streaming `/v1/chat/completions`, unknown path → 404)
- [x] Full suite: 386 passed, 12 pre-existing failures (confirmed present on `main` before any of this branch's work, unrelated `LLM.__init__() got an unexpected keyword argument 'system_prompt'` / timing issues)
- [x] `black`/`isort` clean, `flake8 --select=E9,F63,F7,F82` (actual CI lint scope) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)