### PR TITLE
TLA confirmation UX: per-task allow/deny, show real command/params, no timeout auto-deny

### DIFF
--- a/jarvis/core/component_factory.py
+++ b/jarvis/core/component_factory.py
@@ -150,7 +150,11 @@ class ComponentFactory:
     def create_event_merger() -> EventMerger:
         """Create EventMerger for dual-input event loop."""
         logger.info("Initiating Event merger...")
-        return EventMerger()
+        # Push is the primary delivery path (#26): dispatch wakes ROOT the
+        # moment a task completes. The poll is now a slow catch-up net, so it
+        # runs infrequently to avoid contending with dispatch calls on the
+        # shared MCP session.
+        return EventMerger(poll_interval=3.0)
 
     @staticmethod
     def create_contextor(embeddings=None) -> ContextorAdapter:

--- a/jarvis/core/confirmation_manager.py
+++ b/jarvis/core/confirmation_manager.py
@@ -48,7 +48,10 @@ from .threat_level import ThreatLevel, classify
 
 logger = get_logger(__name__)
 
-DEFAULT_TIMEOUT = 30
+# No auto-deny by default (#185): a confirmation the user hasn't answered stays
+# pending rather than being denied on a timer. A positive CONFIRMATION_TIMEOUT
+# restores an explicit bounded lifetime for unattended/headless setups.
+DEFAULT_TIMEOUT = 0
 
 # Longest rendered command line shown in a confirmation prompt before eliding.
 _MAX_CMD_LEN = 200
@@ -244,7 +247,8 @@ class ConfirmationManager:
             denied_tools: Tools already denied (for partial batches).
             dispatch_context: Opaque context to resume dispatch after response.
             notification_silent: Suppress desktop notification.
