### PR TITLE
fix(dispatch): resolve turn-storm cluster + session/stateful fixes

### DIFF
--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -23,8 +23,10 @@ class Config:
     # those two were never the same var, so the systemd-installed daemon
     # never saw its model dir). Defaults to the platform data dir rather
     # than a cwd-relative "models", which broke depending on launch cwd.
-    MODELS_DIR = os.getenv("MODELS_DIR") or os.getenv("JARVIS_MODELS_DIR") or str(
-        _platform.data_dir() / "models"
+    MODELS_DIR = (
+        os.getenv("MODELS_DIR")
+        or os.getenv("JARVIS_MODELS_DIR")
+        or str(_platform.data_dir() / "models")
     )
 
     # Voice Provider Configuration

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -257,6 +257,13 @@ class Config:
     #          (lets external apps render their own confirmation UI)
     NOTIFICATION_SILENT = os.getenv("NOTIFICATION_SILENT", "false").lower() == "true"
 
+    # Per-goal dispatch repeat / progress guard (#205).
+    # When the same (server, tool, params) fingerprint appears this many times
+    # in the recent-dispatch window, the daemon short-circuits to a respond
+    # instead of dispatching again.
+    DISPATCH_REPEAT_LIMIT: int = int(os.getenv("DISPATCH_REPEAT_LIMIT", "3"))
+    DISPATCH_REPEAT_WINDOW: int = int(os.getenv("DISPATCH_REPEAT_WINDOW", "12"))
+
     # Timeout (seconds) for user to respond to a confirmation prompt before
     # auto-denying. 0 disables the timeout entirely -- pending confirmations
     # are tracked in a persistent, queryable list (CLI/socket) instead, so
@@ -384,6 +391,10 @@ dispatch — Execute tool calls. Only after seeing SERVER_DOCS.
     Set "fire_wake": false on EVERY task of a batch you want to answer ONCE, together (e.g.
     "check my python version AND update my system") — you are then woken a single time, when the
     whole batch has finished, with all results at once, instead of one partial reply per task.
+  ⚠ RULE — SYSTEM-SCOPE ELEVATION: Tools on system-scope servers (e.g. jarvis-shell-system) already
+    run with elevated privileges granted by dmcp via polkit. Send the plain command (e.g. `pacman -Syu`).
+    Do NOT prefix `sudo` or `pkexec` — sudo has no TTY/askpass and will fail; pkexec bypasses the
+    intended TLA gate. On a privilege error, report it; do not retry with sudo.
 
 --- Actions (exact format) ---
 
@@ -553,6 +564,10 @@ dispatch — Execute tool calls. Only after seeing SERVER_DOCS.
     Set "fire_wake": false on EVERY task of a batch you want to answer ONCE, together (e.g.
     "check my python version AND update my system") — you are then woken a single time, when the
     whole batch has finished, with all results at once, instead of one partial reply per task.
+  ⚠ RULE — SYSTEM-SCOPE ELEVATION: Tools on system-scope servers (e.g. jarvis-shell-system) already
+    run with elevated privileges granted by dmcp via polkit. Send the plain command (e.g. `pacman -Syu`).
+    Do NOT prefix `sudo` or `pkexec` — sudo has no TTY/askpass and will fail; pkexec bypasses the
+    intended TLA gate. On a privilege error, report it; do not retry with sudo.
 
 --- Actions (exact format) ---
 

--- a/jarvis/core/command_parser.py
+++ b/jarvis/core/command_parser.py
@@ -267,10 +267,17 @@ def _parse_dispatch(response: Dict[str, Any]) -> Dict[str, Any]:
             "goal_updates": response.get("goal_updates", []),
         }
 
-    if not isinstance(tasks, list) or not tasks:
+    if not isinstance(tasks, list):
         return {
             "error": "Dispatch action requires 'intent' (routing) or non-empty 'tasks' (execution)",
             "raw": response,
+        }
+
+    if not tasks:
+        return {
+            "action": "dispatch",
+            "tasks": [],
+            "goal_updates": response.get("goal_updates", []),
         }
 
     validated_tasks = []

--- a/jarvis/dispatch/goal_manager.py
+++ b/jarvis/dispatch/goal_manager.py
@@ -61,6 +61,7 @@ class Goal:
     timer_pid: Optional[int] = None
     defer_count: int = 0
     deferred_at: Optional[float] = None
