### PR TITLE
legal: add individual Contributor Grant, close CLA/DCO inbound-rights gap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,12 @@ git commit -s -m "Fix memory leak in dispatch adapter"
 
 Commits without a valid `Signed-off-by` line will not be merged.
 
+### Contributor Grant
+
+In addition to the DCO sign-off above, individual contributors must execute the [Contributor Grant](legal/contributor-grant.md) once before their first contribution is merged. The DCO confirms you have the right to submit your work; the Contributor Grant is the actual license grant that lets the Organization include your code in both the AGPLv3 release and, later, in code offered under the [SCCL](legal/SCCL-v1.md) to commercial licensees. You keep full ownership of your contribution — see `legal/contributor-grant.md` Article 2.3.
+
+Pull requests are checked at merge time for both a valid DCO sign-off and an executed Contributor Grant on file.
+
 ### Code of Conduct
 
 All contributors must follow the project's Code of Conduct. Respectful, constructive interaction is expected in all project spaces — issues, PRs, discussions, and chat.
@@ -60,7 +66,7 @@ If you are contributing on behalf of a company operating under the **Sovereign C
 
 ### Contributor License Agreement (CLA)
 
-Commercial licensees must sign the project's CLA before contributions can be accepted. The CLA covers intellectual property assignment for contributions made under SCCL. Contact the Organization for the current CLA.
+Commercial licensees must sign the project's CLA before contributions can be accepted. The CLA covers intellectual property assignment for contributions made under SCCL, and also requires the licensee and its contributing personnel to follow this project's Code of Conduct and community standards (CLA Article 4). Contact the Organization for the current CLA.
 
 ### Contribution-Back Requirement
 

--- a/legal/cla.md
+++ b/legal/cla.md
@@ -11,7 +11,7 @@
 
 This Contributor License Agreement ("Agreement") applies to **commercial licensees** contributing modifications or derivative works to the Project JARVIS codebase under the obligations of the Sustainable Commercial Contributor License (SCCL), Article 5.
 
-Community contributors (individuals) do not sign this Agreement. They use the **Developer Certificate of Origin (DCO)** — a `Signed-off-by` line in each commit — as documented in `CONTRIBUTING.md`.
+Community contributors (individuals) do not sign this Agreement. They execute the **[Contributor Grant](contributor-grant.md)** together with the **Developer Certificate of Origin (DCO)** — a `Signed-off-by` line in each commit — as documented in `CONTRIBUTING.md`. The DCO establishes provenance; the Contributor Grant establishes the license rights the DCO alone does not grant.
 
 This Agreement governs:
 1. Contributions made to satisfy the mandatory contribution-back obligation under SCCL Article 5 (modifications to the Software deployed in a commercial product, due within 90 days of deployment).
@@ -69,9 +69,21 @@ The Contributor represents and warrants that:
 
 ---
 
-## Article 4 — Process
+## Article 4 — Community Standards Compliance
 
-### 4.1 Signing
+**4.1 Code of Conduct.** The Contributor, and any personnel of the Contributor who interact with the Project's spaces (issues, pull requests, discussions, chat, or events) on the Contributor's behalf, shall adhere to the Project's published Code of Conduct at all times, consistent with SCCL Article 3.1.
+
+**4.2 Community Standards.** Contributions and related conduct submitted under this Agreement are subject to the same review standards, engineering guidelines, and community norms documented in `CONTRIBUTING.md` and `docs/engineering-standards.md` as any other contribution — signing this Agreement grants IP rights, it does not grant exemption from ordinary review or community process.
+
+**4.3 Relationship to Ecosystem Alignment.** A material or repeated violation of this Article by the Contributor's personnel is conduct the Board may consider under the Licensee Relationship Index (SCCL Definition 1.11) and, where sufficiently severe or persistent, grounds for Cure Period or revocation proceedings under SCCL Article 6 — independent of, and in addition to, any consequence under Article 5 (Process) of this Agreement.
+
+**4.4 Individual Accountability, Not a Waiver of Employer Obligation.** Nothing in this Article shifts a Contributor entity's Article 5 (SCCL) obligations onto individual personnel, and nothing in this Article limits the individual governance-eligibility rules of Organization Charter B.2.4.
+
+---
+
+## Article 5 — Process
+
+### 5.1 Signing
 
 This Agreement is signed **per legal entity** (not per individual developer). One signed Agreement covers all Contributions made by employees or contractors of the Contributor.
 