-            timeout: Seconds before auto-deny.
+            timeout: Seconds before auto-deny. 0 (the default) means never
+                auto-deny — the confirmation stays pending until answered (#185).
         """
         # Build a human-readable summary of tools needing confirmation. The
         # summary now carries the actual command (#186), not just the tool name,
@@ -441,27 +445,40 @@ class ConfirmationManager:
                 body=body,
                 timeout_ms=int(timeout * 1000),
             )
-            approved = action == "allow"
 
-            if self._inject_confirmation:
-                self._inject_confirmation(
-                    {
-                        "type": "confirmation_response",
-                        "id": request_id,
-                        "approved": approved,
-                    }
+            # Only an EXPLICIT choice resolves the confirmation. A notification
+            # that was dismissed or expired (action is None) is not a "deny" —
+            # the user simply hasn't answered. Leave it pending so unattended
+            # work isn't silently killed; it stays reviewable via list_pending
+            # and can be answered on any channel (#185). Never auto-approve.
+            if action == "allow":
+                self._inject_result(request_id, approved=True)
+            elif action == "deny":
+                self._inject_result(request_id, approved=False)
+            else:
+                logger.info(
+                    "Desktop confirmation dismissed/expired for id=%s; "
+                    "left pending (not denied)",
+                    request_id,
                 )
 
         except Exception as e:
-            logger.warning(f"Desktop notification failed: {e}")
-            if self._inject_confirmation:
-                self._inject_confirmation(
-                    {
-                        "type": "confirmation_response",
-                        "id": request_id,
-                        "approved": False,
-                    }
-                )
+            # A failed notification means the user never saw the prompt, so
+            # denying would kill legitimate work they never got to weigh in on.
+            # Leave it pending for CLI/socket review instead (#185).
+            logger.warning(
+                "Desktop notification failed for id=%s: %s; left pending", request_id, e
+            )
+
+    def _inject_result(self, request_id: str, approved: bool) -> None:
+        if self._inject_confirmation:
+            self._inject_confirmation(
+                {
+                    "type": "confirmation_response",
+                    "id": request_id,
+                    "approved": approved,
+                }
+            )
 
     # -- Socket --------------------------------------------------------
 

--- a/jarvis/core/confirmation_manager.py
+++ b/jarvis/core/confirmation_manager.py
@@ -50,6 +50,70 @@ logger = get_logger(__name__)
 
 DEFAULT_TIMEOUT = 30
 
+# Longest rendered command line shown in a confirmation prompt before eliding.
+_MAX_CMD_LEN = 200
+
+
+def _truncate(text: str, limit: int = _MAX_CMD_LEN) -> str:
+    """Collapse whitespace and elide to ``limit`` chars with an ellipsis."""
+    text = " ".join(str(text).split())
+    if len(text) > limit:
+        return text[: limit - 1] + "…"
+    return text
+
+
+def _short_value(value: Any, limit: int = 60) -> str:
+    if isinstance(value, (dict, list)):
+        rendered = json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+    else:
+        rendered = str(value)
+    return _truncate(rendered, limit)
+
+
+def describe_tool_call(detail: Dict[str, Any]) -> str:
+    """Render a one-line, human-readable command for a tool call.
+
+    The confirmation gate is the human-in-the-loop boundary; a boundary that
+    can't see *what* it is approving is not a boundary (#186). This turns a
+    task's params into the actual command — ``pacman -Syu --noconfirm`` — rather
+    than just the tool identity. Falls back to ``key=value`` for arbitrary tools.
+    """
+    task = detail.get("task") or {}
+    params = detail.get("params")
+    if not isinstance(params, dict):
+        tp = task.get("params")
+        params = tp if isinstance(tp, dict) else {}
+
+    if params:
+        command = params.get("command")
+        if isinstance(command, str) and command:
+            args = params.get("args")
+            if isinstance(args, list):
+                command = " ".join([command] + [str(a) for a in args])
+            extras = []
+            if params.get("cwd"):
+                extras.append(f"cwd={params['cwd']}")
+            if params.get("timeout"):
+                extras.append(f"timeout={params['timeout']}s")
+            suffix = f"  [{', '.join(extras)}]" if extras else ""
+            return _truncate(command) + suffix
+
+        script = params.get("script")
+        if isinstance(script, str) and script:
+            return _truncate(script.replace("\n", " ; "))
+
+        kv = ", ".join(f"{k}={_short_value(v)}" for k, v in params.items())
+        return _truncate(kv)
+
+    # No params: the tool name itself is the most specific thing we can show.
+    return str(task.get("tool") or detail.get("tool_name") or "(no parameters)")
+
+
+def confirmation_line(detail: Dict[str, Any]) -> str:
+    """``<tool_name>: <rendered command>`` for one confirmation item (#186)."""
+    tool_name = detail.get("tool_name", "?")
+    return f"{tool_name}: {describe_tool_call(detail)}"
+
 
 @dataclass
 class PendingConfirmation:
@@ -64,6 +128,8 @@ class PendingConfirmation:
     # Retained so a later list_pending() query can describe what's waiting --
     # the original request only computes these locally otherwise.
     tool_names: List[str] = field(default_factory=list)
+    # Human-readable "tool: command" lines shown in every channel (#186).
+    tool_lines: List[str] = field(default_factory=list)
     created_at: float = field(default_factory=time.time)
 
 
@@ -98,13 +164,14 @@ class ConfirmationManager:
 
     def set_tui_callback(
         self,
-        callback: Callable[[str, List[str]], Any],
+        callback: Callable[[str, List[Dict[str, Any]]], Any],
     ) -> None:
         """Register the TUI confirmation callback.
 
-        The callback receives (request_id, tool_names) and must return a
-        bool (True = allow, False = deny).  It is awaited, so it can use
-        Textual's ``push_screen_wait``.
+        The callback receives (request_id, tools_detail) — the list of
+        ``{tool_name, task, params, ...}`` dicts — and must return a bool
+        (True = allow, False = deny).  It is awaited, so it can use Textual's
+        ``push_screen_wait``.
         """
         self._tui_callback = callback
 
@@ -179,9 +246,11 @@ class ConfirmationManager:
             notification_silent: Suppress desktop notification.
             timeout: Seconds before auto-deny.
         """
-        # Build a human-readable summary of tools needing confirmation.
+        # Build a human-readable summary of tools needing confirmation. The
+        # summary now carries the actual command (#186), not just the tool name,
+        # so every channel shows WHAT will run.
         tool_names = [t["tool_name"] for t in tools_needing_confirmation]
-        tool_summaries = ", ".join(tool_names)
+        tool_lines = [confirmation_line(t) for t in tools_needing_confirmation]
 
         pending = PendingConfirmation(
             request_id=request_id,
@@ -190,18 +259,21 @@ class ConfirmationManager:
             denied_tools=list(denied_tools),
             dispatch_context=dispatch_context,
             tool_names=tool_names,
+            tool_lines=tool_lines,
         )
         self._pending[request_id] = pending
 
         logger.info(
-            f"Confirmation requested (non-blocking): id={request_id}, "
-            f"tools={tool_summaries}"
+            "Confirmation requested (non-blocking): id=%s, tools=%s",
+            request_id,
+            "; ".join(tool_lines),
         )
 
         # Fire notification (non-blocking) on the best available channel.
         await self._send_notification(
             request_id=request_id,
             tool_names=tool_names,
+            tool_lines=tool_lines,
             tools_detail=tools_needing_confirmation,
             notification_silent=notification_silent,
             timeout=timeout,
@@ -223,6 +295,7 @@ class ConfirmationManager:
             {
                 "id": p.request_id,
                 "tool_names": p.tool_names,
+                "tool_lines": p.tool_lines,
                 "created_at": p.created_at,
             }
             for p in self._pending.values()
@@ -281,22 +354,21 @@ class ConfirmationManager:
         self,
         request_id: str,
         tool_names: List[str],
+        tool_lines: List[str],
         tools_detail: List[Dict[str, Any]],
         notification_silent: bool,
         timeout: float,
     ) -> None:
         """Fire notification on the best available channel."""
 
-        tool_summary = ", ".join(tool_names)
-
         # 1. TUI modal — highest priority when Textual is running.
         if self._tui_callback is not None:
-            asyncio.create_task(self._notify_tui(request_id, tool_names))
+            asyncio.create_task(self._notify_tui(request_id, tools_detail))
             return
 
         # 2. Desktop notification (unless silent).
         if not notification_silent and self._has_desktop_notifications():
-            asyncio.create_task(self._notify_desktop(request_id, tool_summary, timeout))
+            asyncio.create_task(self._notify_desktop(request_id, tool_lines, timeout))
             return
 
         # 2. Socket — if clients are connected.
@@ -310,7 +382,7 @@ class ConfirmationManager:
 
         # 3. CLI / TTY fallback.
         if self._has_tty():
-            asyncio.create_task(self._notify_cli(request_id, tool_summary, timeout))
+            asyncio.create_task(self._notify_cli(request_id, tool_lines, timeout))
             return
 
         # No live channel available right now -- that's fine. The request
@@ -324,9 +396,11 @@ class ConfirmationManager:
 
     # -- TUI (ConfirmModal) --------------------------------------------
 
-    async def _notify_tui(self, request_id: str, tool_names: List[str]) -> None:
+    async def _notify_tui(
+        self, request_id: str, tools_detail: List[Dict[str, Any]]
+    ) -> None:
         try:
-            approved = await self._tui_callback(request_id, tool_names)
+            approved = await self._tui_callback(request_id, tools_detail)
         except Exception as e:
             logger.warning(f"TUI confirmation callback failed: {e}")
             approved = False
@@ -351,16 +425,20 @@ class ConfirmationManager:
     async def _notify_desktop(
         self,
         request_id: str,
-        tool_summary: str,
+        tool_lines: List[str],
         timeout: float,
     ) -> None:
         """Show a desktop notification via the platform layer."""
         from ..platform import current as platform
 
+        # Show the actual command(s), not just the tool name, so the user can
+        # see a full system upgrade is in the batch before approving (#186).
+        body = "\n".join(tool_lines) if tool_lines else "(no details)"
+
         try:
             action = await platform.send_desktop_notification(
                 title="JARVIS — Confirmation Required",
-                body=f"Tool: {tool_summary}",
+                body=body,
                 timeout_ms=int(timeout * 1000),
             )
             approved = action == "allow"
@@ -403,8 +481,14 @@ class ConfirmationManager:
             "id": request_id,
             "tools": tool_names,
             "details": [
-                {"tool": t["tool_name"], "params": t.get("params", {})}
-                for t in tools_detail
+                {
+                    "index": i,
+                    "tool": t["tool_name"],
+                    "params": t.get("params", {}),
+                    # Rendered command so a socket GUI can show what runs (#186).
+                    "command": describe_tool_call(t),
+                }
+                for i, t in enumerate(tools_detail)
             ],
             "timeout": timeout,
         }
@@ -422,15 +506,17 @@ class ConfirmationManager:
     async def _notify_cli(
         self,
         request_id: str,
-        tool_summary: str,
+        tool_lines: List[str],
         timeout: float,
     ) -> None:
         """Prompt the user on stdin.  Runs in an executor so it doesn't
         block the event loop.  Injects the response when done.
         """
+        # List the actual command(s) so the user approves what they can see (#186).
+        listing = "\n".join(f"    {line}" for line in tool_lines)
         prompt = (
-            f"\n[JARVIS] Confirmation required\n"
-            f"  Tools: {tool_summary}\n"
+            f"\n[JARVIS] Confirmation required — the following will run:\n"
+            f"{listing}\n"
             f"  Approve? [y/N]: "
         )
         try:

--- a/jarvis/core/confirmation_manager.py
+++ b/jarvis/core/confirmation_manager.py
@@ -126,6 +126,9 @@ class PendingConfirmation:
     tasks: List[Dict[str, Any]]
     denied_tools: List[str] = field(default_factory=list)
     approved_tasks: List[Dict[str, Any]] = field(default_factory=list)
+    # Ordered detail for the tools that need confirmation, so a per-task
+    # response (approved_indices) can approve a subset and deny the rest (#187).
+    confirm_details: List[Dict[str, Any]] = field(default_factory=list)
     # Dispatch sub-chain context to resume after confirmation.
     dispatch_context: Optional[Dict[str, Any]] = None
     # Retained so a later list_pending() query can describe what's waiting --
@@ -264,6 +267,7 @@ class ConfirmationManager:
             dispatch_context=dispatch_context,
             tool_names=tool_names,
             tool_lines=tool_lines,
+            confirm_details=list(tools_needing_confirmation),
         )
         self._pending[request_id] = pending
 
@@ -310,11 +314,19 @@ class ConfirmationManager:
 
         Called by Jarvis when a ``CONFIRMATION_RESPONSE`` event arrives.
 
+        Two response shapes are accepted:
+
+        * ``approved_indices``: a list of indices into the confirmation items
+          (``confirm_details``) that the user approved. The rest are denied.
+          This is the per-task path (#187) — approve some, deny others.
+        * ``approved`` (bool): the all-or-nothing path used by channels that
+          can't express a per-task choice (desktop single item, plain socket
+          approve/deny).
+
         Returns the ``PendingConfirmation`` with approval status applied,
         or None if the request id is unknown (expired / already resolved).
         """
         req_id = response.get("id")
-        approved = response.get("approved", False)
 
         if not req_id or req_id not in self._pending:
             logger.warning(f"Confirmation response for unknown id: {req_id}")
@@ -327,6 +339,32 @@ class ConfirmationManager:
         if timeout_task and not timeout_task.done():
             timeout_task.cancel()
 
+        approved_indices = response.get("approved_indices")
+        if approved_indices is not None:
+            # Per-task: approve the selected confirmation items, deny the rest.
+            # approved_tasks already holds the tools that needed no confirmation.
+            approved_set = {int(i) for i in approved_indices}
+            for i, detail in enumerate(pending.confirm_details):
+                task = detail.get("task")
+                if i in approved_set:
+                    if task is not None:
+                        pending.approved_tasks.append(task)
+                else:
+                    tool_name = detail.get("tool_name") or (
+                        f"{(task or {}).get('server', '?')}."
+                        f"{(task or {}).get('tool', '?')}"
+                    )
+                    if tool_name not in pending.denied_tools:
+                        pending.denied_tools.append(tool_name)
+            logger.info(
+                "Confirmation partially resolved: id=%s, approved=%d/%d",
+                req_id,
+                len(approved_set),
+                len(pending.confirm_details),
+            )
+            return pending
+
+        approved = response.get("approved", False)
         if approved:
             # Move all tools_needing_confirmation into approved.
             # (The tasks that needed confirmation are everything in
@@ -432,34 +470,70 @@ class ConfirmationManager:
         tool_lines: List[str],
         timeout: float,
     ) -> None:
-        """Show a desktop notification via the platform layer."""
+        """Show a desktop notification via the platform layer.
+
+        A single item gets one Allow/Deny notification. A batch gets one Allow/
+        Deny notification per task, aggregated into a per-task decision (#187) —
+        notify-send has only two actions, so per-task granularity comes from
+        asking about each task in turn rather than one dialog. An explicit choice
+        resolves; a dismissed/expired notification (action None) is never a deny
+        (#185) — it leaves the confirmation pending on any channel.
+        """
         from ..platform import current as platform
 
-        # Show the actual command(s), not just the tool name, so the user can
-        # see a full system upgrade is in the batch before approving (#186).
-        body = "\n".join(tool_lines) if tool_lines else "(no details)"
+        timeout_ms = int(timeout * 1000)
 
         try:
-            action = await platform.send_desktop_notification(
-                title="JARVIS — Confirmation Required",
-                body=body,
-                timeout_ms=int(timeout * 1000),
-            )
+            if len(tool_lines) <= 1:
+                # Show the actual command, not just the tool name (#186).
+                body = tool_lines[0] if tool_lines else "(no details)"
+                action = await platform.send_desktop_notification(
+                    title="JARVIS — Confirmation Required",
+                    body=body,
+                    timeout_ms=timeout_ms,
+                )
+                if action == "allow":
+                    self._inject_result(request_id, approved=True)
+                elif action == "deny":
+                    self._inject_result(request_id, approved=False)
+                else:
+                    logger.info(
+                        "Desktop confirmation dismissed/expired for id=%s; "
+                        "left pending (not denied)",
+                        request_id,
+                    )
+                return
 
-            # Only an EXPLICIT choice resolves the confirmation. A notification
-            # that was dismissed or expired (action is None) is not a "deny" —
-            # the user simply hasn't answered. Leave it pending so unattended
-            # work isn't silently killed; it stays reviewable via list_pending
-            # and can be answered on any channel (#185). Never auto-approve.
-            if action == "allow":
-                self._inject_result(request_id, approved=True)
-            elif action == "deny":
-                self._inject_result(request_id, approved=False)
-            else:
-                logger.info(
-                    "Desktop confirmation dismissed/expired for id=%s; "
-                    "left pending (not denied)",
-                    request_id,
+            approved_indices: List[int] = []
+            total = len(tool_lines)
+            for i, line in enumerate(tool_lines):
+                action = await platform.send_desktop_notification(
+                    title=f"JARVIS — Confirm ({i + 1}/{total})",
+                    body=line,
+                    timeout_ms=timeout_ms,
+                )
+                if action == "allow":
+                    approved_indices.append(i)
+                elif action == "deny":
+                    continue
+                else:
+                    # Dismissed/expired mid-batch: don't resolve the whole batch
+                    # on a partial answer — leave it pending (#185).
+                    logger.info(
+                        "Desktop confirmation dismissed at item %d for id=%s; "
+                        "left pending (not denied)",
+                        i,
+                        request_id,
+                    )
+                    return
+
+            if self._inject_confirmation:
+                self._inject_confirmation(
+                    {
+                        "type": "confirmation_response",
+                        "id": request_id,
+                        "approved_indices": approved_indices,
+                    }
                 )
 
         except Exception as e:
@@ -528,29 +602,60 @@ class ConfirmationManager:
     ) -> None:
         """Prompt the user on stdin.  Runs in an executor so it doesn't
         block the event loop.  Injects the response when done.
+
+        A batch is confirmed per task (#187): each command shows what it runs
+        (#186) and takes its own y/N. Returns approved_indices. A non-answer
+        (EOF, or an explicit-timeout expiry) leaves the confirmation pending
+        rather than denying it (#185).
         """
-        # List the actual command(s) so the user approves what they can see (#186).
-        listing = "\n".join(f"    {line}" for line in tool_lines)
-        prompt = (
-            f"\n[JARVIS] Confirmation required — the following will run:\n"
-            f"{listing}\n"
-            f"  Approve? [y/N]: "
-        )
+
+        def _prompt() -> Optional[List[int]]:
+            try:
+                if len(tool_lines) <= 1:
+                    line = tool_lines[0] if tool_lines else "(no details)"
+                    answer = input(
+                        "\n[JARVIS] Confirmation required — the following will run:\n"
+                        f"    {line}\n  Approve? [y/N]: "
+                    )
+                    return [0] if answer.strip().lower() in ("y", "yes") else []
+
+                print("\n[JARVIS] Confirmation required — approve each task [y/N]:")
+                approved: List[int] = []
+                for i, line in enumerate(tool_lines):
+                    answer = input(
+                        f"  [{i + 1}/{len(tool_lines)}] {line}\n      [y/N]: "
+                    )
+                    if answer.strip().lower() in ("y", "yes"):
+                        approved.append(i)
+                return approved
+            except EOFError:
+                return None
+
+        loop = asyncio.get_event_loop()
         try:
-            answer = await asyncio.wait_for(
-                asyncio.get_event_loop().run_in_executor(None, input, prompt),
-                timeout=timeout,
+            if timeout and timeout > 0:
+                result = await asyncio.wait_for(
+                    loop.run_in_executor(None, _prompt), timeout=timeout
+                )
+            else:
+                # Default: no auto-deny — wait for an actual answer (#185).
+                result = await loop.run_in_executor(None, _prompt)
+        except asyncio.TimeoutError:
+            logger.info(
+                "CLI confirmation timed out for id=%s; left pending", request_id
             )
-            approved = answer.strip().lower() in ("y", "yes")
-        except (asyncio.TimeoutError, EOFError):
-            approved = False
+            return
+
+        if result is None:
+            logger.info("CLI confirmation got EOF for id=%s; left pending", request_id)
+            return
 
         if self._inject_confirmation:
             self._inject_confirmation(
                 {
                     "type": "confirmation_response",
                     "id": request_id,
-                    "approved": approved,
+                    "approved_indices": result,
                 }
             )
 

--- a/jarvis/dispatch/adapter.py
+++ b/jarvis/dispatch/adapter.py
@@ -18,7 +18,7 @@ do what they're told.
 """
 
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from ..config import Config
 from ..core.logger import get_logger
@@ -62,6 +62,15 @@ class DispatchAdapter:
         self.session = None
         self._client = None
         self._connected = False
+        # Sink for signals PUSHED by dispatch (notifications/message, #26).
+        # Set by the runtime to EventMerger.enqueue_pushed_signal once the
+        # merger exists; the MCP logging handler in transport reads it at call
+        # time, so it is safe for it to be None during early connect.
+        self._signal_sink: Optional[Callable[[Dict[str, Any]], None]] = None
+
+    def set_signal_sink(self, sink: Optional[Callable[[Dict[str, Any]], None]]) -> None:
+        """Register where pushed dispatch signals are delivered (#26)."""
+        self._signal_sink = sink
 
     async def connect(self):
         """Connect to the dispatch binary via stdio MCP."""

--- a/jarvis/dispatch/event_merger.py
+++ b/jarvis/dispatch/event_merger.py
@@ -5,11 +5,14 @@ Merges multiple input sources into a single event stream:
 1. User input (voice, stdin, socket, or injected)
 2. Dispatch signals (task completions, reminders, etc.)
 
-The signal reader runs as a background asyncio Task, polling the dispatch
-signal window every 0.5 s. Each signal is fingerprinted by
-(pid, type, timestamp) and tracked in a seen-set; duplicates are silently
-dropped so the same signal is never delivered twice even if it stays in the
-Rust window for multiple polls.
+Dispatch signals arrive by two paths that share one ingest (_ingest_one):
+- PUSH (primary, #26): dispatch emits a notifications/message the moment a
+  task completes or a reminder fires; the MCP session's logging handler calls
+  enqueue_pushed_signal, so ROOT is woken on completion without polling.
+- POLL (fallback): a background asyncio Task polls the dispatch signal window
+  as a catch-up net. Each signal is fingerprinted by (pid, type, timestamp)
+  and tracked in a seen-set; duplicates are silently dropped, so a signal
+  observed by both push and poll is delivered exactly once.
 
 On the first poll, all already-present signals are marked seen without being
 enqueued — this prevents stale signals from a previous JARVIS session being
@@ -303,56 +306,28 @@ class EventMerger:
                         if s.get("type") in ("EXIT", "TIMEOUT") and "pid" in s
                     }
                     for sig in signals:
-                        key = self._signal_key(sig)
-                        if key in self._seen:
-                            continue
-                        self._seen.add(key)
-
-                        # INIT and WAIT are always handled inline; skip delivery.
-                        if sig.get("type") in _INLINE_SIGNAL_TYPES:
-                            continue
-
-                        # Verify dispatch's output-provenance boundary (#165): an
-                        # EXIT body must be wrapped by the nonce dispatch assigned
-                        # to that PID. A missing/mismatched tag means the output
-                        # did not come through dispatch's boundary (or was
-                        # tampered) — flag it in-band so ROOT treats it as
-                        # untrusted rather than acting on it.
-                        if sig.get("type") in ("EXIT", "TIMEOUT") and verify_and_mark(
-                            sig
+                        # REMIND+EXIT merging needs the batch snapshot, so it
+                        # happens here (the push path sees signals one at a time
+                        # and can't merge). Only enrich a first-seen REMIND whose
+                        # task has already exited, so ROOT gets the full picture
+                        # in one LLM turn.
+                        if (
+                            sig.get("type") == "REMIND"
+                            and sig.get("pid") in exits_by_pid
+                            and self._signal_key(sig) not in self._seen
                         ):
-                            logger.warning(
-                                "EventMerger: output-provenance boundary FAILED for "
-                                f"pid={sig.get('pid')} ({sig.get('_boundary_reason')}) "
-                                "— marked UNVERIFIED"
-                            )
-
-                        if sig.get("type") == "REMIND":
                             pid = sig.get("pid")
-                            if pid in exits_by_pid:
-                                # Task already finished — merge exit info so
-                                # ROOT gets the full picture in one LLM turn.
-                                verify_and_mark(exits_by_pid[pid])
-                                sig = {
-                                    **sig,
-                                    "_remind_completed": True,
-                                    "_exit": exits_by_pid[pid],
-                                }
-                                logger.info(
-                                    f"EventMerger: REMIND+EXIT merged for pid={pid}"
-                                )
-
-                        logger.debug(
-                            f"EventMerger: Queued signal "
-                            f"type={sig.get('type')}, pid={sig.get('pid')}"
-                        )
-                        try:
-                            self._queue.put_nowait(Event.dispatch_signal(sig))
-                        except asyncio.QueueFull:
-                            logger.warning(
-                                f"EventMerger: Queue full, dropping signal "
-                                f"type={sig.get('type')}, pid={sig.get('pid')}"
+                            verify_and_mark(exits_by_pid[pid])
+                            sig = {
+                                **sig,
+                                "_remind_completed": True,
+                                "_exit": exits_by_pid[pid],
+                            }
+                            logger.info(
+                                f"EventMerger: REMIND+EXIT merged for pid={pid}"
                             )
+
+                        self._ingest_one(sig)
 
             except asyncio.CancelledError:
                 break
@@ -360,6 +335,69 @@ class EventMerger:
                 logger.error(f"EventMerger: Signal reader error: {e}")
 
             await asyncio.sleep(self._poll_interval)
+
+    def _ingest_one(self, sig: Dict[str, Any]) -> bool:
+        """Dedup, filter, boundary-verify, and enqueue a single signal.
+
+        Shared by the polling loop and the push path (enqueue_pushed_signal).
+        Signals are keyed by (pid, type, timestamp); one already in the seen-set
+        is dropped, so a signal observed by both push and poll is delivered
+        exactly once. INIT/WAIT are handled inline elsewhere and never enqueued.
+        EXIT/TIMEOUT bodies are checked against dispatch's output-provenance
+        boundary (#165) and flagged in-band if unverified. Returns True if the
+        signal was enqueued.
+        """
+        key = self._signal_key(sig)
+        if key in self._seen:
+            return False
+        self._seen.add(key)
+
+        # INIT and WAIT are always handled inline; skip delivery.
+        if sig.get("type") in _INLINE_SIGNAL_TYPES:
+            return False
+
+        # Verify dispatch's output-provenance boundary (#165): an EXIT body must
+        # be wrapped by the nonce dispatch assigned to that PID. A missing or
+        # mismatched tag means the output did not come through dispatch's
+        # boundary (or was tampered) — flag it in-band so ROOT treats it as
+        # untrusted rather than acting on it.
+        if sig.get("type") in ("EXIT", "TIMEOUT") and verify_and_mark(sig):
+            logger.warning(
+                "EventMerger: output-provenance boundary FAILED for "
+                f"pid={sig.get('pid')} ({sig.get('_boundary_reason')}) "
+                "— marked UNVERIFIED"
+            )
+
+        try:
+            self._queue.put_nowait(Event.dispatch_signal(sig))
+            logger.debug(
+                f"EventMerger: Queued signal "
+                f"type={sig.get('type')}, pid={sig.get('pid')}"
+            )
+            return True
+        except asyncio.QueueFull:
+            logger.warning(
+                f"EventMerger: Queue full, dropping signal "
+                f"type={sig.get('type')}, pid={sig.get('pid')}"
+            )
+            return False
+
+    def enqueue_pushed_signal(self, sig: Dict[str, Any]) -> None:
+        """Ingest a signal PUSHED by dispatch via notifications/message (#26).
+
+        Called from the dispatch MCP session's logging handler, which runs on
+        this event loop, so it goes through the same dedup/boundary/enqueue path
+        as the poll loop. Push and poll share the seen-set, so whichever observes
+        a given (pid, type, timestamp) first wins and the other is a no-op.
+
+        Unlike the poll loop, pushes are never gated on the seen-set init: a
+        pushed signal is always live (dispatch emits only on a fresh event and
+        its orchestrator starts empty each session), so there are no stale
+        cross-session replays to skip here.
+        """
+        if not sig:
+            return
+        self._ingest_one(sig)
 
     @staticmethod
     def _signal_key(sig: Dict[str, Any]) -> str:

--- a/jarvis/dispatch/transport.py
+++ b/jarvis/dispatch/transport.py
@@ -9,6 +9,58 @@ from typing import Any, Callable, Dict, List, Optional
 
 from ..config import Config
 
+# The logger name dispatch stamps on pushed-signal notifications (#26).
+_PUSH_SIGNAL_LOGGER = "dispatch.signal"
+
+
+def _normalize_pushed_signal(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Map dispatch's raw SignalEntry to the daemon's canonical signal shape.
+
+    Dispatch serializes signals as ``kind``/``message``; the daemon (EventMerger,
+    goal_manager, boundary verification) reads ``type``/``data``. Translate here
+    so a pushed signal is indistinguishable from a polled one downstream.
+    """
+    norm: Dict[str, Any] = {
+        "type": raw.get("kind"),
+        "pid": raw.get("pid"),
+        "data": raw.get("message"),
+        "timestamp": raw.get("timestamp"),
+    }
+    if raw.get("nonce") is not None:
+        norm["nonce"] = raw.get("nonce")
+    if raw.get("payload") is not None:
+        norm["payload"] = raw.get("payload")
+    return norm
+
+
+def _make_logging_callback(adapter: Any, logger: Logger):
+    """Build the MCP logging-notification handler for pushed dispatch signals.
+
+    dispatch pushes each wakeup-worthy signal as a ``notifications/message`` with
+    ``logger="dispatch.signal"``; we normalize it and hand it to the adapter's
+    signal sink (EventMerger.enqueue_pushed_signal). The sink is read at call
+    time, so it may be unset during early connect — such signals are dropped and
+    the poll fallback still catches up (#26).
+    """
+
+    async def _on_log_message(params: Any) -> None:
+        try:
+            if getattr(params, "logger", None) != _PUSH_SIGNAL_LOGGER:
+                return
+            raw = getattr(params, "data", None)
+            if not isinstance(raw, dict):
+                logger.debug("Dispatch: pushed signal had no dict payload — ignoring")
+                return
+            sink = getattr(adapter, "_signal_sink", None)
+            if sink is None:
+                logger.debug("Dispatch: pushed signal dropped — sink not registered")
+                return
+            sink(_normalize_pushed_signal(raw))
+        except Exception as e:  # never let a bad push break the session
+            logger.error(f"Dispatch: error handling pushed signal: {e}")
+
+    return _on_log_message
+
 
 async def connect(adapter: Any, logger: Logger) -> None:
     """Connect DispatchAdapter to dispatch serve over stdio MCP."""
@@ -28,7 +80,14 @@ async def connect(adapter: Any, logger: Logger) -> None:
         )
         adapter._client = stdio_client(params)
         read, write = await adapter._client.__aenter__()
-        adapter.session = ClientSession(read, write)
+        # Register the logging handler so dispatch's pushed signals
+        # (notifications/message, logger="dispatch.signal") wake ROOT the moment
+        # a task completes, rather than waiting for the next poll (#26).
+        adapter.session = ClientSession(
+            read,
+            write,
+            logging_callback=_make_logging_callback(adapter, logger),
+        )
         await adapter.session.__aenter__()
         await adapter.session.initialize()
         adapter._connected = True

--- a/jarvis/runtime/io.py
+++ b/jarvis/runtime/io.py
@@ -126,6 +126,27 @@ async def _handle_confirmation_query(
         )
         return True
 
+    if msg_type == "partial_approve_confirmation":
+        # Per-task decision (#187): approve a subset of a batched confirmation
+        # by index; the rest are denied. `approved_indices` is a list of ints
+        # into the confirmation's items (as sent in the request `details`).
+        indices = msg.get("approved_indices", [])
+        app.events.inject_confirmation_response(
+            {
+                "type": "confirmation_response",
+                "id": msg.get("id", ""),
+                "approved_indices": indices,
+            }
+        )
+        await _gui_write(
+            writer,
+            {
+                "type": "ack",
+                "message": f"Resolved {msg.get('id', '')} ({len(indices)} approved)",
+            },
+        )
+        return True
+
     if msg_type == "approve_all_confirmations":
         ids = [c["id"] for c in app.confirmation.list_pending()]
         for cid in ids:

--- a/jarvis/runtime/lifecycle.py
+++ b/jarvis/runtime/lifecycle.py
@@ -106,6 +106,10 @@ async def start_runtime_services(app: Any, logger: Logger) -> dict[str, Any]:
         signal_window_source=app.dispatch.get_signal_window,
         user_source=user_source,
     )
+    # Route signals PUSHED by dispatch (notifications/message) into the same
+    # merged event queue as polled signals, so ROOT is woken on task completion
+    # without waiting for a poll (#26). Deduplicated against the poll fallback.
+    app.dispatch.set_signal_sink(app.events.enqueue_pushed_signal)
 
     app.output_manager.set_state_callback(
         lambda state: _notify_voice_output_state(app, state)

--- a/jarvis/tui/app.py
+++ b/jarvis/tui/app.py
@@ -354,8 +354,8 @@ class JarvisTUI(App):
 
         self.push_screen(ConfigModal(initial_tab=tab), _on_config)
 
-    async def _tui_confirm(self, request_id: str, tool_names: list[str]) -> bool:
-        return await self.push_screen_wait(ConfirmModal(request_id, tool_names))
+    async def _tui_confirm(self, request_id: str, tools_detail: list) -> bool:
+        return await self.push_screen_wait(ConfirmModal(request_id, tools_detail))
 
     def _export_transcript_to_disk(self, filename: Optional[str]) -> None:
         """Save plain transcript as Markdown under ``JARVIS_DATA_DIR/transcripts``."""

--- a/jarvis/tui/confirm_modal.py
+++ b/jarvis/tui/confirm_modal.py
@@ -69,17 +69,21 @@ class ConfirmModal(ModalScreen[bool]):
     }
     """
 
-    def __init__(self, request_id: str, tool_names: list[str]) -> None:
+    def __init__(self, request_id: str, tools_detail: list) -> None:
         super().__init__()
         self._request_id = request_id
-        self._tool_names = tool_names
+        # Each entry is a {tool_name, task, params, ...} dict; render the actual
+        # command so the user sees what will run, not just the tool name (#186).
+        from ..core.confirmation_manager import confirmation_line
+
+        self._tool_lines = [confirmation_line(d) for d in tools_detail]
 
     def compose(self) -> ComposeResult:
-        tools_text = "\n".join(f"  • {name}" for name in self._tool_names)
+        tools_text = "\n".join(f"  • {line}" for line in self._tool_lines)
         with Vertical(id="confirm-dialog"):
             yield Label("⚠  JARVIS — Confirmation Required", id="confirm-title")
             yield Static(
-                f"[bold]Tools requesting execution:[/bold]\n{tools_text}",
+                f"[bold]The following will run:[/bold]\n{tools_text}",
                 id="confirm-tools",
                 markup=True,
             )

--- a/tests/test_confirmation_tla.py
+++ b/tests/test_confirmation_tla.py
@@ -1,0 +1,94 @@
+"""TLA confirmation-gate tests (#185, #186, #187).
+
+Covers the human-in-the-loop boundary hardening found during testing:
+- #186 the prompt must show the actual command/params, not just tool names
+- #187 per-task allow/deny for batched confirmations
+- #185 no auto-deny when the user simply hasn't answered yet
+"""
+
+from jarvis.core.confirmation_manager import (
+    ConfirmationManager,
+    PendingConfirmation,
+    confirmation_line,
+    describe_tool_call,
+)
+
+
+def _cmd_detail(tool_name, command, args=None, **params):
+    p = {"command": command}
+    if args is not None:
+        p["args"] = args
+    p.update(params)
+    return {
+        "tool_name": tool_name,
+        "task": {
+            "server": tool_name.split(".")[0],
+            "tool": tool_name.split(".")[-1],
+            "params": p,
+        },
+        "params": p,
+    }
+
+
+# --- #186: command/params are rendered ---------------------------------------
+
+
+def test_describe_execute_command_shows_full_command():
+    d = _cmd_detail("sys.execute_command", "pacman", ["-Syu", "--noconfirm"])
+    assert describe_tool_call(d) == "pacman -Syu --noconfirm"
+
+
+def test_describe_includes_cwd_and_timeout():
+    d = _cmd_detail("sys.execute_command", "git", ["status"], cwd="/tmp", timeout=30)
+    rendered = describe_tool_call(d)
+    assert "git status" in rendered
+    assert "cwd=/tmp" in rendered
+    assert "timeout=30s" in rendered
+
+
+def test_describe_script_is_flattened():
+    d = {"tool_name": "sh.execute_script", "params": {"script": "echo hi\nls -la"}}
+    assert describe_tool_call(d) == "echo hi ; ls -la"
+
+
+def test_describe_generic_params_as_key_value():
+    d = {"tool_name": "x.write_file", "params": {"path": "/etc/hosts", "content": "x"}}
+    rendered = describe_tool_call(d)
+    assert "path=/etc/hosts" in rendered
+    assert "content=x" in rendered
+
+
+def test_describe_long_command_is_truncated():
+    d = _cmd_detail("sys.execute_command", "echo", ["a" * 500])
+    rendered = describe_tool_call(d)
+    assert len(rendered) <= 201
+    assert rendered.endswith("…")
+
+
+def test_confirmation_line_prefixes_tool_name():
+    d = _cmd_detail("sys.execute_command", "pacman", ["-Syu"])
+    assert confirmation_line(d) == "sys.execute_command: pacman -Syu"
+
+
+def test_request_stores_rendered_lines_for_list_pending():
+    import asyncio
+
+    mgr = ConfirmationManager()
+    detail = _cmd_detail("sys.execute_command", "pacman", ["-Syu", "--noconfirm"])
+    task = detail["task"]
+
+    async def run():
+        # No channels registered -> stays pending, reviewable.
+        await mgr.request_confirmation(
+            request_id="abc",
+            tasks=[task],
+            tools_needing_confirmation=[detail],
+            approved_tasks=[],
+            denied_tools=[],
+            timeout=0,
+        )
+
+    asyncio.run(run())
+    pend = mgr.list_pending()
+    assert len(pend) == 1
+    assert pend[0]["tool_lines"] == ["sys.execute_command: pacman -Syu --noconfirm"]

--- a/tests/test_confirmation_tla.py
+++ b/tests/test_confirmation_tla.py
@@ -6,7 +6,13 @@ Covers the human-in-the-loop boundary hardening found during testing:
 - #185 no auto-deny when the user simply hasn't answered yet
 """
 
+import asyncio
+
+import pytest
+
+import jarvis.platform as platform_mod
 from jarvis.core.confirmation_manager import (
+    DEFAULT_TIMEOUT,
     ConfirmationManager,
     PendingConfirmation,
     confirmation_line,
@@ -92,3 +98,65 @@ def test_request_stores_rendered_lines_for_list_pending():
     pend = mgr.list_pending()
     assert len(pend) == 1
     assert pend[0]["tool_lines"] == ["sys.execute_command: pacman -Syu --noconfirm"]
+
+
+# --- #185: no auto-deny; dismiss != deny -------------------------------------
+
+
+def test_default_timeout_is_no_auto_deny():
+    assert DEFAULT_TIMEOUT == 0
+
+
+def test_request_with_zero_timeout_creates_no_auto_deny_task():
+    mgr = ConfirmationManager()
+    detail = _cmd_detail("sys.execute_command", "pacman", ["-Syu"])
+
+    async def run():
+        await mgr.request_confirmation(
+            request_id="t0",
+            tasks=[detail["task"]],
+            tools_needing_confirmation=[detail],
+            approved_tasks=[],
+            denied_tools=[],
+            timeout=0,
+        )
+
+    asyncio.run(run())
+    # Still pending, and no timeout task scheduled to auto-deny it.
+    assert mgr.has_pending("t0")
+    assert "t0" not in mgr._timeout_tasks
+
+
+def _desktop_notify(mgr, action, tool_lines=("sys.execute_command: pacman -Syu",)):
+    """Drive _notify_desktop with a stubbed platform action, capturing injects."""
+    injected = []
+    mgr.set_event_injector(injected.append)
+
+    async def fake_send(title, body, timeout_ms):
+        return action
+
+    orig = platform_mod.current.send_desktop_notification
+    platform_mod.current.send_desktop_notification = fake_send
+    try:
+        asyncio.run(mgr._notify_desktop("d1", list(tool_lines), 0))
+    finally:
+        platform_mod.current.send_desktop_notification = orig
+    return injected
+
+
+def test_desktop_dismiss_leaves_pending_not_denied():
+    # action=None means dismissed/expired — must NOT inject a deny (#185).
+    injected = _desktop_notify(ConfirmationManager(), None)
+    assert injected == []
+
+
+def test_desktop_explicit_deny_injects_deny():
+    injected = _desktop_notify(ConfirmationManager(), "deny")
+    assert injected == [
+        {"type": "confirmation_response", "id": "d1", "approved": False}
+    ]
+
+
+def test_desktop_allow_injects_approve():
+    injected = _desktop_notify(ConfirmationManager(), "allow")
+    assert injected == [{"type": "confirmation_response", "id": "d1", "approved": True}]

--- a/tests/test_confirmation_tla.py
+++ b/tests/test_confirmation_tla.py
@@ -160,3 +160,87 @@ def test_desktop_explicit_deny_injects_deny():
 def test_desktop_allow_injects_approve():
     injected = _desktop_notify(ConfirmationManager(), "allow")
     assert injected == [{"type": "confirmation_response", "id": "d1", "approved": True}]
+
+
+# --- #187: per-task allow/deny -----------------------------------------------
+
+
+def _setup_batch(mgr, req_id="b1", n=2, pre_approved=None):
+    """Seed a pending confirmation directly (no channel dispatch)."""
+    details = [_cmd_detail(f"s.tool{i}", "cmd", [str(i)]) for i in range(n)]
+    tasks = [d["task"] for d in details]
+    pre = list(pre_approved or [])
+    mgr._pending[req_id] = PendingConfirmation(
+        request_id=req_id,
+        tasks=pre + tasks,
+        approved_tasks=list(pre),
+        denied_tools=[],
+        confirm_details=details,
+        tool_names=[d["tool_name"] for d in details],
+    )
+    return details, tasks
+
+
+def test_resolve_per_task_approves_subset_denies_rest():
+    mgr = ConfirmationManager()
+    _, tasks = _setup_batch(mgr, "b1", n=2)
+    pending = mgr.resolve({"id": "b1", "approved_indices": [0]})
+    assert pending.approved_tasks == [tasks[0]]
+    assert pending.denied_tools == ["s.tool1"]
+
+
+def test_resolve_per_task_empty_denies_all():
+    mgr = ConfirmationManager()
+    _setup_batch(mgr, "b2", n=2)
+    pending = mgr.resolve({"id": "b2", "approved_indices": []})
+    assert pending.approved_tasks == []
+    assert set(pending.denied_tools) == {"s.tool0", "s.tool1"}
+
+
+def test_resolve_per_task_preserves_preapproved():
+    mgr = ConfirmationManager()
+    pre = [{"server": "safe", "tool": "noop", "params": {}}]
+    _, tasks = _setup_batch(mgr, "b3", n=2, pre_approved=pre)
+    pending = mgr.resolve({"id": "b3", "approved_indices": [1]})
+    assert pending.approved_tasks == pre + [tasks[1]]
+    assert pending.denied_tools == ["s.tool0"]
+
+
+def test_resolve_fallback_all_or_nothing_without_indices():
+    mgr = ConfirmationManager()
+    _, tasks = _setup_batch(mgr, "b4", n=2)
+    pending = mgr.resolve({"id": "b4", "approved": True})
+    assert pending.approved_tasks == tasks
+    assert pending.denied_tools == []
+
+
+def _desktop_batch(mgr, actions, req_id="d2", n=2):
+    injected = []
+    mgr.set_event_injector(injected.append)
+    it = iter(actions)
+
+    async def fake_send(title, body, timeout_ms):
+        return next(it)
+
+    lines = [f"s.tool{i}: cmd {i}" for i in range(n)]
+    orig = platform_mod.current.send_desktop_notification
+    platform_mod.current.send_desktop_notification = fake_send
+    try:
+        asyncio.run(mgr._notify_desktop(req_id, lines, 0))
+    finally:
+        platform_mod.current.send_desktop_notification = orig
+    return injected
+
+
+def test_desktop_per_task_aggregates_indices():
+    injected = _desktop_batch(ConfirmationManager(), ["allow", "deny"])
+    assert injected == [
+        {"type": "confirmation_response", "id": "d2", "approved_indices": [0]}
+    ]
+
+
+def test_desktop_per_task_dismiss_midbatch_leaves_pending():
+    # First allowed, second dismissed -> don't resolve the batch on a partial
+    # answer; leave it pending (#185 + #187).
+    injected = _desktop_batch(ConfirmationManager(), ["allow", None])
+    assert injected == []

--- a/tests/test_dispatch_push_signals.py
+++ b/tests/test_dispatch_push_signals.py
@@ -1,0 +1,125 @@
+"""Tests for pushed dispatch-signal delivery (#26).
+
+Covers the daemon side of the push architecture: normalizing dispatch's raw
+SignalEntry into the daemon's canonical shape, and EventMerger.enqueue_pushed_signal
+sharing one dedup/ingest path with the poll loop so a signal seen by both is
+delivered exactly once.
+"""
+
+import asyncio
+
+import pytest
+
+from jarvis.dispatch.event_merger import EventMerger, EventType
+from jarvis.dispatch.transport import _normalize_pushed_signal
+
+
+def _raw_exit(pid=1, nonce="abc123", ts="2026-07-13T12:00:00-07:00"):
+    """A raw dispatch EXIT SignalEntry as it arrives in a pushed notification."""
+    return {
+        "timestamp": ts,
+        "pid": pid,
+        "kind": "EXIT",
+        "message": f"[hash={nonce}] 200 <{nonce}>done</{nonce}>",
+        "nonce": nonce,
+    }
+
+
+def test_normalize_maps_kind_and_message():
+    raw = _raw_exit()
+    norm = _normalize_pushed_signal(raw)
+    assert norm["type"] == "EXIT"
+    assert norm["pid"] == 1
+    assert norm["data"] == raw["message"]
+    assert norm["timestamp"] == raw["timestamp"]
+    assert norm["nonce"] == "abc123"
+
+
+def test_normalize_omits_absent_optional_fields():
+    raw = {"timestamp": "t", "pid": 5, "kind": "REMIND", "message": "Running for 30s"}
+    norm = _normalize_pushed_signal(raw)
+    assert norm["type"] == "REMIND"
+    assert "nonce" not in norm
+    assert "payload" not in norm
+
+
+def test_pushed_exit_is_enqueued():
+    async def run():
+        merger = EventMerger()
+        merger.enqueue_pushed_signal(_normalize_pushed_signal(_raw_exit()))
+        assert merger._queue.qsize() == 1
+        event = await merger._queue.get()
+        assert event.type == EventType.DISPATCH_SIGNAL
+        assert event.data["type"] == "EXIT"
+        assert event.data["pid"] == 1
+
+    asyncio.run(run())
+
+
+def test_pushed_signal_deduplicated_on_repeat():
+    async def run():
+        merger = EventMerger()
+        sig = _normalize_pushed_signal(_raw_exit())
+        merger.enqueue_pushed_signal(sig)
+        merger.enqueue_pushed_signal(sig)  # same (pid, type, timestamp)
+        assert merger._queue.qsize() == 1
+
+    asyncio.run(run())
+
+
+def test_push_and_poll_share_dedup():
+    async def run():
+        merger = EventMerger()
+        sig = _normalize_pushed_signal(_raw_exit())
+        # Push observes it first...
+        merger.enqueue_pushed_signal(sig)
+        # ...then the poll fallback sees the same (pid, type, timestamp): no-op.
+        assert merger._ingest_one(dict(sig)) is False
+        assert merger._queue.qsize() == 1
+
+    asyncio.run(run())
+
+
+def test_inline_types_not_pushed():
+    async def run():
+        merger = EventMerger()
+        for kind in ("INIT", "WAIT"):
+            raw = {"timestamp": "t", "pid": 9, "kind": kind, "message": "x"}
+            merger.enqueue_pushed_signal(_normalize_pushed_signal(raw))
+        assert merger._queue.qsize() == 0
+
+    asyncio.run(run())
+
+
+def test_empty_push_is_ignored():
+    async def run():
+        merger = EventMerger()
+        merger.enqueue_pushed_signal({})
+        merger.enqueue_pushed_signal(None)  # type: ignore[arg-type]
+        assert merger._queue.qsize() == 0
+
+    asyncio.run(run())
+
+
+def test_unverified_exit_is_marked_in_band():
+    async def run():
+        merger = EventMerger()
+        # Body lacks the nonce wrapper dispatch's boundary requires: the ingest
+        # path must flag it untrusted rather than pass it through clean (#165).
+        raw = {
+            "timestamp": "t",
+            "pid": 2,
+            "kind": "EXIT",
+            "message": "[hash=deadbeef] 200 unwrapped output",
+            "nonce": "deadbeef",
+        }
+        merger.enqueue_pushed_signal(_normalize_pushed_signal(raw))
+        event = await merger._queue.get()
+        assert event.data.get("_boundary_verified") is False
+        assert event.data["data"].startswith("[⚠ UNVERIFIED")
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Rebases Yakup's stale `yakup/dev` branch work (it predated #183/#188 and would have reverted the OpenAI-compat endpoint + provider changes if merged as-is) onto current `main` via cherry-pick, keeping only the commits relevant to this cluster.

Fixes:
- #186 - confirmation prompts now render the actual command/params, not just tool names
- #185 - confirmation no longer auto-denies on timeout when unattended; stays pending until an explicit answer
- #187 - per-task allow/deny for batched dispatch confirmations (previously all-or-nothing)

Also carries #184 (wake ROOT on dispatch push instead of poll) as a prerequisite - the above three commits build on top of it in the original branch and don't cherry-pick cleanly without it. #184/#189/#190 are tracked separately (Project-JARVIS task cluster) and not closed by this PR.

## Test plan
- [x] `pytest tests/test_confirmation_tla.py tests/test_dispatch_push_signals.py` - all pass
- [x] Full suite: 411 passed, 13 pre-existing failures verified identical on `main` before this branch (Python 3.14 env drift in LLM/voice-activation tests, unrelated to this change) - no new failures introduced