+    recent_dispatches: List[str] = field(default_factory=list)  # rolling fingerprint window (#205)
 
     def to_context(self) -> Dict[str, Any]:
         """Flat serialization for LLM context (no children — use get_goal_context)."""
@@ -134,9 +135,20 @@ class GoalManager:
         """Attach dispatched task PIDs to a goal and mark it active."""
         goal = self._find_goal(goal_id)
         if goal:
-            goal.task_pids.extend(pids)
+            new_pids = [p for p in pids if p not in goal.task_pids]
+            goal.task_pids.extend(new_pids)
             goal.status = GoalStatus.ACTIVE
-            logger.info(f"GoalManager: Goal [{goal_id}] linked to PIDs {pids}")
+            logger.info(f"GoalManager: Goal [{goal_id}] linked to PIDs {new_pids} (deduped)")
+
+    def record_dispatch(self, goal_id: str, fingerprint: str) -> int:
+        """Record a dispatch fingerprint; return how many times it appears in the window."""
+        goal = self._find_goal(goal_id)
+        if not goal:
+            return 0
+        goal.recent_dispatches.append(fingerprint)
+        if len(goal.recent_dispatches) > Config.DISPATCH_REPEAT_WINDOW:
+            goal.recent_dispatches = goal.recent_dispatches[-Config.DISPATCH_REPEAT_WINDOW:]
+        return goal.recent_dispatches.count(fingerprint)
 
     def update_strategy(self, goal_id: str, strategy: str):
         """LLM updates its forward-looking plan for this goal."""

--- a/jarvis/dispatch/goal_manager.py
+++ b/jarvis/dispatch/goal_manager.py
@@ -61,7 +61,9 @@ class Goal:
     timer_pid: Optional[int] = None
     defer_count: int = 0
     deferred_at: Optional[float] = None
-    recent_dispatches: List[str] = field(default_factory=list)  # rolling fingerprint window (#205)
+    recent_dispatches: List[str] = field(
+        default_factory=list
+    )  # rolling fingerprint window (#205)
 
     def to_context(self) -> Dict[str, Any]:
         """Flat serialization for LLM context (no children — use get_goal_context)."""
@@ -138,7 +140,9 @@ class GoalManager:
             new_pids = [p for p in pids if p not in goal.task_pids]
             goal.task_pids.extend(new_pids)
             goal.status = GoalStatus.ACTIVE
-            logger.info(f"GoalManager: Goal [{goal_id}] linked to PIDs {new_pids} (deduped)")
+            logger.info(
+                f"GoalManager: Goal [{goal_id}] linked to PIDs {new_pids} (deduped)"
+            )
 
     def record_dispatch(self, goal_id: str, fingerprint: str) -> int:
         """Record a dispatch fingerprint; return how many times it appears in the window."""
@@ -147,7 +151,9 @@ class GoalManager:
             return 0
         goal.recent_dispatches.append(fingerprint)
         if len(goal.recent_dispatches) > Config.DISPATCH_REPEAT_WINDOW:
-            goal.recent_dispatches = goal.recent_dispatches[-Config.DISPATCH_REPEAT_WINDOW:]
+            goal.recent_dispatches = goal.recent_dispatches[
+                -Config.DISPATCH_REPEAT_WINDOW :
+            ]
         return goal.recent_dispatches.count(fingerprint)
 
     def update_strategy(self, goal_id: str, strategy: str):

--- a/jarvis/runtime/dispatch_flow.py
+++ b/jarvis/runtime/dispatch_flow.py
@@ -545,7 +545,9 @@ async def dispatch_send(
             continue
         if server_id not in _manifest_cache:
             try:
-                _manifest_cache[server_id] = await app.dispatch.get_server_manifest(server_id)
+                _manifest_cache[server_id] = await app.dispatch.get_server_manifest(
+                    server_id
+                )
             except Exception:
                 _manifest_cache[server_id] = {}
         if _manifest_cache.get(server_id, {}).get("stateful"):
@@ -650,7 +652,11 @@ def _dispatch_fingerprint(tasks: list[dict[str, Any]]) -> str:
     parts = []
     for t in tasks:
         key = json.dumps(
-            {"server": t.get("server"), "tool": t.get("tool"), "params": t.get("params", {})},
+            {
+                "server": t.get("server"),
+                "tool": t.get("tool"),
+                "params": t.get("params", {}),
+            },
             sort_keys=True,
         )
         parts.append(key)
@@ -695,10 +701,14 @@ async def dispatch_execute_tasks(
                     )
                 }
             )