@@ -80,31 +92,31 @@ Signing process:
 2. The Organization maintains a registry of signed CLAs. Upon signing, the Contributor is added to `legal/cla-signatories.md`.
 3. A signed Agreement remains in effect indefinitely unless terminated by either party with 30 days' written notice.
 
-### 4.2 Submission
+### 5.2 Submission
 
 Contributions subject to this Agreement are submitted via pull request to the Project JARVIS GitHub repository. Each pull request must:
 - Reference the SCCL Article 5 obligation (if applicable) or state that it is a voluntary contribution.
 - Include a commit footer: `Contributed-under: Project JARVIS CLA v1.0`
 
-### 4.3 Relationship to SCCL Article 5
+### 5.3 Relationship to SCCL Article 5
 
 This Agreement satisfies the legal framework for the contribution-back obligation in SCCL Article 5. A Contributor that has not signed this Agreement is not in compliance with Article 5 until a signed Agreement is on file with the Organization.
 
 ---
 
-## Article 5 — Disclaimer
+## Article 6 — Disclaimer
 
 THE CONTRIBUTION IS PROVIDED "AS IS". THE CONTRIBUTOR MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT.
 
 ---
 
-## Article 6 — Governing Law
+## Article 7 — Governing Law
 
 This Agreement is governed by the laws of the jurisdiction specified in the Organization Charter (SCCL Article 8.3), without regard to conflict-of-law principles.
 
 ---
 
-## Article 7 — Entire Agreement
+## Article 8 — Entire Agreement
 
 This Agreement, together with the SCCL and the Organization Charter, constitutes the entire agreement between the parties with respect to the subject matter hereof and supersedes all prior or contemporaneous understandings regarding such subject matter.
 

