### PR TITLE
feat(security): persistent constraint register enforced at dispatch gate (#214)

### DIFF
--- a/jarvis/cli.py
+++ b/jarvis/cli.py
@@ -523,7 +523,9 @@ def _cmd_constraints() -> None:
     for c in active:
         print(f"  #{c['id']}  {c['text']}")
         print(f"          pattern: {c['pattern']}")
-        print(f"          added:   {c['created_at'][:19]}  source: {c.get('source', '?')}")
+        print(
+            f"          added:   {c['created_at'][:19]}  source: {c.get('source', '?')}"
+        )
 
 
 def _cmd_constrain() -> None:
@@ -579,7 +581,7 @@ def show_usage() -> None:
     print("Pending Confirmations:")
     print()
     print("Standing Constraints:")
-    print('  jarvis constrain <path> [desc]     # Add path-prefix deny constraint')
+    print("  jarvis constrain <path> [desc]     # Add path-prefix deny constraint")
     print("  jarvis unconstrain <id>             # Remove constraint by id")
     print("  jarvis constraints                  # List active constraints")
     print()

--- a/jarvis/cli.py
+++ b/jarvis/cli.py
@@ -510,6 +510,53 @@ def _show_providers_usage() -> None:
     print("  jarvis providers edit <name> --model <model>      # Update a field")
 
 
+def _cmd_constraints() -> None:
+    """List active standing constraints."""
+    from .core.constraint_store import load_constraints
+
+    records = load_constraints()
+    active = [r for r in records if r.get("active", True)]
+    if not active:
+        print("No standing constraints.")
+        return
+    print(f"Standing constraints ({len(active)}):")
+    for c in active:
+        print(f"  #{c['id']}  {c['text']}")
+        print(f"          pattern: {c['pattern']}")
+        print(f"          added:   {c['created_at'][:19]}  source: {c.get('source', '?')}")
+
+
+def _cmd_constrain() -> None:
+    """Add a path-prefix deny constraint: jarvis constrain <path> [description]."""
+    if len(sys.argv) < 3:
+        print("Usage: jarvis constrain <path> [description]")
+        print('Example: jarvis constrain /home/user/photos "never touch my photos"')
+        sys.exit(1)
+    path_arg = sys.argv[2]
+    text = " ".join(sys.argv[3:]) if len(sys.argv) > 3 else f"deny access to {path_arg}"
+    from .core.constraint_store import add_constraint
+
+    record = add_constraint(text=text, pattern=path_arg, source="cli")
+    print(f"Constraint #{record['id']} added: {text!r}")
+    print(f"  Blocks any dispatch touching paths under: {record['pattern']}")
+
+
+def _cmd_unconstrain() -> None:
+    """Remove a constraint by id: jarvis unconstrain <id>."""
+    if len(sys.argv) < 3:
+        print("Usage: jarvis unconstrain <id>")
+        print("  (get ids from: jarvis constraints)")
+        sys.exit(1)
+    constraint_id = sys.argv[2]
+    from .core.constraint_store import remove_constraint
+
+    if remove_constraint(constraint_id):
+        print(f"Constraint #{constraint_id} removed.")
+    else:
+        print(f"Error: No constraint with id '{constraint_id}'.")
+        sys.exit(1)
+
+
 def show_usage() -> None:
     """Display usage information."""
     print("JARVIS AI Assistant - CLI Interface")
@@ -528,6 +575,13 @@ def show_usage() -> None:
     print("  jarvis sudo enable        # Enable sudo access (requires root)")
     print("  jarvis sudo disable       # Disable sudo access (requires root)")
     print("  jarvis sudo               # Show current sudo access status")
+    print()
+    print("Pending Confirmations:")
+    print()
+    print("Standing Constraints:")
+    print('  jarvis constrain <path> [desc]     # Add path-prefix deny constraint')
+    print("  jarvis unconstrain <id>             # Remove constraint by id")
+    print("  jarvis constraints                  # List active constraints")
     print()
     print("Pending Confirmations:")
     print("  jarvis confirmations               # List pending confirmations")
@@ -717,6 +771,15 @@ def main() -> None:
         else:
             print("Usage: jarvis auto-pull [on|off]")
             sys.exit(1)
+
+    elif command == "constraints":
+        _cmd_constraints()
+
+    elif command == "constrain":
+        _cmd_constrain()
+
+    elif command == "unconstrain":
+        _cmd_unconstrain()
 
     elif command in ["-h", "--help", "help"]:
         show_usage()

--- a/jarvis/core/constraint_store.py
+++ b/jarvis/core/constraint_store.py
@@ -1,0 +1,92 @@
+"""Standing constraints — path-prefix deny rules enforced at the dispatch gate (#214).
+
+Constraints are stored as JSON at $JARVIS_DATA_DIR/constraints.json and written
+atomically. Enforcement is mechanical: checked before the confirmation gate, so
+allow_all cannot bypass it. All public functions fail-safe — they catch every
+exception and return an empty result rather than crashing the dispatch path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+from uuid import uuid4
+
+from ..config import Config
+
+
+def _store_path() -> Path:
+    return Path(Config.JARVIS_DATA_DIR).expanduser() / "constraints.json"
+
+
+def load_constraints() -> list[dict]:
+    """Return all constraint records (active and inactive). Empty list on any error."""
+    try:
+        path = _store_path()
+        if not path.exists():
+            return []
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, list):
+            return []
+        return [r for r in data if isinstance(r, dict)]
+    except Exception:
+        return []
+
+
+def _save_constraints(records: list[dict]) -> None:
+    path = _store_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".constraints_")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(records, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def add_constraint(text: str, pattern: str, source: str = "cli") -> dict:
+    """Add a path-prefix deny constraint. Returns the new record."""
+    norm = os.path.abspath(os.path.expanduser(pattern.strip()))
+    record: dict = {
+        "id": uuid4().hex[:8],
+        "text": text.strip(),
+        "pattern": norm,
+        "created_at": datetime.now(tz=timezone.utc).isoformat(),
+        "source": source,
+        "active": True,
+    }
+    records = load_constraints()
+    records.append(record)
+    _save_constraints(records)
+    return record
+
+
+def remove_constraint(constraint_id: str) -> bool:
+    """Remove constraint by id. Returns True if found and removed."""
+    try:
+        records = load_constraints()
+        new = [r for r in records if r.get("id") != constraint_id]
+        if len(new) == len(records):
+            return False
+        _save_constraints(new)
+        return True
+    except Exception:
+        return False
+
+
+def active_constraints() -> list[dict]:
+    """Return only active constraint records. Empty list on any error."""
+    try:
+        return [r for r in load_constraints() if r.get("active", True)]
+    except Exception:
+        return []

--- a/jarvis/runtime/dispatch_flow.py
+++ b/jarvis/runtime/dispatch_flow.py
@@ -558,9 +558,7 @@ def _check_constraints(tasks: list[dict[str, Any]]) -> str:
             for c in constraints:
                 pat = c.get("pattern", "")
                 if pat and (norm == pat or norm.startswith(pat.rstrip("/") + "/")):
-                    return (
-                        f'Path "{norm}" matches constraint #{c["id"]}: {c["text"]!r}'
-                    )
+                    return f'Path "{norm}" matches constraint #{c["id"]}: {c["text"]!r}'
     return ""
 
 

--- a/jarvis/runtime/dispatch_flow.py
+++ b/jarvis/runtime/dispatch_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shlex
 import uuid
@@ -531,6 +532,38 @@ async def _stamp_stateful_tasks(
             )
 
 
+def _check_constraints(tasks: list[dict[str, Any]]) -> str:
+    """Return a refusal string if any task param matches a standing constraint, else ''.
+
+    Path matching is deliberate narrow scope: absolute paths and ~/… only.
+    Paths buried in shell one-liners, relative paths, and symlinks are not caught —
+    the role-level permission and TLA gate are the backstop for those cases (#214).
+    """
+    from ..core.constraint_store import active_constraints
+    from ..core.threat_level import _iter_strings
+
+    constraints = active_constraints()
+    if not constraints:
+        return ""
+    for task in tasks:
+        params = task.get("params") or {}
+        for s in _iter_strings(params):
+            s = s.strip()
+            if not s.startswith("/") and not s.startswith("~"):
+                continue
+            try:
+                norm = os.path.abspath(os.path.expanduser(s))
+            except Exception:
+                continue
+            for c in constraints:
+                pat = c.get("pattern", "")
+                if pat and (norm == pat or norm.startswith(pat.rstrip("/") + "/")):
+                    return (
+                        f'Path "{norm}" matches constraint #{c["id"]}: {c["text"]!r}'
+                    )
+    return ""
+
+
 def _revoked_servers(app: Any, tasks: list[dict[str, Any]]) -> list[str]:
     """Servers in this batch the registry sweep marked revoked (#39).
 
@@ -610,6 +643,26 @@ async def dispatch_send(
                 if len(parts) >= 2:
                     params["command"] = parts[0]
                     params["args"] = parts[1:]
+
+    # Standing constraints — path-prefix deny rules from constraints.json (#214).
+    # Checked before revocation and before the confirmation gate so allow_all
+    # cannot bypass them. The whole batch is refused on any match.
+    constraint_violation = _check_constraints(tasks)
+    if constraint_violation:
+        logger.warning(
+            f"JARVIS: Dispatch blocked by standing constraint: {constraint_violation}"
+        )
+        emit_activity(
+            app, f"Blocked by constraint: {constraint_violation}", kind="dispatch"
+        )
+        return {
+            "error": (
+                f"Dispatch refused: a standing constraint blocks this action. "
+                f"{constraint_violation} "
+                "The constraint was set by the user and cannot be overridden here. "
+                "Tell the user what was blocked and why, then ask what they want to do instead."
+            )
+        }
 
     # Registry revocation is a hard stop, decided here rather than asked of the
     # LLM (#39): a "removed" server is one whose vetting the registry withdrew,

--- a/jarvis/runtime/root_context.py
+++ b/jarvis/runtime/root_context.py
@@ -75,6 +75,20 @@ def build_root_context(
 ) -> str:
     parts = []
 
+    # Standing constraints — injected unconditionally (not gated on new_input) so
+    # the LLM always knows why certain dispatches will be mechanically refused (#214).
+    from ..core.constraint_store import active_constraints
+
+    constraints = active_constraints()
+    if constraints:
+        lines = [
+            "STANDING CONSTRAINTS (enforced mechanically — the daemon refuses"
+            " matching dispatches regardless of your reasoning):"
+        ]
+        for c in constraints:
+            lines.append(f"  #{c['id']}: {c['text']}")
+        parts.append("\n".join(lines))
+
     active_goals = app.goals.get_context()
     if active_goals:
         parts.append(f"GOALS: {json.dumps(active_goals)}")


### PR DESCRIPTION
## Summary

Implements v1 of the standing constraint store — Threat #6 (Forgetful Context) mitigation. Closes #214.

- **`jarvis/core/constraint_store.py`** (new) — JSON file at `$JARVIS_DATA_DIR/constraints.json`. Atomic `mkstemp`+`os.replace` write (same pattern as `skill_store.py`). Record: `{id, text, pattern, created_at, source, active}`. All load paths are fail-safe: any exception → empty list, never raises into the dispatch gate.

- **`jarvis/runtime/dispatch_flow.py`** — `_check_constraints(tasks)`: walks every task param via `_iter_strings` (reusing `threat_level.py:_iter_strings`), normalizes filesystem-looking strings with `expanduser`+`abspath`, prefix-matches against active constraints. Checked **before** `_revoked_servers` so `allow_all` cannot bypass it. A match aborts the whole batch with a hard `{"error": ...}` returned to the LLM.

- **`jarvis/runtime/root_context.py`** — `build_root_context()` prepends `STANDING CONSTRAINTS:` unconditionally before GOALS so the LLM always understands why dispatches may be refused, including on signal-driven turns with no `new_input`.

- **`jarvis/cli.py`** — `jarvis constraints` / `jarvis constrain <path> [desc]` / `jarvis unconstrain <id>`. Deterministic user-driven capture (not LLM-mediated) so constraints don't depend on the model deciding to store them — which is exactly the Forgetful Context attack operating one level up.

## Scope and honest limitations

Path matching is deliberately narrow: absolute paths and `~/…` only. Relative paths, shell one-liner embedded paths, and symlink targets are not caught — the TLA gate and role-level permissions are the backstop for those cases. Documented in the function docstring.

The context block deliberately only **explains** the constraint to the LLM; the mechanical enforcement in `_check_constraints` happens regardless of LLM reasoning. This resolves the tension noted in #214: the constraint block lives in the channel the LLM is trained to treat as reference-only (Threat #2 mitigation), but enforcement is not LLM-mediated.

## Test plan

- [ ] `jarvis constrain ~/photos "never touch photos dir"` → appears in `jarvis constraints`
- [ ] Dispatch a tool with `path: ~/photos/foo.jpg` → blocked with `{"error": "...matches constraint..."}`
- [ ] `allow_all` mode → still blocked (constraint check before confirmation gate)
- [ ] `jarvis unconstrain <id>` → removed; dispatch proceeds
- [ ] Kill and restart daemon → constraint survives (JSON persisted)
- [ ] Corrupt `constraints.json` → dispatch gate doesn't crash (fail-safe load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01W3W5ydiSGMwT3zqSFP2VQT