-            app.goals.fail_goal(goal.id, reason=f"Repeat guard: {tool_label} made no progress")
+            app.goals.fail_goal(
+                goal.id, reason=f"Repeat guard: {tool_label} made no progress"
+            )
             return
 
-    result = await dispatch_send(app, logger, tasks, session_id=goal.id if goal else None)
+    result = await dispatch_send(
+        app, logger, tasks, session_id=goal.id if goal else None
+    )
 
     if isinstance(result, dict) and result.get("awaiting_confirmation"):
         logger.info(
@@ -724,7 +734,9 @@ async def dispatch_execute_tasks(
         # and drive the next ROOT turn. Asking LLM here (before any EXIT) duplicates
         # the turn and produces the empty-dispatch / turn-storm loop (#195).
         emit_activity(app, "Tasks dispatched, waiting for results…", kind="dispatch")
-        logger.debug(f"JARVIS: dispatch_execute_tasks — silent return, signal path drives next turn")
+        logger.debug(
+            f"JARVIS: dispatch_execute_tasks — silent return, signal path drives next turn"
+        )
 
 
 async def do_kill(app: Any, logger: Logger, pids: Any) -> None:

--- a/jarvis/runtime/dispatch_flow.py
+++ b/jarvis/runtime/dispatch_flow.py
@@ -536,6 +536,21 @@ async def dispatch_send(
                     params["command"] = parts[0]
                     params["args"] = parts[1:]
 
+    # Stamp stateful:true on tasks whose server manifest declares stateful=true (#206).
+    # The daemon derives this from the registry manifest so the LLM never has to remember it.
+    _manifest_cache: dict[str, dict] = {}
+    for task in tasks:
+        server_id = task.get("server")
+        if not server_id or task.get("stateful"):
+            continue
+        if server_id not in _manifest_cache:
+            try:
+                _manifest_cache[server_id] = await app.dispatch.get_server_manifest(server_id)
+            except Exception:
+                _manifest_cache[server_id] = {}
+        if _manifest_cache.get(server_id, {}).get("stateful"):
+            task["stateful"] = True
+
     approved_tasks: list[dict[str, Any]] = []
     tools_needing_confirmation: list[dict[str, Any]] = []
 
@@ -630,6 +645,18 @@ def _contains_auth_error(text: str) -> bool:
     return any(p in text_lower for p in _AUTH_ERROR_PATTERNS)
 
 
+def _dispatch_fingerprint(tasks: list[dict[str, Any]]) -> str:
+    """Stable fingerprint for a batch of tasks: sorted (server, tool, params) tuples."""
+    parts = []
+    for t in tasks:
+        key = json.dumps(
+            {"server": t.get("server"), "tool": t.get("tool"), "params": t.get("params", {})},
+            sort_keys=True,
+        )
+        parts.append(key)
+    return "|".join(sorted(parts))
+
+
 async def dispatch_execute_tasks(
     app: Any,
     logger: Logger,
@@ -643,7 +670,35 @@ async def dispatch_execute_tasks(
         )
         return
 
-    result = await dispatch_send(app, logger, tasks)
+    active = app.goals.get_active_goals()
+    goal = active[-1] if active else None
+
+    # Per-goal dispatch repeat guard (#205): short-circuit when the same batch
+    # fingerprint has been issued too many times without making progress.
+    if goal:
+        fingerprint = _dispatch_fingerprint(tasks)
+        repeat_count = app.goals.record_dispatch(goal.id, fingerprint)
+        if repeat_count >= Config.DISPATCH_REPEAT_LIMIT:
+            sample = tasks[0] if tasks else {}
+            tool_label = f"{sample.get('server', '?')}.{sample.get('tool', '?')}"
+            logger.warning(
+                f"JARVIS: dispatch repeat guard tripped for goal [{goal.id}] "
+                f"— '{tool_label}' issued {repeat_count}× with no progress"
+            )
+            app.output_manager.handle_response(
+                {
+                    "output": (
+                        f"I've attempted to run `{tool_label}` {repeat_count} times "
+                        f"without making progress — the tool appears to be returning "
+                        f"no usable content. I've stopped retrying. "
+                        f"You may want to try a different approach or tool."
+                    )
+                }
+            )
+            app.goals.fail_goal(goal.id, reason=f"Repeat guard: {tool_label} made no progress")
+            return
+
+    result = await dispatch_send(app, logger, tasks, session_id=goal.id if goal else None)
 
     if isinstance(result, dict) and result.get("awaiting_confirmation"):
         logger.info(
@@ -653,46 +708,23 @@ async def dispatch_execute_tasks(
         return
 
     pids = _extract_pids_from_result(result)
-    if pids:
-        active = app.goals.get_active_goals()
-        if active:
-            app.goals.link_tasks(active[-1].id, pids)
+    if pids and goal:
+        app.goals.link_tasks(goal.id, pids)
 
-    app.llm.switch_mode("root")
-    context = build_root_context(app, logger)
     if isinstance(result, dict) and "error" in result:
+        # Send-level error (not a tool EXIT error): drive a ROOT turn now because
+        # no signal will arrive to drive it for us.
+        app.llm.switch_mode("root")
+        context = build_root_context(app, logger)
         context += f"\nDISPATCH_ERROR: {compact_payload_for_llm(result)}"
+        response = await ask_llm(app, logger, context, tag="root-dispatch-error")
+        await app._act_on_root_response(response, depth + 1)
     else:
-        trimmed = _trim_to_current_batch(result, len(tasks))
-        result_text = compact_payload_for_llm(trimmed)
-        context += f"\nDISPATCH_RESULT: {result_text}"
-
-        # When the exit payload contains auth/token errors, surface the exact
-        # env-var key names from each server's configurableProperties. Without
-        # this the LLM guesses the key from the error wording (e.g.
-        # "subscription_token" instead of "BRAVE_API_KEY").
-        if _contains_auth_error(result_text):
-            server_ids = {
-                t["server"] for t in tasks if isinstance(t, dict) and t.get("server")
-            }
-            for sid in server_ids:
-                manifest = await app.dispatch.get_server_manifest(sid)
-                props = manifest.get("configurableProperties") or []
-                if props:
-                    required_keys = [
-                        p["key"] for p in props if isinstance(p, dict) and p.get("key")
-                    ]
-                    if required_keys:
-                        key_list = ", ".join(required_keys)
-                        example = ", ".join(f'"{k}": "<value>"' for k in required_keys)
-                        context += (
-                            f"\nCONFIG_HINT: {sid} requires configuration."
-                            f"\n  Required key(s): {key_list}"
-                            f'\n  Call: {{"action": "configure_server", "server_id": "{sid}", "config": {{{example}}}}}'
-                        )
-
-    response = await ask_llm(app, logger, context, tag="root-dispatch-result")
-    await app._act_on_root_response(response, depth + 1)
+        # Tasks started successfully. EXIT signals will arrive via on_dispatch_signal
+        # and drive the next ROOT turn. Asking LLM here (before any EXIT) duplicates
+        # the turn and produces the empty-dispatch / turn-storm loop (#195).
+        emit_activity(app, "Tasks dispatched, waiting for results…", kind="dispatch")
+        logger.debug(f"JARVIS: dispatch_execute_tasks — silent return, signal path drives next turn")
 
 
 async def do_kill(app: Any, logger: Logger, pids: Any) -> None:

--- a/jarvis/runtime/root_actions.py
+++ b/jarvis/runtime/root_actions.py
@@ -365,14 +365,24 @@ async def act_on_root_response(
         err = parsed["error"]
         logger.warning(f"JARVIS: Root parse error: {err} — retrying with correction")
         context = build_root_context(app, logger)
-        context += (
-            f"\nYour last response had a format error: {err}\n"
-            "Fix the JSON and try again. Reminder:\n"
-            '  {"action": "search_tools", "capability": "<domain or service needed>", "goal_updates": []}\n'
-            '  {"action": "get_server_docs", "server_id": "<id from SEARCH_RESULTS>", "goal_updates": []}\n'
-            '  {"action": "respond", "output": "<message>", "goal_updates": []}\n'
-            "Do NOT wrap fields in a 'params' object. Output exactly one JSON object."
-        )
+        raw = parsed.get("raw", {})
+        raw_action = raw.get("action", "") if isinstance(raw, dict) else ""
+        if raw_action == "dispatch" or (isinstance(raw, dict) and "tasks" in raw):
+            context += (
+                f"\nYour last response had a format error: {err}\n"
+                "Fix the JSON and try again. For a dispatch, each task must use this exact schema:\n"
+                '  {"action": "dispatch", "tasks": [{"server": "<id>", "tool": "<name>", "params": {"<key>": "<value>"}}], "goal_updates": []}\n'
+                "All tool arguments go inside 'params'. Do NOT flatten them to the top level of the task object."
+            )
+        else:
+            context += (
+                f"\nYour last response had a format error: {err}\n"
+                "Fix the JSON and try again. Reminder:\n"
+                '  {"action": "search_tools", "capability": "<domain or service needed>", "goal_updates": []}\n'
+                '  {"action": "get_server_docs", "server_id": "<id from SEARCH_RESULTS>", "goal_updates": []}\n'
+                '  {"action": "respond", "output": "<message>", "goal_updates": []}\n'
+                "Output exactly one JSON object."
+            )
         retry_response = await ask_llm(
             app, logger, context, tag="root-retry-parse", mode="root"
         )
@@ -442,7 +452,11 @@ async def act_on_root_response(
 
     elif action == "dispatch":
         if "tasks" in parsed:
-            await app._dispatch_execute_tasks(parsed["tasks"], depth)
+            tasks = parsed["tasks"]
+            if not tasks:
+                logger.debug("JARVIS: empty dispatch tasks — no-op acknowledge, waiting for signals")
+            else:
+                await app._dispatch_execute_tasks(tasks, depth)
         else:
             logger.warning(
                 "JARVIS: dispatch action without tasks — ignored (use search_tools first)"

--- a/jarvis/runtime/root_actions.py
+++ b/jarvis/runtime/root_actions.py
@@ -454,7 +454,9 @@ async def act_on_root_response(
         if "tasks" in parsed:
             tasks = parsed["tasks"]
             if not tasks:
-                logger.debug("JARVIS: empty dispatch tasks — no-op acknowledge, waiting for signals")
+                logger.debug(
+                    "JARVIS: empty dispatch tasks — no-op acknowledge, waiting for signals"
+                )
             else:
                 await app._dispatch_execute_tasks(tasks, depth)
         else:

--- a/jarvis/runtime/root_handlers.py
+++ b/jarvis/runtime/root_handlers.py
@@ -233,18 +233,22 @@ async def on_confirmation_response(
             if pids:
                 app.goals.link_tasks(pending.session_id, pids)
 
-        context = build_root_context(app, logger)
-
         if isinstance(result, dict) and "error" in result:
+            # Send-level error: no signal will arrive, drive a ROOT turn now.
+            context = build_root_context(app, logger)
             context += f"\nDISPATCH_ERROR: {compact_payload_for_llm(result)}"
+            if pending.denied_tools:
+                denied_list = ", ".join(pending.denied_tools)
+                context += f"\nUSER_DENIAL: Action {denied_list} was denied by the user"
+            response = await ask_llm(
+                app, logger, context, tag="root-confirmation-error", mode="root"
+            )
+            await app._act_on_root_response(response)
         else:
-            context += f"\nDISPATCH_RESULT: {compact_payload_for_llm(result)}"
-
-        if pending.denied_tools:
-            denied_list = ", ".join(pending.denied_tools)
-            context += f"\nUSER_DENIAL: Action {denied_list} was denied by the user"
-
-        response = await ask_llm(
-            app, logger, context, tag="root-confirmation-result", mode="root"
-        )
-        await app._act_on_root_response(response)
+            # Tasks started. EXIT signals drive the next ROOT turn via on_dispatch_signal.
+            # Asking LLM here (before EXITs) duplicates the turn and causes turn storms (#195).
+            from .dispatch_flow import emit_activity
+            emit_activity(app, "Tasks dispatched, waiting for results…", kind="dispatch")
+            if pending.denied_tools:
+                denied_list = ", ".join(pending.denied_tools)
+                logger.info(f"JARVIS: Confirmation — denied tools: {denied_list}")

--- a/jarvis/runtime/root_handlers.py
+++ b/jarvis/runtime/root_handlers.py
@@ -248,7 +248,10 @@ async def on_confirmation_response(
             # Tasks started. EXIT signals drive the next ROOT turn via on_dispatch_signal.
             # Asking LLM here (before EXITs) duplicates the turn and causes turn storms (#195).
             from .dispatch_flow import emit_activity
-            emit_activity(app, "Tasks dispatched, waiting for results…", kind="dispatch")
+
+            emit_activity(
+                app, "Tasks dispatched, waiting for results…", kind="dispatch"
+            )
             if pending.denied_tools:
                 denied_list = ", ".join(pending.denied_tools)
                 logger.info(f"JARVIS: Confirmation — denied tools: {denied_list}")

--- a/shellmcp/src/server.py
+++ b/shellmcp/src/server.py
@@ -189,7 +189,9 @@ def _open_command(target: str) -> str:
 
 async def open_app(target: str) -> str:
     """Open a file, URL, or application via the OS's default opener."""
-    env = _display_env() if sys.platform not in ("darwin", "win32") else os.environ.copy()
+    env = (
+        _display_env() if sys.platform not in ("darwin", "win32") else os.environ.copy()
+    )
     cmd = _open_command(target)
     try:
         proc = await asyncio.create_subprocess_shell(

--- a/tests/test_confirmation_goal_link.py
+++ b/tests/test_confirmation_goal_link.py
@@ -59,6 +59,17 @@ class _FakeDispatch:
         }
 
 
+class _FakeOutputManager:
+    def __init__(self):
+        self.activities = []
+
+    def emit_activity(self, text, kind=None):
+        self.activities.append(text)
+
+    def handle_response(self, response):
+        pass
+
+
 class _FakeApp:
     def __init__(self, goals, confirmation):
         self.goals = goals
@@ -67,6 +78,7 @@ class _FakeApp:
         self.llm = object()  # not None
         self._gui_clients = None
         self.acted = None
+        self.output_manager = _FakeOutputManager()
 
     async def _act_on_root_response(self, response):
         self.acted = response
@@ -128,5 +140,9 @@ def test_confirmation_resume_without_goal_does_not_crash(tmp_path, monkeypatch):
             app, _LOG, {"id": "r2", "approved": True}
         )
     )
+    # session_id=None → dispatch was scoped to None (no goal to attach to)
     assert app.dispatch.session_id is None
-    assert app.acted == {"action": "respond", "output": "ok"}
+    # On success, the signal path drives the next ROOT turn — ask_llm is NOT
+    # called here (#195). The activity emission tells the UI tasks are running.
+    assert app.acted is None
+    assert any("dispatched" in a.lower() for a in app.output_manager.activities)


### PR DESCRIPTION
## Summary

Six system-level issues fixed — all part of the \"one request → ~30 LLM calls\" turn-storm cluster plus session attribution and stateful-server regressions.

- **#195** — Remove premature post-send `ask_llm`. EXIT signals drive the next ROOT turn; asking immediately before any EXIT duplicates the turn and starts the retry loop.
- **#196** — Thread `session_id` in ROOT-direct dispatch path. `dispatch_execute_tasks` now passes `session_id=goal.id`. Fixes "No goal found for PID N" and re-dispatch of already-run tasks.
- **#197** — Rescope parse-error correction. Detects dispatch/tasks failures and shows correct task schema (`params` inside task) instead of action-level reminder that caused `KeyError: 'command'`.
- **#198** — Empty `tasks=[]` treated as no-op acknowledge, not a hard format error.
- **#199** — Prompt rule: system-scope tools elevated by dmcp/polkit — send plain command, never prefix `sudo`/`pkexec`.
- **#205** — Per-goal dispatch repeat guard. Fingerprints `(server, tool, params)`; short-circuits to a `respond` + goal fail when same fingerprint hits `DISPATCH_REPEAT_LIMIT` (default 3) in rolling window. Also dedups `task_pids` in `link_tasks`.
- **#206** — Auto-sets `stateful:true` from server manifest in `dispatch_send`. Daemon derives the flag — LLM never has to remember it. Fixes Playwright `about:blank` regression.

## Test plan
- [ ] `pacman -Syu` via jarvis-shell-system completes without ROOT improvising `sudo`
- [ ] Each EXIT fires exactly one ROOT turn (not two)
- [ ] "No goal found for PID N" no longer logged on ROOT-direct dispatch
- [ ] Parse error on dispatch shows task-schema hint, not action-schema hint
- [ ] Empty `tasks=[]` → no-op, no retry loop
- [ ] Playwright navigate+snapshot inside one goal returns page content, not `about:blank`
- [ ] 8× navigate loop terminates at ≤3 repeats with informative respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01NYzwfgBCRkgZYjCMngAC5W