--- a/legal/contributor-grant-signatories.md
+++ b/legal/contributor-grant-signatories.md
@@ -1,0 +1,24 @@
+# Project JARVIS — Contributor Grant Signatories
+
+**Status:** Working draft registry. Part of the [Contributor Grant](contributor-grant.md)'s retroactive-coverage process (Article 4.3).
+
+> Entries below record that a Contributor has executed the Contributor Grant. They do not, by themselves, make the Grant binding — the Grant carries the same "requires legal review before becoming binding" status as every other document in `legal/` until the Organization completes that review.
+
+---
+
+## Retroactive execution
+
+Per Article 4.3, the two Founders execute the Grant retroactively for their own pre-existing contributions, ahead of collecting execution from any future contributor. This is the "cheapest it will ever be" step described in the original inbound-rights analysis — done now, while the contributor base is still the two of them.
+
+| Contributor | GitHub handle | Executed | Coverage |
+|---|---|---|---|
+| Toufic Majdalani | [@majdaltouzach](https://github.com/majdaltouzach) | 2026-08-04 | Retroactive — all merged contributions of record as of this date, per Article 4.3 |
+| Yakup Atahanov | [@YakupAtahanov](https://github.com/YakupAtahanov) | 2026-08-04 | Retroactive — all merged contributions of record as of this date, per Article 4.3 |
+
+## Ongoing execution
+
+Future contributors are appended to this table as they execute the Grant (Article 4.1), enforced at merge time per Article 4.2 (bot-gated, alongside the existing DCO check).
+
+| Contributor | GitHub handle | Executed | Coverage |
+|---|---|---|---|
+| — | — | — | — |

--- a/legal/contributor-grant.md
+++ b/legal/contributor-grant.md
@@ -1,0 +1,107 @@
+# Project JARVIS — Contributor Grant
+
+**Version:** 1.0-draft
+**Effective date:** To be set upon Organization formation (see SCCL-v1.md Article 2.1)
+
+> **Note:** This document is a working draft. It requires legal review before becoming binding.
+
+---
+
+## Scope and Purpose
+
+This Contributor Grant ("Grant") applies to **individual community contributors** — anyone submitting a Contribution to the Project JARVIS codebase who is not signing the commercial [Contributor License Agreement (CLA)](cla.md) on behalf of a Licensee under SCCL Article 5.
+
+The Developer Certificate of Origin (DCO) `Signed-off-by` line, required on every commit per `CONTRIBUTING.md`, is an attestation of provenance — it confirms the Contributor has the right to submit the work. It is **not a license grant**: standing alone, it leaves the Contribution's copyright with the Contributor and licenses it to the Organization only under AGPLv3. Because the Organization cannot sell an SCCL commercial license over code it holds under AGPLv3 alone, every Contribution must also be covered by this Grant before it is eligible for inclusion in code offered to SCCL Licensees.
+
+This Grant and the DCO are complementary, not substitutes: the DCO establishes provenance; this Grant establishes rights.
+
+---
+
+## Article 1 — Definitions
+
+Terms not defined here have the meaning given in `cla.md` Article 1 and the Organization Charter.
+
+**"Contributor"** means the individual person submitting a Contribution under this Grant, in their personal capacity.
+
+**"Contribution"** means any original work of authorship — code, documentation, or other content — submitted by the Contributor to the Project JARVIS repository, that is signed off via DCO and not submitted under the commercial CLA.
+
+---
+
+## Article 2 — License Grant
+
+### 2.1 Copyright License
+
+The Contributor grants the Organization, and all recipients of software distributed by the Organization, a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, sublicensable** copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute the Contribution and derivative works of it — including under terms other than AGPLv3, such as the SCCL.
+
+### 2.2 Patent License
+
+The Contributor grants the Organization, and all recipients of software distributed by the Organization, a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, sublicensable** patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Contribution, limited to patent claims licensable by the Contributor that are necessarily infringed by the Contribution alone or in combination with the Project.
+
+### 2.3 Retained Rights
+
+The Contributor retains all right, title, and interest in the Contribution not expressly granted above. This is a **license grant, not a copyright assignment or exclusive license** — the Contributor keeps full ownership and may use, relicense, or sell their own Contribution however they wish, independent of this Grant.
+
+### 2.4 Conditional Irrevocability — Foundation Reciprocal Promises
+
+This Grant is **irrevocable for so long as, and only for so long as**, the Organization upholds each of the following, owed as a contractual obligation to the Contributor personally, not merely as Charter prose the Organization could unilaterally amend:
+
+  (a) the Software remains publicly available under AGPLv3, permanently (Organization Charter B.7.3, immutable under B.4.6(e));
+
+  (b) no less than fifty percent (50%) of SCCL fees collected are allocated to contributor compensation (Organization Charter B.5.1, immutable under B.4.6(d));
+
+  (c) upon dissolution, assets are never distributed to a commercial Licensee or Board member (Organization Charter B.7.3, immutable under B.4.6(e)).
+
+If the Organization materially breaches any of (a)–(c) and fails to cure within ninety (90) days of written notice from any Active Contributor, the **extended rights granted in 2.1–2.2 beyond what AGPLv3 already permits — specifically, the right to sublicense the Contribution under terms other than AGPLv3, including the SCCL — terminate prospectively** for all Contributions covered by this Grant. This termination does not affect copies of the Software already lawfully distributed under AGPLv3 or an already-issued SCCL license prior to the breach, and does not revoke the Organization's ordinary AGPLv3 rights, which remain in force independent of this Grant.
+
+### 2.5 No Governance Rights From the Grant Alone
+
+Signing this Grant does not, by itself, confer Governance Pool membership or C-points. Governance eligibility is determined by the Organization Charter (B.2.1–B.2.4), independent of this Grant.
+
+---
+
+## Article 3 — Representations and Warranties
+
+The Contributor represents and warrants that:
+
+1. **Authority.** The Contributor has the legal right to enter into this Grant and to grant the licenses in Article 2.
+2. **Originality.** Each Contribution is the Contributor's original work, or the Contributor has sufficient rights to grant the licenses described in Article 2.
+3. **No third-party IP conflicts.** The Contribution does not, to the Contributor's knowledge, infringe or misappropriate any third party's intellectual property rights.
+4. **Employer authorization.** If the Contribution was created within the scope of the Contributor's employment, the Contributor's employer has authorized this Grant, has waived rights in the Contribution, or the Contribution falls outside the employer's ordinary business such that no such authorization is required.
+
+---
+
+## Article 4 — Process
+
+### 4.1 Execution
+
+This Grant is executed **per individual**, once, and covers all future Contributions by that individual unless revoked prospectively by the Contributor with respect to future Contributions only — past Contributions remain licensed under the terms in effect at the time of submission.
+
+### 4.2 Bot-Gated Enforcement
+
+Pull requests from individual contributors are checked at merge time for a signed Grant on file, in addition to the DCO `Signed-off-by` check already required. A pull request without both is not merged. This uses the same enforcement point already in place for DCO — see `CONTRIBUTING.md`.
+
+### 4.3 Retroactive Coverage
+
+Contributions merged before this Grant's effective date are covered once the original Contributor executes this Grant retroactively. The Organization shall prioritize collecting retroactive execution from all contributors of record as of this Grant's adoption before any SCCL license is issued covering their code.
+
+---
+
+## Article 5 — Disclaimer
+
+THE CONTRIBUTION IS PROVIDED "AS IS". THE CONTRIBUTOR MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT.
+
+---
+
+## Article 6 — Governing Law
+
+This Grant is governed by the laws of the jurisdiction specified in the Organization Charter (SCCL Article 8.3).
+
+---
+
+## Article 7 — Entire Agreement
+
+This Grant, together with the DCO attestation, the SCCL, and the Organization Charter, constitutes the entire agreement between the Contributor and the Organization with respect to the rights granted herein.
+
+---
+
+*By submitting a Contribution and executing this Grant, the Contributor agrees to be bound by the terms herein.*

--- a/legal/contributor-grant.md
+++ b/legal/contributor-grant.md
@@ -82,7 +82,7 @@ Pull requests from individual contributors are checked at merge time for a signe
 
 ### 4.3 Retroactive Coverage
 
-Contributions merged before this Grant's effective date are covered once the original Contributor executes this Grant retroactively. The Organization shall prioritize collecting retroactive execution from all contributors of record as of this Grant's adoption before any SCCL license is issued covering their code.
+Contributions merged before this Grant's effective date are covered once the original Contributor executes this Grant retroactively. The Organization shall prioritize collecting retroactive execution from all contributors of record as of this Grant's adoption before any SCCL license is issued covering their code. Executed Grants — retroactive and prospective alike — are recorded in [`legal/contributor-grant-signatories.md`](contributor-grant-signatories.md), mirroring the registry process used for the commercial CLA (`cla.md` Article 5.1).
 
 ---
 

--- a/legal/organization-charter.md
+++ b/legal/organization-charter.md
@@ -16,13 +16,13 @@
 
 ### B.2 — Membership
 
-**B.2.1 Contributors.** Any individual who has authored at least one merged contribution to the Software (as evidenced by the project's version control history and signed off via DCO) is a Contributor. Contributors are the primary stakeholders of the Organization.
+**B.2.1 Contributors.** Any individual who has authored at least one merged contribution to the Software (as evidenced by the project's version control history, signed off via DCO, and covered by an executed [Contributor Grant](contributor-grant.md)) is a Contributor. Contributors are the primary stakeholders of the Organization.
 
 **B.2.2 Active Contributors.** A Contributor is "Active" if they have authored at least one merged contribution within the preceding twenty-four (24) months. Only Active Contributors may exercise governance rights available at the current Governance Stage.
 
 **B.2.3 Corporate Contribution Exclusion.** Contributions submitted on behalf of a commercial licensee — including those fulfilling the contribution-back obligation under SCCL Article 5, signed under the CLA, or authored in the scope of employment with a licensee — do **not** count toward an individual's Active Contributor status for governance purposes. Such contributions satisfy the licensee's contractual obligations but confer no governance rights.
 
-**B.2.4 Individual Contributions by Licensee Employees.** An individual employed by a commercial licensee may qualify as an Active Contributor if and only if: (a) the contribution is signed off via DCO (not CLA); (b) the contribution is made outside the scope of their employment; and (c) the contribution is not fulfilling any part of their employer's SCCL Article 5 obligations. The individual's governance rights are personal and may not be directed or influenced by their employer.
+**B.2.4 Individual Contributions by Licensee Employees.** An individual employed by a commercial licensee may qualify as an Active Contributor if and only if: (a) the contribution is made outside the scope of their employment; and (b) the contribution is not fulfilling any part of their employer's SCCL Article 5 obligations. Which rights-grant mechanism was used — the individual's own [Contributor Grant](contributor-grant.md) per B.2.1, versus the commercial CLA their employer separately signs for Article 5 contributions — does not by itself determine governance eligibility; (a) and (b) are the operative test. The individual's governance rights are personal and may not be directed or influenced by their employer.
 
 **B.2.5 Contribution Points (C-Points).** Each Active Contributor accumulates **Contribution Points (C-points)** — a weighted composite score reflecting the quality, scope, and nature of their contributions. C-points are used to rank contributors for Governance Pool membership (B.2.6) and other governance purposes. The methodology for calculating C-points — including the variables considered and their respective weights — is defined in the [C-Points Methodology](c-points.md). C-points are recalculated continuously as contributions are merged.
 


### PR DESCRIPTION
## What changed

- Adds `legal/contributor-grant.md` — a one-page **Contributor Grant** for individual community contributors: perpetual, non-exclusive, sublicensable copyright + patent grant (contributor keeps ownership), with irrevocability made **conditional** on the Organization upholding its AGPLv3-availability, 50% compensation-floor, and dissolution-asset-lock promises (Charter B.4.6(d)/(e)). Breach uncured after 90 days terminates the extended (beyond-AGPLv3) sublicensing right prospectively — self-executing anti-capture protection without full exclusive-assignment/reversion complexity.
- Updates `legal/cla.md`: cross-references the new Contributor Grant, and adds a new **Article 4 — Community Standards Compliance** requiring commercial licensees and their personnel to follow the Code of Conduct and community standards (subsequent articles renumbered 5–8).
- Updates `legal/organization-charter.md` B.2.1 (Contributor status now also requires an executed Contributor Grant) and B.2.4 (decouples the governance-eligibility test from *which* rights-grant mechanism was signed — the DCO-vs-CLA distinction is dropped in favor of the substantive scope-of-employment / not-fulfilling-Article-5 test).
- Updates `CONTRIBUTING.md` to document the Contributor Grant requirement alongside DCO, and note the CLA's new community-standards clause.

## Why this change

DCO is provenance, not a license grant — community contributions were held under AGPLv3 only, so the Organization had no legal right to cover them under an SCCL commercial license. Every dual-licensed project (MongoDB, Elastic, Qt, MySQL) solves this with a broad contributor grant from *all* contributors, not just commercial ones. This is the cheapest point to fix it — debt compounds with every merged community PR.

Closes #217
Closes #218
Closes #219

## Test plan

- [ ] `legal/contributor-grant.md` renders correctly and cross-links resolve
- [ ] `cla.md` article renumbering is internally consistent (checked manually; no other doc in-repo cites `cla.md` by article number)
- [ ] Legal counsel review before any of this becomes binding (per existing project convention, see Charter status notices)

## Risk and rollout notes

Documentation-only change (draft legal text), no code or build impact. Still requires legal counsel review and Board ratification before becoming binding, consistent with every other document in `legal/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_018bNmMzPVub55rPHryyPyPC)_